### PR TITLE
Restrict CI to pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,8 +1,6 @@
 name: SonarCloud
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
This removes the push trigger from the build and SonarCloud GitHub Actions workflows so they only run for pull requests targeting main. This keeps CI checks focused on review-driven changes and avoids duplicate executions on direct pushes to the branch.