### PR TITLE
Add GitHub Actions build and SonarCloud workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,50 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Run unit tests
+        run: dotnet test tests/GDSB.Infrastructure.Tests/GDSB.Infrastructure.Tests.csproj -c Release
+
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore MAUI Android workload
+        run: dotnet workload restore src/GDSB.MAUI/GDSB.MAUI.csproj -p:GdsbAndroidOnly=true
+
+      - name: Build Android
+        run: dotnet build src/GDSB.MAUI/GDSB.MAUI.csproj -c Release -p:GdsbAndroidOnly=true
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore MAUI workload
+        run: dotnet workload restore src/GDSB.MAUI/GDSB.MAUI.csproj
+
+      - name: Build Windows
+        run: dotnet build src/GDSB.MAUI/GDSB.MAUI.csproj -c Release -f net10.0-windows10.0.19041.0 -p:WindowsPackageType=None

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,56 @@
+name: SonarCloud
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  sonarcloud:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Install SonarScanner
+        run: dotnet tool install --global dotnet-sonarscanner
+
+      - name: Restore MAUI Android workload
+        run: dotnet workload restore src/GDSB.MAUI/GDSB.MAUI.csproj -p:GdsbAndroidOnly=true
+
+      - name: Begin SonarCloud analysis
+        run: >
+          dotnet sonarscanner begin
+          /k:"betinn_GDSB.MAUI"
+          /o:"betinn"
+          /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+          /d:sonar.host.url="https://sonarcloud.io"
+
+      - name: Build
+        run: dotnet build src/GDSB.MAUI/GDSB.MAUI.sln -c Release -p:GdsbAndroidOnly=true
+
+      - name: Run tests
+        run: dotnet test tests/GDSB.Infrastructure.Tests/GDSB.Infrastructure.Tests.csproj -c Release
+
+      - name: End SonarCloud analysis
+        run: dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
## Summary

- Adiciona `.github/workflows/build.yml` com três jobs (`test`, `build-android`, `build-windows`), disparando em push/PR contra `main`.
- Adiciona `.github/workflows/sonarcloud.yml`, que builda o Android + roda os testes dentro do `dotnet-sonarscanner`, publicando a análise no projeto `betinn_GDSB.MAUI` (organização `betinn`) no SonarCloud.
- Gratuito: o repositório é público, então GitHub Actions e SonarCloud não cobram nada nesse cenário.

## Test plan

- [ ] Conferir na aba Actions que os 4 jobs (`test`, `build-android`, `build-windows`, `sonarcloud`) rodam e ficam verdes neste PR.
- [ ] Depois do primeiro run, marcar esses 4 checks como obrigatórios na rule de branch protection já existente da `main`.
- [ ] Confirmar em https://sonarcloud.io/project/overview?id=betinn_GDSB.MAUI que a análise apareceu.


---
_Generated by [Claude Code](https://claude.ai/code/session_019D2csQSqfNXWSdMKhgz5Ts)_