### PR TITLE
Implement brand identity: icons, colors, and design system

### DIFF
--- a/src/GDSB.MAUI.ViewModels/ViewModels/VaultViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/VaultViewModel.cs
@@ -46,6 +46,17 @@ namespace GDSB.MAUI.ViewModels
         /// </summary>
         public event EventHandler? SecretCreated;
 
+        /// <summary>
+        /// Disparado quando um item EXISTENTE foi alterado e gravado com sucesso. Mesma regra
+        /// do SecretCreated: nada de animar uma gravação que falhou.
+        /// </summary>
+        public event EventHandler? SecretUpdated;
+
+        /// <summary>
+        /// Disparado quando um item foi removido e o cofre gravado com sucesso.
+        /// </summary>
+        public event EventHandler? SecretDeleted;
+
         public ObservableCollection<SecretBoxItemViewModel> Items { get; } = new();
 
         [ObservableProperty]
@@ -386,8 +397,13 @@ namespace GDSB.MAUI.ViewModels
 
             // Depois do RefreshItems: a animação passa por cima da lista já atualizada,
             // então o item novo aparece atrás do cadeado fechando.
-            if (isNewItem && saved)
+            if (!saved)
+                return;
+
+            if (isNewItem)
                 SecretCreated?.Invoke(this, EventArgs.Empty);
+            else
+                SecretUpdated?.Invoke(this, EventArgs.Empty);
         }
 
         private bool CanSaveItem() => !IsBusy;
@@ -427,8 +443,11 @@ namespace GDSB.MAUI.ViewModels
             IsConfirmingDelete = false;
             IsEditorOpen = false;
 
-            await PersistAsync();
+            var saved = await PersistAsync();
             RefreshItems();
+
+            if (saved)
+                SecretDeleted?.Invoke(this, EventArgs.Empty);
         }
 
         [RelayCommand]

--- a/src/GDSB.MAUI.ViewModels/ViewModels/VaultViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/VaultViewModel.cs
@@ -38,6 +38,14 @@ namespace GDSB.MAUI.ViewModels
         // IsVisible) porque a duração/fade é responsabilidade de apresentação, não de estado.
         public event EventHandler<string>? ToastRequested;
 
+        /// <summary>
+        /// Disparado só quando um item NOVO acabou de ser gravado no arquivo com sucesso -
+        /// nunca em edição de item existente, e nunca se o Save falhou. A view usa isso para
+        /// a animação de cadeado fechando; comemorar uma gravação que não aconteceu seria
+        /// pior do que não ter animação nenhuma.
+        /// </summary>
+        public event EventHandler? SecretCreated;
+
         public ObservableCollection<SecretBoxItemViewModel> Items { get; } = new();
 
         [ObservableProperty]
@@ -234,10 +242,11 @@ namespace GDSB.MAUI.ViewModels
         [RelayCommand]
         private Task GoHomeAsync() => _navigationService.GoHomeAsync();
 
-        private async Task PersistAsync()
+        /// <summary>Devolve true só se o cofre foi realmente gravado em disco.</summary>
+        private async Task<bool> PersistAsync()
         {
             if (_profile is null || _location is null || _password is null)
-                return;
+                return false;
 
             IsBusy = true;
             try
@@ -246,10 +255,12 @@ namespace GDSB.MAUI.ViewModels
                 var password = _password;
                 var profile = _profile;
                 await Task.Run(() => _profileFileService.Save(location, profile, password));
+                return true;
             }
             catch (Exception)
             {
                 await _alertService.DisplayAlertAsync(null, "Não foi possível salvar o cofre. Tente novamente.", "Ok");
+                return false;
             }
             finally
             {
@@ -341,6 +352,8 @@ namespace GDSB.MAUI.ViewModels
 
             ValidationError = null;
 
+            var isNewItem = SelectedItem is null;
+
             if (SelectedItem is null)
             {
                 var box = new SecretBox
@@ -365,11 +378,16 @@ namespace GDSB.MAUI.ViewModels
                 box.Favorito = EditFavorito;
             }
 
-            await PersistAsync();
+            var saved = await PersistAsync();
 
             IsEditingItem = false;
             IsEditorOpen = false;
             RefreshItems();
+
+            // Depois do RefreshItems: a animação passa por cima da lista já atualizada,
+            // então o item novo aparece atrás do cadeado fechando.
+            if (isNewItem && saved)
+                SecretCreated?.Invoke(this, EventArgs.Empty);
         }
 
         private bool CanSaveItem() => !IsBusy;

--- a/src/GDSB.MAUI/CreateVaultPage.xaml
+++ b/src/GDSB.MAUI/CreateVaultPage.xaml
@@ -21,11 +21,12 @@
             <VerticalStackLayout Grid.Row="1" Spacing="28">
 
                 <VerticalStackLayout Spacing="14" HorizontalOptions="Center">
-                    <Border WidthRequest="72" HeightRequest="72" StrokeShape="RoundRectangle 36"
-                            BackgroundColor="{StaticResource Tertiary}" Stroke="{StaticResource PrimaryDarkBrush}"
-                            HorizontalOptions="Center">
-                        <Label Text="&#128273;" FontSize="30" HorizontalOptions="Center" VerticalOptions="Center" />
-                    </Border>
+                    <!-- A mesma marca da tela de desbloqueio, com a haste erguida: lá o cofre
+                         está selado e você vai abri-lo; aqui ele ainda não existe. Mesmo
+                         desenho, estados opostos - ver BrandMarkDrawable.Open. Antes era o
+                         emoji 🔑, que muda de desenho a cada plataforma. -->
+                    <GraphicsView x:Name="BrandMark" WidthRequest="72" HeightRequest="72"
+                                  HorizontalOptions="Center" />
                     <Label Text="Novo cofre" FontSize="22" FontFamily="OpenSansSemibold"
                            TextColor="{StaticResource TextPrimaryDark}" HorizontalOptions="Center" />
                     <Label Text="Escolha onde guardar e defina a senha mestra" FontSize="13"

--- a/src/GDSB.MAUI/CreateVaultPage.xaml.cs
+++ b/src/GDSB.MAUI/CreateVaultPage.xaml.cs
@@ -1,4 +1,5 @@
 using GDSB.MAUI.ViewModels;
+using GDSB.MAUI.Views;
 
 namespace GDSB.MAUI;
 
@@ -8,5 +9,7 @@ public partial class CreateVaultPage : ContentPage
     {
         InitializeComponent();
         BindingContext = viewModel;
+        // Haste erguida: o cofre desta tela ainda não foi selado.
+        BrandMark.Drawable = new BrandMarkDrawable { Open = true };
     }
 }

--- a/src/GDSB.MAUI/GDSB.MAUI.csproj
+++ b/src/GDSB.MAUI/GDSB.MAUI.csproj
@@ -48,7 +48,10 @@
 
 	<ItemGroup>
 		<!-- App Icon -->
-		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#00186E" />
+		<!-- BaseSize explícito: sem ele o resizetizer deduz a caixa de cada SVG, e fundo e
+		     primeiro plano com dimensões diferentes saem desalinhados/achatados no Windows. -->
+		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg"
+		          Color="#00186E" BaseSize="128,128" />
 
 		<!-- Splash Screen -->
 		<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#00186E" BaseSize="128,128" />

--- a/src/GDSB.MAUI/GDSB.MAUI.csproj
+++ b/src/GDSB.MAUI/GDSB.MAUI.csproj
@@ -48,10 +48,10 @@
 
 	<ItemGroup>
 		<!-- App Icon -->
-		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
+		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#00186E" />
 
 		<!-- Splash Screen -->
-		<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
+		<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#00186E" BaseSize="128,128" />
 
 		<!-- Images -->
 		<MauiImage Include="Resources\Images\*" />

--- a/src/GDSB.MAUI/Platforms/Android/Resources/values/colors.xml
+++ b/src/GDSB.MAUI/Platforms/Android/Resources/values/colors.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#D936D3</color>
-    <color name="colorPrimaryDark">#400880</color>
+    <!-- Navy da marca: a barra de status encosta no topo da página, que abre
+         em #00186E dissolvendo no fundo #060B24. Magenta aqui brigaria com o
+         gradiente de ação dos botões. -->
+    <color name="colorPrimary">#00186E</color>
+    <color name="colorPrimaryDark">#00186E</color>
+    <!-- Ação: o mesmo #C21FBC do Primary/chip selecionado (4.85:1 com texto branco) -->
     <color name="colorAccent">#C21FBC</color>
 </resources>

--- a/src/GDSB.MAUI/Platforms/Android/Resources/values/colors.xml
+++ b/src/GDSB.MAUI/Platforms/Android/Resources/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#512BD4</color>
-    <color name="colorPrimaryDark">#2B0B98</color>
-    <color name="colorAccent">#2B0B98</color>
+    <color name="colorPrimary">#D936D3</color>
+    <color name="colorPrimaryDark">#400880</color>
+    <color name="colorAccent">#C21FBC</color>
 </resources>

--- a/src/GDSB.MAUI/Resources/AppIcon/appicon.svg
+++ b/src/GDSB.MAUI/Resources/AppIcon/appicon.svg
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg">
-    <rect x="0" y="0" width="456" height="456" fill="#00186E" />
+<!-- Fundo do ícone. Mesmas dimensões do appiconfg.svg de propósito: com o fundo em
+     456x456 e o primeiro plano em 128x128, o resizetizer compõe duas caixas de tamanhos
+     diferentes e a marca sai deformada (achatada nos tiles do Windows). -->
+<svg width="128" height="128" viewBox="0 0 128 128" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <rect x="0" y="0" width="128" height="128" fill="#00186E" />
 </svg>

--- a/src/GDSB.MAUI/Resources/AppIcon/appicon.svg
+++ b/src/GDSB.MAUI/Resources/AppIcon/appicon.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg">
-    <rect x="0" y="0" width="456" height="456" fill="#512BD4" />
+    <rect x="0" y="0" width="456" height="456" fill="#00186E" />
 </svg>

--- a/src/GDSB.MAUI/Resources/AppIcon/appiconfg.svg
+++ b/src/GDSB.MAUI/Resources/AppIcon/appiconfg.svg
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg">
-  <!-- G arc (magenta) -->
-  <path d="M 297.36,149.4 A 85.5,85.5 0 1 0 299.64,297.15 L 299.64,220.5 L 252.75,220.5" fill="none" stroke="#D936D3" stroke-width="39.375" stroke-linecap="round" stroke-linejoin="round"/>
-
-  <!-- Body (D deitado) with lock cutout mask -->
-  <defs>
-    <mask id="lockMask" maskUnits="userSpaceOnUse" x="0" y="0" width="456" height="456">
-      <rect width="456" height="456" fill="white"/>
-      <!-- Keyhole cutout: circle + shaft -->
-      <circle cx="228" cy="281.25" r="28.5" fill="black"/>
-      <path d="M 228,309.75 C 204.75,327 204.75,358.5 228,375.75" fill="none" stroke="black" stroke-width="23.25" stroke-linecap="round"/>
-    </mask>
-  </defs>
-
-  <!-- D-shaped body (semicircle at bottom) with mask applied -->
-  <path d="M 78.75,228 L 357.75,228 A 149.25,149.25 0 0 1 78.75,228 Z" fill="#FCFCFC" mask="url(#lockMask)"/>
+<svg width="128" height="128" viewBox="0 0 128 128" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <!-- Marca GDSB: arco do G (cadeado) sobre o D deitado, com a fechadura recortada.
+         Sem <mask> e sem gradiente de proposito: o resizetizer do MAUI rasteriza via
+         SkiaSharp e o recorte por fill-rule="evenodd" e o unico que sobrevive intacto
+         em todas as densidades. Conteudo escalado para caber na zona segura de 66%
+         do icone adaptativo do Android. -->
+    <g transform="translate(64,64) scale(0.74) translate(-64,-58.9)">
+        <path d="M83.2,27.6 A24,24 0 1 0 84.1,55.1 L84.1,45 L71,45"
+              fill="none" stroke="#D936D3" stroke-width="11"
+              stroke-linecap="round" stroke-linejoin="round"/>
+        <path fill-rule="evenodd" fill="#FCFCFC"
+              d="M22,64 h84 a42,42 0 0 1 -84,0 z
+                 M56,79 a8,8 0 1 1 16,0 a8,8 0 1 1 -16,0 z
+                 M60.5,86.5 C54,90.5 55,97 61,100.5 L64.5,98.5 C60,96 59.5,92 64,88.5 Z"/>
+    </g>
 </svg>

--- a/src/GDSB.MAUI/Resources/AppIcon/appiconfg.svg
+++ b/src/GDSB.MAUI/Resources/AppIcon/appiconfg.svg
@@ -1,8 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <path d="m 105.50037,281.60863 c -2.70293,0 -5.00091,-0.90042 -6.893127,-2.70209 -1.892214,-1.84778 -2.837901,-4.04181 -2.837901,-6.58209 0,-2.58722 0.945687,-4.80389 2.837901,-6.65167 1.892217,-1.84778 4.190197,-2.77167 6.893127,-2.77167 2.74819,0 5.06798,0.92389 6.96019,2.77167 1.93749,1.84778 2.90581,4.06445 2.90581,6.65167 0,2.54028 -0.96832,4.73431 -2.90581,6.58209 -1.89221,1.80167 -4.212,2.70209 -6.96019,2.70209 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
-    <path d="M 213.56111,280.08446 H 195.99044 L 149.69953,207.0544 c -1.17121,-1.84778 -2.14037,-3.76515 -2.90581,-5.75126 h -0.40578 c 0.36051,2.12528 0.54076,6.67515 0.54076,13.6496 v 65.13172 h -15.54349 v -99.36009 h 18.71925 l 44.7374,71.29798 c 1.89222,2.95695 3.1087,4.98917 3.64945,6.09751 h 0.26996 c -0.45021,-2.6325 -0.67573,-7.09015 -0.67573,-13.37293 v -64.02256 h 15.47557 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
-    <path d="m 289.25134,280.08446 h -54.40052 v -99.36009 h 52.23835 v 13.99669 h -36.15411 v 28.13085 h 33.31621 v 13.9271 h -33.31621 v 29.37835 h 38.31628 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
-    <path d="M 366.56466,194.72106 H 338.7222 v 85.3634 h -16.08423 v -85.3634 h -27.77455 v -13.99669 h 71.70124 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
+<svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <!-- G arc (magenta) -->
+  <path d="M 297.36,149.4 A 85.5,85.5 0 1 0 299.64,297.15 L 299.64,220.5 L 252.75,220.5" fill="none" stroke="#D936D3" stroke-width="39.375" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Body (D deitado) with lock cutout mask -->
+  <defs>
+    <mask id="lockMask" maskUnits="userSpaceOnUse" x="0" y="0" width="456" height="456">
+      <rect width="456" height="456" fill="white"/>
+      <!-- Keyhole cutout: circle + shaft -->
+      <circle cx="228" cy="281.25" r="28.5" fill="black"/>
+      <path d="M 228,309.75 C 204.75,327 204.75,358.5 228,375.75" fill="none" stroke="black" stroke-width="23.25" stroke-linecap="round"/>
+    </mask>
+  </defs>
+
+  <!-- D-shaped body (semicircle at bottom) with mask applied -->
+  <path d="M 78.75,228 L 357.75,228 A 149.25,149.25 0 0 1 78.75,228 Z" fill="#FCFCFC" mask="url(#lockMask)"/>
 </svg>

--- a/src/GDSB.MAUI/Resources/Splash/splash.svg
+++ b/src/GDSB.MAUI/Resources/Splash/splash.svg
@@ -1,8 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <path d="m 105.50037,281.60863 c -2.70293,0 -5.00091,-0.90042 -6.893127,-2.70209 -1.892214,-1.84778 -2.837901,-4.04181 -2.837901,-6.58209 0,-2.58722 0.945687,-4.80389 2.837901,-6.65167 1.892217,-1.84778 4.190197,-2.77167 6.893127,-2.77167 2.74819,0 5.06798,0.92389 6.96019,2.77167 1.93749,1.84778 2.90581,4.06445 2.90581,6.65167 0,2.54028 -0.96832,4.73431 -2.90581,6.58209 -1.89221,1.80167 -4.212,2.70209 -6.96019,2.70209 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
-    <path d="M 213.56111,280.08446 H 195.99044 L 149.69953,207.0544 c -1.17121,-1.84778 -2.14037,-3.76515 -2.90581,-5.75126 h -0.40578 c 0.36051,2.12528 0.54076,6.67515 0.54076,13.6496 v 65.13172 h -15.54349 v -99.36009 h 18.71925 l 44.7374,71.29798 c 1.89222,2.95695 3.1087,4.98917 3.64945,6.09751 h 0.26996 c -0.45021,-2.6325 -0.67573,-7.09015 -0.67573,-13.37293 v -64.02256 h 15.47557 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
-    <path d="m 289.25134,280.08446 h -54.40052 v -99.36009 h 52.23835 v 13.99669 h -36.15411 v 28.13085 h 33.31621 v 13.9271 h -33.31621 v 29.37835 h 38.31628 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
-    <path d="M 366.56466,194.72106 H 338.7222 v 85.3634 h -16.08423 v -85.3634 h -27.77455 v -13.99669 h 71.70124 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
+<svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <!-- G arc (magenta) -->
+  <path d="M 297.36,149.4 A 85.5,85.5 0 1 0 299.64,297.15 L 299.64,220.5 L 252.75,220.5" fill="none" stroke="#D936D3" stroke-width="39.375" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Body (D deitado) with lock cutout mask -->
+  <defs>
+    <mask id="lockMask" maskUnits="userSpaceOnUse" x="0" y="0" width="456" height="456">
+      <rect width="456" height="456" fill="white"/>
+      <!-- Keyhole cutout: circle + shaft -->
+      <circle cx="228" cy="281.25" r="28.5" fill="black"/>
+      <path d="M 228,309.75 C 204.75,327 204.75,358.5 228,375.75" fill="none" stroke="black" stroke-width="23.25" stroke-linecap="round"/>
+    </mask>
+  </defs>
+
+  <!-- D-shaped body (semicircle at bottom) with mask applied -->
+  <path d="M 78.75,228 L 357.75,228 A 149.25,149.25 0 0 1 78.75,228 Z" fill="#FCFCFC" mask="url(#lockMask)"/>
 </svg>

--- a/src/GDSB.MAUI/Resources/Splash/splash.svg
+++ b/src/GDSB.MAUI/Resources/Splash/splash.svg
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg">
-  <!-- G arc (magenta) -->
-  <path d="M 297.36,149.4 A 85.5,85.5 0 1 0 299.64,297.15 L 299.64,220.5 L 252.75,220.5" fill="none" stroke="#D936D3" stroke-width="39.375" stroke-linecap="round" stroke-linejoin="round"/>
-
-  <!-- Body (D deitado) with lock cutout mask -->
-  <defs>
-    <mask id="lockMask" maskUnits="userSpaceOnUse" x="0" y="0" width="456" height="456">
-      <rect width="456" height="456" fill="white"/>
-      <!-- Keyhole cutout: circle + shaft -->
-      <circle cx="228" cy="281.25" r="28.5" fill="black"/>
-      <path d="M 228,309.75 C 204.75,327 204.75,358.5 228,375.75" fill="none" stroke="black" stroke-width="23.25" stroke-linecap="round"/>
-    </mask>
-  </defs>
-
-  <!-- D-shaped body (semicircle at bottom) with mask applied -->
-  <path d="M 78.75,228 L 357.75,228 A 149.25,149.25 0 0 1 78.75,228 Z" fill="#FCFCFC" mask="url(#lockMask)"/>
+<svg width="128" height="128" viewBox="0 0 128 128" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <!-- Mesma marca do appiconfg, ocupando ~62% do quadro sobre o navy chapado.
+         Igualmente sem <mask> e sem gradiente - ver appiconfg.svg. -->
+    <g transform="translate(64,64) scale(0.84) translate(-64,-58.9)">
+        <path d="M83.2,27.6 A24,24 0 1 0 84.1,55.1 L84.1,45 L71,45"
+              fill="none" stroke="#D936D3" stroke-width="11"
+              stroke-linecap="round" stroke-linejoin="round"/>
+        <path fill-rule="evenodd" fill="#FCFCFC"
+              d="M22,64 h84 a42,42 0 0 1 -84,0 z
+                 M56,79 a8,8 0 1 1 16,0 a8,8 0 1 1 -16,0 z
+                 M60.5,86.5 C54,90.5 55,97 61,100.5 L64.5,98.5 C60,96 59.5,92 64,88.5 Z"/>
+    </g>
 </svg>

--- a/src/GDSB.MAUI/Resources/Styles/Colors.xaml
+++ b/src/GDSB.MAUI/Resources/Styles/Colors.xaml
@@ -1,49 +1,73 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <?xaml-comp compile="true" ?>
-<ResourceDictionary 
+<ResourceDictionary
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
 
     <!-- Note: For Android please see also Platforms\Android\Resources\values\colors.xml -->
 
-    <Color x:Key="Primary">#512BD4</Color>
-    <Color x:Key="PrimaryDark">#ac99ea</Color>
-    <Color x:Key="PrimaryDarkText">#242424</Color>
-    <Color x:Key="Secondary">#DFD8F7</Color>
-    <Color x:Key="SecondaryDarkText">#9880e5</Color>
-    <Color x:Key="Tertiary">#2B0B98</Color>
+    <!-- ===================================================================
+         Paleta da marca GDSB.
+         Quatro cores base (navy, roxo, magenta, off-white) mais dois
+         derivados que existem só para passar em contraste AA, e três
+         funcionais. Os números de contraste citados são contra o fundo
+         #060B24.
+         =================================================================== -->
 
-    <Color x:Key="White">White</Color>
-    <Color x:Key="Black">Black</Color>
-    <Color x:Key="Magenta">#D600AA</Color>
-    <Color x:Key="MidnightBlue">#190649</Color>
-    <Color x:Key="OffBlack">#1f1f1f</Color>
-
-    <Color x:Key="Gray100">#E1E1E1</Color>
-    <Color x:Key="Gray200">#C8C8C8</Color>
-    <Color x:Key="Gray300">#ACACAC</Color>
-    <Color x:Key="Gray400">#919191</Color>
-    <Color x:Key="Gray500">#6E6E6E</Color>
-    <Color x:Key="Gray600">#404040</Color>
-    <Color x:Key="Gray900">#212121</Color>
-    <Color x:Key="Gray950">#141414</Color>
-
-    <!-- Fase 3: aprovadas junto com o protótipo visual (favorito / ações destrutivas) -->
-    <Color x:Key="FavoriteGold">#FFC53D</Color>
-    <Color x:Key="Danger">#FF5A6A</Color>
-
-    <!-- Brand colors - nova identidade visual -->
+    <!-- Base -->
     <Color x:Key="BrandNavy">#00186E</Color>
     <Color x:Key="BrandViolet">#400880</Color>
     <Color x:Key="BrandPink">#D936D3</Color>
     <Color x:Key="BrandWhite">#FCFCFC</Color>
+    <!-- Derivados por contraste: branco sobre #D936D3 dá 3.8:1 e reprova no AA;
+         o #C21FBC dá 4.85:1 e é indistinguível a olho. O #D936D3 em corpo de
+         texto fica no limite, então texto/ícone rosa usa o #F27BEB (8.1:1). -->
     <Color x:Key="BrandPinkContrast">#C21FBC</Color>
     <Color x:Key="BrandPinkText">#F27BEB</Color>
 
-    <!-- Aliases da superfície escura usada no protótipo (tela de desbloqueio, lista, editor) -->
+    <!-- Tokens do template remapeados para a marca.
+         Primary é a cor de ação preenchida (chip selecionado, botão);
+         Tertiary é o fundo de card, que é como as páginas já o usavam. -->
+    <Color x:Key="Primary">#C21FBC</Color>
+    <Color x:Key="PrimaryDark">#F27BEB</Color>
+    <Color x:Key="PrimaryDarkText">#FCFCFC</Color>
+    <Color x:Key="Secondary">#C9CEE8</Color>
+    <Color x:Key="SecondaryDarkText">#A9B0D6</Color>
+    <Color x:Key="Tertiary">#0E1540</Color>
+
+    <Color x:Key="White">White</Color>
+    <Color x:Key="Black">Black</Color>
+    <Color x:Key="Magenta">#D936D3</Color>
+    <Color x:Key="MidnightBlue">#00186E</Color>
+    <Color x:Key="OffBlack">#060B24</Color>
+
+    <!-- Escala de cinza com viés navy: cinza neutro sobre superfície azul
+         fica embarrado. Gray400 é o "metadado" da tabela de contraste (6.5:1). -->
+    <Color x:Key="Gray100">#E8EAF6</Color>
+    <Color x:Key="Gray200">#C9CEE8</Color>
+    <Color x:Key="Gray300">#A9B0D6</Color>
+    <Color x:Key="Gray400">#8A93C4</Color>
+    <Color x:Key="Gray500">#6E77A8</Color>
+    <Color x:Key="Gray600">#3C4585</Color>
+    <Color x:Key="Gray900">#0E1540</Color>
+    <Color x:Key="Gray950">#060B24</Color>
+
+    <!-- Funcionais. FavoriteGold é o #F5B93E um pouco mais saturado, para
+         segurar contra o rosa; Danger substitui o #E5484D por um vermelho
+         mais quente, para "excluir" não parecer irmão de "salvar"; Success
+         é verde-azulado por ser o complemento do magenta. -->
+    <Color x:Key="FavoriteGold">#FFC53D</Color>
+    <Color x:Key="Danger">#FF5A6A</Color>
+    <Color x:Key="Success">#2ED3A7</Color>
+
+    <!-- Superfícies escuras (tela de desbloqueio, lista, editor) -->
     <Color x:Key="SurfaceDark">#060B24</Color>
     <Color x:Key="SurfaceCardDark">#0E1540</Color>
+    <Color x:Key="SurfaceElevatedDark">#16205C</Color>
     <Color x:Key="BorderDark">#232B63</Color>
+    <Color x:Key="BorderStrongDark">#3C4585</Color>
+
+    <!-- Texto sobre o fundo #060B24 -->
     <Color x:Key="TextPrimaryDark">#FCFCFC</Color>
     <Color x:Key="TextSecondaryDark">#A9B0D6</Color>
     <Color x:Key="TextMutedDark">#6E77A8</Color>
@@ -55,14 +79,35 @@
     <SolidColorBrush x:Key="BlackBrush" Color="{StaticResource Black}"/>
     <SolidColorBrush x:Key="FavoriteGoldBrush" Color="{StaticResource FavoriteGold}"/>
     <SolidColorBrush x:Key="DangerBrush" Color="{StaticResource Danger}"/>
+    <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource Success}"/>
     <!-- Stroke/Background de Border são Brush, não Color: estes existem pra não depender de conversão implícita -->
     <SolidColorBrush x:Key="SurfaceDarkBrush" Color="{StaticResource SurfaceDark}"/>
     <SolidColorBrush x:Key="SurfaceCardDarkBrush" Color="{StaticResource SurfaceCardDark}"/>
+    <SolidColorBrush x:Key="SurfaceElevatedDarkBrush" Color="{StaticResource SurfaceElevatedDark}"/>
     <SolidColorBrush x:Key="BorderDarkBrush" Color="{StaticResource BorderDark}"/>
+    <SolidColorBrush x:Key="BorderStrongDarkBrush" Color="{StaticResource BorderStrongDark}"/>
     <SolidColorBrush x:Key="PrimaryDarkBrush" Color="{StaticResource PrimaryDark}"/>
+
+    <!-- Gradiente de ação: roxo → magenta profundo, 135°. Termina no #C21FBC
+         de propósito, para o rótulo branco ficar acima de 4.5:1 em qualquer
+         ponto do botão. É o Background do PrimaryActionButtonStyle. -->
     <LinearGradientBrush x:Key="PrimaryGradientBrush" StartPoint="0,0" EndPoint="1,1">
-        <GradientStop Color="{StaticResource Primary}" Offset="0.0" />
-        <GradientStop Color="{StaticResource Tertiary}" Offset="1.0" />
+        <GradientStop Color="{StaticResource BrandViolet}" Offset="0.0" />
+        <GradientStop Color="{StaticResource BrandPinkContrast}" Offset="1.0" />
+    </LinearGradientBrush>
+
+    <!-- Gradiente da marca, três paradas. Só para superfície de destaque
+         (cabeçalho de desbloqueio, marca-d'água) — nunca atrás de texto corrido. -->
+    <LinearGradientBrush x:Key="BrandGradientBrush" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="{StaticResource BrandNavy}" Offset="0.0" />
+        <GradientStop Color="{StaticResource BrandViolet}" Offset="0.55" />
+        <GradientStop Color="{StaticResource BrandPink}" Offset="1.0" />
+    </LinearGradientBrush>
+
+    <!-- Lavagem de topo: navy dissolvendo no fundo da página. -->
+    <LinearGradientBrush x:Key="TopWashBrush" StartPoint="0,0" EndPoint="0,1">
+        <GradientStop Color="{StaticResource BrandNavy}" Offset="0.0" />
+        <GradientStop Color="{StaticResource SurfaceDark}" Offset="1.0" />
     </LinearGradientBrush>
 
     <SolidColorBrush x:Key="Gray100Brush" Color="{StaticResource Gray100}"/>
@@ -73,16 +118,4 @@
     <SolidColorBrush x:Key="Gray600Brush" Color="{StaticResource Gray600}"/>
     <SolidColorBrush x:Key="Gray900Brush" Color="{StaticResource Gray900}"/>
     <SolidColorBrush x:Key="Gray950Brush" Color="{StaticResource Gray950}"/>
-
-    <!-- Brand brushes -->
-    <SolidColorBrush x:Key="BrandNavyBrush" Color="{StaticResource BrandNavy}"/>
-    <SolidColorBrush x:Key="BrandVioletBrush" Color="{StaticResource BrandViolet}"/>
-    <SolidColorBrush x:Key="BrandPinkBrush" Color="{StaticResource BrandPink}"/>
-    <SolidColorBrush x:Key="BrandWhiteBrush" Color="{StaticResource BrandWhite}"/>
-    <SolidColorBrush x:Key="BrandPinkContrastBrush" Color="{StaticResource BrandPinkContrast}"/>
-    <SolidColorBrush x:Key="BrandPinkTextBrush" Color="{StaticResource BrandPinkText}"/>
-    <LinearGradientBrush x:Key="BrandGradientBrush" StartPoint="0,0" EndPoint="1,1">
-        <GradientStop Color="{StaticResource BrandViolet}" Offset="0.0" />
-        <GradientStop Color="{StaticResource BrandPinkContrast}" Offset="1.0" />
-    </LinearGradientBrush>
 </ResourceDictionary>

--- a/src/GDSB.MAUI/Resources/Styles/Colors.xaml
+++ b/src/GDSB.MAUI/Resources/Styles/Colors.xaml
@@ -29,16 +29,24 @@
     <Color x:Key="Gray950">#141414</Color>
 
     <!-- Fase 3: aprovadas junto com o protótipo visual (favorito / ações destrutivas) -->
-    <Color x:Key="FavoriteGold">#F5B93E</Color>
-    <Color x:Key="Danger">#E5484D</Color>
+    <Color x:Key="FavoriteGold">#FFC53D</Color>
+    <Color x:Key="Danger">#FF5A6A</Color>
+
+    <!-- Brand colors - nova identidade visual -->
+    <Color x:Key="BrandNavy">#00186E</Color>
+    <Color x:Key="BrandViolet">#400880</Color>
+    <Color x:Key="BrandPink">#D936D3</Color>
+    <Color x:Key="BrandWhite">#FCFCFC</Color>
+    <Color x:Key="BrandPinkContrast">#C21FBC</Color>
+    <Color x:Key="BrandPinkText">#F27BEB</Color>
 
     <!-- Aliases da superfície escura usada no protótipo (tela de desbloqueio, lista, editor) -->
-    <Color x:Key="SurfaceDark">#141414</Color>
-    <Color x:Key="SurfaceCardDark">#1f1f1f</Color>
-    <Color x:Key="BorderDark">#2b2b2b</Color>
-    <Color x:Key="TextPrimaryDark">#F7F5FC</Color>
-    <Color x:Key="TextSecondaryDark">#919191</Color>
-    <Color x:Key="TextMutedDark">#6E6E6E</Color>
+    <Color x:Key="SurfaceDark">#060B24</Color>
+    <Color x:Key="SurfaceCardDark">#0E1540</Color>
+    <Color x:Key="BorderDark">#232B63</Color>
+    <Color x:Key="TextPrimaryDark">#FCFCFC</Color>
+    <Color x:Key="TextSecondaryDark">#A9B0D6</Color>
+    <Color x:Key="TextMutedDark">#6E77A8</Color>
 
     <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource Primary}"/>
     <SolidColorBrush x:Key="SecondaryBrush" Color="{StaticResource Secondary}"/>
@@ -65,4 +73,16 @@
     <SolidColorBrush x:Key="Gray600Brush" Color="{StaticResource Gray600}"/>
     <SolidColorBrush x:Key="Gray900Brush" Color="{StaticResource Gray900}"/>
     <SolidColorBrush x:Key="Gray950Brush" Color="{StaticResource Gray950}"/>
+
+    <!-- Brand brushes -->
+    <SolidColorBrush x:Key="BrandNavyBrush" Color="{StaticResource BrandNavy}"/>
+    <SolidColorBrush x:Key="BrandVioletBrush" Color="{StaticResource BrandViolet}"/>
+    <SolidColorBrush x:Key="BrandPinkBrush" Color="{StaticResource BrandPink}"/>
+    <SolidColorBrush x:Key="BrandWhiteBrush" Color="{StaticResource BrandWhite}"/>
+    <SolidColorBrush x:Key="BrandPinkContrastBrush" Color="{StaticResource BrandPinkContrast}"/>
+    <SolidColorBrush x:Key="BrandPinkTextBrush" Color="{StaticResource BrandPinkText}"/>
+    <LinearGradientBrush x:Key="BrandGradientBrush" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="{StaticResource BrandViolet}" Offset="0.0" />
+        <GradientStop Color="{StaticResource BrandPinkContrast}" Offset="1.0" />
+    </LinearGradientBrush>
 </ResourceDictionary>

--- a/src/GDSB.MAUI/UnlockPage.xaml
+++ b/src/GDSB.MAUI/UnlockPage.xaml
@@ -14,11 +14,11 @@
             <VerticalStackLayout Grid.Row="1" Spacing="32">
 
                 <VerticalStackLayout Spacing="14" HorizontalOptions="Center">
-                    <Border WidthRequest="84" HeightRequest="84" StrokeShape="RoundRectangle 42"
-                            BackgroundColor="{StaticResource Tertiary}" Stroke="{StaticResource PrimaryDarkBrush}"
-                            HorizontalOptions="Center">
-                        <Label Text="&#128274;" FontSize="34" HorizontalOptions="Center" VerticalOptions="Center" />
-                    </Border>
+                    <!-- A marca de verdade, desenhada pelo BrandMarkDrawable a partir da mesma
+                         geometria das animações e do ícone do app. Antes era o emoji 🔒, que muda
+                         de desenho a cada plataforma e não aceita a cor da marca. -->
+                    <GraphicsView x:Name="BrandMark" WidthRequest="92" HeightRequest="92"
+                                  HorizontalOptions="Center" />
                     <Label Text="GDSB" FontSize="26" FontFamily="OpenSansSemibold"
                            TextColor="{StaticResource TextPrimaryDark}" HorizontalOptions="Center" />
                     <Label Text="Seu cofre de senhas" FontSize="13"

--- a/src/GDSB.MAUI/UnlockPage.xaml
+++ b/src/GDSB.MAUI/UnlockPage.xaml
@@ -89,10 +89,27 @@
                                 </VerticalStackLayout>
                             </Border>
 
-                            <Button Text="&#128272; Desbloquear com biometria"
-                                    Style="{StaticResource PrimaryActionButtonStyle}"
-                                    Command="{Binding UnlockWithBiometricCommand}"
-                                    IsEnabled="{Binding CanInteract}" />
+                            <!-- Button do MAUI não aceita conteúdo vetorial, então o ícone e o
+                                 rótulo ficam sobrepostos num Grid: o Button segue responsável
+                                 pelo toque, comando e estado, e a camada de cima é
+                                 InputTransparent (cascateia para os filhos). O texto sai do
+                                 Button para não aparecer duplicado. -->
+                            <Grid>
+                                <Button Style="{StaticResource PrimaryActionButtonStyle}"
+                                        Command="{Binding UnlockWithBiometricCommand}"
+                                        IsEnabled="{Binding CanInteract}"
+                                        SemanticProperties.Description="Desbloquear com biometria" />
+                                <HorizontalStackLayout HorizontalOptions="Center" VerticalOptions="Center"
+                                                       Spacing="9" InputTransparent="True">
+                                    <GraphicsView x:Name="BiometricButtonIcon"
+                                                  WidthRequest="18" HeightRequest="18"
+                                                  VerticalOptions="Center" />
+                                    <Label Text="Desbloquear com biometria"
+                                           TextColor="{StaticResource White}"
+                                           FontFamily="OpenSansSemibold" FontSize="15"
+                                           VerticalOptions="Center" />
+                                </HorizontalStackLayout>
+                            </Grid>
 
                             <Button Text="Trocar cofre"
                                     Style="{StaticResource SecondaryActionButtonStyle}"

--- a/src/GDSB.MAUI/UnlockPage.xaml.cs
+++ b/src/GDSB.MAUI/UnlockPage.xaml.cs
@@ -13,6 +13,14 @@ public partial class UnlockPage : ContentPage
         _viewModel = viewModel;
         BindingContext = _viewModel;
         BrandMark.Drawable = new BrandMarkDrawable();
+        // No botão a digital é branca e sem a crista curta, como no protótipo: em 18px
+        // ela vira um risco solto.
+        BiometricButtonIcon.Drawable = new FingerprintDrawable
+        {
+            Stroke = Colors.White,
+            StrokeWidth = 1.7f,
+            Compact = true,
+        };
     }
 
     protected override async void OnAppearing()

--- a/src/GDSB.MAUI/UnlockPage.xaml.cs
+++ b/src/GDSB.MAUI/UnlockPage.xaml.cs
@@ -1,4 +1,5 @@
 using GDSB.MAUI.ViewModels;
+using GDSB.MAUI.Views;
 
 namespace GDSB.MAUI;
 
@@ -11,6 +12,7 @@ public partial class UnlockPage : ContentPage
         InitializeComponent();
         _viewModel = viewModel;
         BindingContext = _viewModel;
+        BrandMark.Drawable = new BrandMarkDrawable();
     }
 
     protected override async void OnAppearing()

--- a/src/GDSB.MAUI/VaultPage.xaml
+++ b/src/GDSB.MAUI/VaultPage.xaml
@@ -236,8 +236,10 @@
         </Border>
 
         <!--
-          Selo de criação: a marca desenhada como cadeado que fecha, disparado por
-          SecretCreated (só em item novo e só se o Save deu certo) - ver LockSealDrawable.
+          Selo de confirmação: a marca animada em três gestos - cadeado que fecha ao criar,
+          anel que completa a volta ao editar, marca que estilhaça ao excluir. Disparado por
+          SecretCreated / SecretUpdated / SecretDeleted, que só ocorrem quando a gravação no
+          arquivo deu certo - ver LockSealDrawable.
           InputTransparent porque é puramente ilustrativo: não deve prender o toque do
           usuário durante o segundo em que aparece.
         -->
@@ -246,7 +248,7 @@
             <VerticalStackLayout HorizontalOptions="Center" VerticalOptions="Center" Spacing="18">
                 <GraphicsView x:Name="SealView" WidthRequest="132" HeightRequest="132"
                               HorizontalOptions="Center" />
-                <Label Text="Segredo guardado" HorizontalOptions="Center"
+                <Label x:Name="SealLabel" HorizontalOptions="Center"
                        TextColor="{StaticResource TextPrimaryDark}" FontSize="15"
                        FontFamily="OpenSansSemibold" />
             </VerticalStackLayout>

--- a/src/GDSB.MAUI/VaultPage.xaml
+++ b/src/GDSB.MAUI/VaultPage.xaml
@@ -5,8 +5,14 @@
              xmlns:behaviors="clr-namespace:GDSB.MAUI.Behaviors"
              x:Class="GDSB.MAUI.VaultPage"
              x:Name="ThisPage"
-             Title="{Binding VaultName}"
              BackgroundColor="{StaticResource SurfaceDark}">
+
+    <!--
+      Sem Title de propósito: o nome do cofre já aparece no cabeçalho da página, nos dois
+      layouts. Com o Title do Shell também ligado ao VaultName, o layout largo mostrava o
+      nome duas vezes no canto superior esquerdo. A barra do Shell fica só com a seta de
+      voltar.
+    -->
 
     <!--
       Sobrescreve o botão de voltar padrão do Shell (a seta no canto superior esquerdo): o pop
@@ -116,6 +122,11 @@
         <Grid RowDefinitions="Auto,*" IsVisible="{Binding IsCompactLayout}">
 
             <VerticalStackLayout Grid.Row="0" Padding="18,16,18,10" Spacing="12" BackgroundColor="{StaticResource Tertiary}">
+                <!-- O nome do cofre vive no cabeçalho da página, não no Title do Shell: com os
+                     dois, o layout largo mostrava o nome duas vezes. Aqui ele acompanha o
+                     layout largo, que já fazia assim. -->
+                <Label Text="{Binding VaultName}" FontFamily="OpenSansSemibold" FontSize="18"
+                       TextColor="{StaticResource TextPrimaryDark}" LineBreakMode="TailTruncation" />
                 <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
                     <Border Grid.Column="0" BackgroundColor="{StaticResource SurfaceCardDark}" Stroke="{StaticResource BorderDarkBrush}"
                             StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="44">

--- a/src/GDSB.MAUI/VaultPage.xaml
+++ b/src/GDSB.MAUI/VaultPage.xaml
@@ -235,5 +235,22 @@
                    FontFamily="OpenSansSemibold" />
         </Border>
 
+        <!--
+          Selo de criação: a marca desenhada como cadeado que fecha, disparado por
+          SecretCreated (só em item novo e só se o Save deu certo) - ver LockSealDrawable.
+          InputTransparent porque é puramente ilustrativo: não deve prender o toque do
+          usuário durante o segundo em que aparece.
+        -->
+        <Grid x:Name="SealOverlay" IsVisible="False" Opacity="0" InputTransparent="True"
+              BackgroundColor="#B3060B24">
+            <VerticalStackLayout HorizontalOptions="Center" VerticalOptions="Center" Spacing="18">
+                <GraphicsView x:Name="SealView" WidthRequest="132" HeightRequest="132"
+                              HorizontalOptions="Center" />
+                <Label Text="Segredo guardado" HorizontalOptions="Center"
+                       TextColor="{StaticResource TextPrimaryDark}" FontSize="15"
+                       FontFamily="OpenSansSemibold" />
+            </VerticalStackLayout>
+        </Grid>
+
     </Grid>
 </ContentPage>

--- a/src/GDSB.MAUI/VaultPage.xaml.cs
+++ b/src/GDSB.MAUI/VaultPage.xaml.cs
@@ -1,11 +1,16 @@
 using GDSB.MAUI.ViewModels;
+using GDSB.MAUI.Views;
 
 namespace GDSB.MAUI;
 
 public partial class VaultPage : ContentPage
 {
+    private const string SealAnimationName = "GdsbLockSeal";
+
     private readonly VaultViewModel _viewModel;
+    private readonly LockSealDrawable _sealDrawable = new();
     private CancellationTokenSource? _toastCts;
+    private CancellationTokenSource? _sealCts;
 
     public VaultPage(VaultViewModel viewModel)
     {
@@ -13,6 +18,8 @@ public partial class VaultPage : ContentPage
         _viewModel = viewModel;
         BindingContext = _viewModel;
         _viewModel.ToastRequested += OnToastRequested;
+        _viewModel.SecretCreated += OnSecretCreated;
+        SealView.Drawable = _sealDrawable;
     }
 
     protected override void OnSizeAllocated(double width, double height)
@@ -50,5 +57,59 @@ public partial class VaultPage : ContentPage
         {
             // Um novo toast chegou antes do delay acabar - a chamada nova assume o fade-out.
         }
+    }
+
+    /// <summary>
+    /// Cadeado da marca fechando, por cima da lista já atualizada. Só chega aqui quando o
+    /// item é novo e a gravação no arquivo deu certo - ver VaultViewModel.SecretCreated.
+    /// </summary>
+    private async void OnSecretCreated(object? sender, EventArgs e)
+    {
+        _sealCts?.Cancel();
+        this.AbortAnimation(SealAnimationName);
+
+        var cts = new CancellationTokenSource();
+        _sealCts = cts;
+
+        _sealDrawable.Progress = 0f;
+        SealView.Invalidate();
+        SealOverlay.Opacity = 0;
+        SealOverlay.IsVisible = true;
+
+        try
+        {
+            await SealOverlay.FadeToAsync(1, 90);
+            await RunSealAnimationAsync();
+            await Task.Delay(420, cts.Token);
+            await SealOverlay.FadeToAsync(0, 200);
+
+            // Se outra criação assumiu o overlay durante o fade, quem esconde é ela.
+            if (_sealCts == cts)
+                SealOverlay.IsVisible = false;
+        }
+        catch (TaskCanceledException)
+        {
+            // Outra criação chegou antes do fim - a chamada nova assume o overlay.
+        }
+    }
+
+    /// <summary>
+    /// Linear de propósito: o escalonamento de cada fase (queda da haste, repique, anel)
+    /// já está no LockSealDrawable, que precisa receber o tempo cru para compô-las.
+    /// </summary>
+    private Task RunSealAnimationAsync()
+    {
+        var tcs = new TaskCompletionSource();
+
+        new Microsoft.Maui.Controls.Animation(
+                v =>
+                {
+                    _sealDrawable.Progress = (float)v;
+                    SealView.Invalidate();
+                }, 0d, 1d)
+            .Commit(this, SealAnimationName, length: 760, easing: Easing.Linear,
+                finished: (_, _) => tcs.TrySetResult());
+
+        return tcs.Task;
     }
 }

--- a/src/GDSB.MAUI/VaultPage.xaml.cs
+++ b/src/GDSB.MAUI/VaultPage.xaml.cs
@@ -65,11 +65,17 @@ public partial class VaultPage : ContentPage
     /// </summary>
     private async void OnSecretCreated(object? sender, EventArgs e)
     {
-        _sealCts?.Cancel();
-        this.AbortAnimation(SealAnimationName);
-
+        // Troca o token source antes de cancelar o anterior: com o await do CancelAsync no
+        // meio, assumir o overlay primeiro evita que duas criações quase simultâneas se
+        // intercalem entre o cancelamento e a atribuição.
+        var previous = _sealCts;
         var cts = new CancellationTokenSource();
         _sealCts = cts;
+
+        if (previous is not null)
+            await previous.CancelAsync();
+
+        this.AbortAnimation(SealAnimationName);
 
         _sealDrawable.Progress = 0f;
         SealView.Invalidate();

--- a/src/GDSB.MAUI/VaultPage.xaml.cs
+++ b/src/GDSB.MAUI/VaultPage.xaml.cs
@@ -19,6 +19,8 @@ public partial class VaultPage : ContentPage
         BindingContext = _viewModel;
         _viewModel.ToastRequested += OnToastRequested;
         _viewModel.SecretCreated += OnSecretCreated;
+        _viewModel.SecretUpdated += OnSecretUpdated;
+        _viewModel.SecretDeleted += OnSecretDeleted;
         SealView.Drawable = _sealDrawable;
     }
 
@@ -59,14 +61,25 @@ public partial class VaultPage : ContentPage
         }
     }
 
-    /// <summary>
-    /// Cadeado da marca fechando, por cima da lista já atualizada. Só chega aqui quando o
-    /// item é novo e a gravação no arquivo deu certo - ver VaultViewModel.SecretCreated.
-    /// </summary>
+    // Os três selos, por cima da lista já atualizada. Só chegam aqui quando a gravação no
+    // arquivo deu certo - ver os eventos correspondentes no VaultViewModel.
     private async void OnSecretCreated(object? sender, EventArgs e)
+        => await PlaySealAsync(LockSealMode.Create, "Segredo guardado", 760);
+
+    private async void OnSecretUpdated(object? sender, EventArgs e)
+        => await PlaySealAsync(LockSealMode.Update, "Alterações salvas", 620);
+
+    private async void OnSecretDeleted(object? sender, EventArgs e)
+        => await PlaySealAsync(LockSealMode.Delete, "Segredo excluído", 740);
+
+    /// <summary>
+    /// Duração por modo: a edição é mais curta por ser o evento menor, e a exclusão precisa
+    /// de um pouco mais para os cacos saírem de cena.
+    /// </summary>
+    private async Task PlaySealAsync(LockSealMode mode, string label, uint length)
     {
         // Troca o token source antes de cancelar o anterior: com o await do CancelAsync no
-        // meio, assumir o overlay primeiro evita que duas criações quase simultâneas se
+        // meio, assumir o overlay primeiro evita que duas ações quase simultâneas se
         // intercalem entre o cancelamento e a atribuição.
         var previous = _sealCts;
         var cts = new CancellationTokenSource();
@@ -77,7 +90,9 @@ public partial class VaultPage : ContentPage
 
         this.AbortAnimation(SealAnimationName);
 
+        _sealDrawable.Mode = mode;
         _sealDrawable.Progress = 0f;
+        SealLabel.Text = label;
         SealView.Invalidate();
         SealOverlay.Opacity = 0;
         SealOverlay.IsVisible = true;
@@ -85,17 +100,17 @@ public partial class VaultPage : ContentPage
         try
         {
             await SealOverlay.FadeToAsync(1, 90);
-            await RunSealAnimationAsync();
+            await RunSealAnimationAsync(length);
             await Task.Delay(420, cts.Token);
             await SealOverlay.FadeToAsync(0, 200);
 
-            // Se outra criação assumiu o overlay durante o fade, quem esconde é ela.
+            // Se outro selo assumiu o overlay durante o fade, quem esconde é ele.
             if (_sealCts == cts)
                 SealOverlay.IsVisible = false;
         }
         catch (TaskCanceledException)
         {
-            // Outra criação chegou antes do fim - a chamada nova assume o overlay.
+            // Outro selo chegou antes do fim - a chamada nova assume o overlay.
         }
     }
 
@@ -103,7 +118,7 @@ public partial class VaultPage : ContentPage
     /// Linear de propósito: o escalonamento de cada fase (queda da haste, repique, anel)
     /// já está no LockSealDrawable, que precisa receber o tempo cru para compô-las.
     /// </summary>
-    private Task RunSealAnimationAsync()
+    private Task RunSealAnimationAsync(uint length)
     {
         var tcs = new TaskCompletionSource();
 
@@ -113,7 +128,7 @@ public partial class VaultPage : ContentPage
                     _sealDrawable.Progress = (float)v;
                     SealView.Invalidate();
                 }, 0d, 1d)
-            .Commit(this, SealAnimationName, length: 760, easing: Easing.Linear,
+            .Commit(this, SealAnimationName, length: length, easing: Easing.Linear,
                 finished: (_, _) => tcs.TrySetResult());
 
         return tcs.Task;

--- a/src/GDSB.MAUI/Views/BiometricOptInView.xaml
+++ b/src/GDSB.MAUI/Views/BiometricOptInView.xaml
@@ -14,7 +14,9 @@
                 <Border WidthRequest="64" HeightRequest="64" StrokeShape="RoundRectangle 32"
                         BackgroundColor="{StaticResource Tertiary}" Stroke="{StaticResource PrimaryDarkBrush}"
                         HorizontalOptions="Center">
-                    <Label Text="&#128272;" FontSize="26" HorizontalOptions="Center" VerticalOptions="Center" />
+                    <!-- Impressão digital vetorial no lugar do emoji 🔐 - ver FingerprintDrawable. -->
+                    <GraphicsView x:Name="BiometricIcon" WidthRequest="30" HeightRequest="30"
+                                  HorizontalOptions="Center" VerticalOptions="Center" />
                 </Border>
 
                 <VerticalStackLayout Spacing="8">

--- a/src/GDSB.MAUI/Views/BiometricOptInView.xaml.cs
+++ b/src/GDSB.MAUI/Views/BiometricOptInView.xaml.cs
@@ -5,5 +5,6 @@ public partial class BiometricOptInView : ContentView
     public BiometricOptInView()
     {
         InitializeComponent();
+        BiometricIcon.Drawable = new FingerprintDrawable();
     }
 }

--- a/src/GDSB.MAUI/Views/FingerprintDrawable.cs
+++ b/src/GDSB.MAUI/Views/FingerprintDrawable.cs
@@ -1,0 +1,108 @@
+using Microsoft.Maui.Graphics;
+
+namespace GDSB.MAUI.Views;
+
+/// <summary>
+/// Ícone de impressão digital, no lugar do emoji 🔐 que o app usava para biometria - emoji
+/// muda de desenho a cada plataforma e não aceita a cor da marca.
+///
+/// Os traços vêm do protótipo (viewBox 24x24), aqui escalados para o tamanho da view. As
+/// cristas são arcos concêntricos em (12,11) com raios 1,8 / 4,6 / 7,8, ligados por curvas
+/// cúbicas - os arcos SVG originais eram "a1.8 1.8 0 0 1 3.6 0" e equivalentes, cujos centros
+/// caem todos nesse mesmo ponto.
+///
+/// Como no restante do app, os arcos são traçados por amostragem em vez das APIs de arco do
+/// canvas: evita depender da convenção de ângulo/sentido de cada rasterizador.
+/// </summary>
+public sealed class FingerprintDrawable : IDrawable
+{
+    private const float CenterX = 12f;
+    private const float CenterY = 11f;
+
+    /// <summary>Cor do traço. O card de biometria usa #F27BEB; o botão, branco.</summary>
+    public Color Stroke { get; set; } = Color.FromArgb("#F27BEB");
+
+    /// <summary>Espessura no espaço 24x24 do desenho: 1,5 no card e 1,7 no botão.</summary>
+    public float StrokeWidth { get; set; } = 1.5f;
+
+    /// <summary>
+    /// Omite a crista curta da esquerda, como o protótipo faz no botão: em 18px ela vira
+    /// um risco solto e só suja o desenho.
+    /// </summary>
+    public bool Compact { get; set; }
+
+    public void Draw(ICanvas canvas, RectF dirtyRect)
+    {
+        var size = Math.Min(dirtyRect.Width, dirtyRect.Height);
+        if (size <= 0)
+            return;
+
+        canvas.SaveState();
+        canvas.Translate(
+            dirtyRect.X + (dirtyRect.Width - size) / 2f,
+            dirtyRect.Y + (dirtyRect.Height - size) / 2f);
+        canvas.Scale(size / 24f, size / 24f);
+
+        canvas.StrokeColor = Stroke;
+        canvas.StrokeSize = StrokeWidth;
+        canvas.StrokeLineCap = LineCap.Round;
+        canvas.StrokeLineJoin = LineJoin.Round;
+
+        canvas.DrawPath(Compact ? CompactRidges : FullRidges);
+
+        canvas.RestoreState();
+    }
+
+    private static readonly PathF FullRidges = BuildRidges(compact: false);
+    private static readonly PathF CompactRidges = BuildRidges(compact: true);
+
+    private static PathF BuildRidges(bool compact)
+    {
+        var path = new PathF();
+
+        // Crista central, a mais curta.
+        path.MoveTo(12f, 11f);
+        path.CurveTo(12f, 14.5f, 11.5f, 16.8f, 10.6f, 18.6f);
+
+        // Segunda crista: sobe pela esquerda, contorna o topo com raio 1,8 e desce.
+        path.MoveTo(8.6f, 19.5f);
+        path.CurveTo(9.7f, 17.3f, 10.2f, 14.6f, 10.2f, 11f);
+        AppendArc(path, 1.8f, 180f, 360f);
+        path.CurveTo(13.8f, 13.6f, 13.5f, 15.7f, 13f, 17.4f);
+
+        // Terceira crista: mesmo desenho espelhado, raio 4,6.
+        path.MoveTo(15.6f, 18.2f);
+        path.CurveTo(16.3f, 16.1f, 16.6f, 13.6f, 16.6f, 11f);
+        AppendArc(path, 4.6f, 0f, -180f);
+        path.CurveTo(7.4f, 12.5f, 7.3f, 13.9f, 7f, 15.1f);
+
+        // Crista externa, raio 7,8, incompleta à esquerda.
+        path.MoveTo(19.4f, 15.6f);
+        path.CurveTo(19.7f, 14f, 19.8f, 12.4f, 19.8f, 11f);
+        AppendArc(path, 7.8f, 0f, -133.95f);
+
+        if (!compact)
+        {
+            path.MoveTo(4.2f, 13.4f);
+            path.CurveTo(4.3f, 12.6f, 4.4f, 11.8f, 4.4f, 11f);
+            path.CurveTo(4.4f, 9.6f, 4.8f, 8.3f, 5.4f, 7.2f);
+        }
+
+        return path;
+    }
+
+    /// <summary>Acrescenta um arco centrado em (12,11) ao subcaminho atual, por amostragem.</summary>
+    private static void AppendArc(PathF path, float radius, float startDeg, float endDeg)
+    {
+        var span = endDeg - startDeg;
+        var steps = Math.Max(2, (int)MathF.Ceiling(MathF.Abs(span) / 6f));
+
+        for (var i = 1; i <= steps; i++)
+        {
+            var rad = (startDeg + span * i / steps) * MathF.PI / 180f;
+            path.LineTo(
+                CenterX + radius * MathF.Cos(rad),
+                CenterY + radius * MathF.Sin(rad));
+        }
+    }
+}

--- a/src/GDSB.MAUI/Views/LockSealDrawable.cs
+++ b/src/GDSB.MAUI/Views/LockSealDrawable.cs
@@ -2,6 +2,20 @@ using Microsoft.Maui.Graphics;
 
 namespace GDSB.MAUI.Views;
 
+/// <summary>
+/// A marca GDSB parada, para uso decorativo na interface (o emblema da tela de desbloqueio).
+/// Reaproveita a geometria do <see cref="LockSealDrawable"/> em vez de duplicá-la, então a
+/// marca da tela e a das animações não podem divergir.
+/// </summary>
+public sealed class BrandMarkDrawable : IDrawable
+{
+    /// <summary>Desenha o disco navy atrás da marca. Desligue sobre superfície já escura.</summary>
+    public bool ShowBadge { get; set; } = true;
+
+    public void Draw(ICanvas canvas, RectF dirtyRect)
+        => LockSealDrawable.DrawStaticMark(canvas, dirtyRect, ShowBadge);
+}
+
 /// <summary>Qual momento o selo está confirmando.</summary>
 public enum LockSealMode
 {
@@ -100,6 +114,29 @@ public sealed class LockSealDrawable : IDrawable
         canvas.RestoreState();
     }
 
+    /// <summary>
+    /// A marca completa e parada, no mesmo enquadramento das animações. Usada pelo
+    /// <see cref="BrandMarkDrawable"/>.
+    /// </summary>
+    internal static void DrawStaticMark(ICanvas canvas, RectF dirtyRect, bool withBadge)
+    {
+        var size = Math.Min(dirtyRect.Width, dirtyRect.Height);
+        if (size <= 0)
+            return;
+
+        canvas.SaveState();
+        canvas.Translate(
+            dirtyRect.X + (dirtyRect.Width - size) / 2f,
+            dirtyRect.Y + (dirtyRect.Height - size) / 2f);
+        canvas.Scale(size / 128f, size / 128f);
+
+        if (withBadge)
+            DrawBadge(canvas, 1f, 1f, Pink, 0.34f);
+
+        DrawMarkFull(canvas);
+        canvas.RestoreState();
+    }
+
     // ---------------------------------------------------------------- criação
 
     private static void DrawCreateSeal(ICanvas canvas, float p)
@@ -131,7 +168,7 @@ public sealed class LockSealDrawable : IDrawable
             ScaleAbout(canvas, 64f, 64f, 0.86f + 0.14f * body);
 
             canvas.FillColor = OffWhite;
-            canvas.FillPath(BuildBody());
+            canvas.FillPath(BodyPath);
 
             var keyhole = EaseOutCubic(Segment(p, 0.46f, 0.70f));
             if (keyhole > 0f)
@@ -177,10 +214,10 @@ public sealed class LockSealDrawable : IDrawable
         ScaleAbout(canvas, 64f, 64f, 1f + 0.055f * MathF.Sin(MathF.PI * Segment(p, 0.58f, 0.86f)));
 
         SetShackleStroke(canvas, Pink);
-        canvas.DrawPath(BuildShackle(1f));
+        canvas.DrawPath(FullShacklePath);
 
         canvas.FillColor = OffWhite;
-        canvas.FillPath(BuildBody());
+        canvas.FillPath(BodyPath);
 
         DrawKeyhole(canvas, Navy);
 
@@ -303,6 +340,8 @@ public sealed class LockSealDrawable : IDrawable
             canvas.Alpha = appear * crack * 0.85f;
 
             // As fraturas não chegam ao centro: 16 linhas convergindo viravam um borrão.
+            // Todas num único PathF: um por linha eram 16 alocações por frame.
+            var cracks = new PathF();
             foreach (var s in Shards)
             {
                 var rad = s.StartDeg * MathF.PI / 180f;
@@ -310,11 +349,11 @@ public sealed class LockSealDrawable : IDrawable
                 var outer = Math.Min(s.OuterRadius, 58f);
                 var tip = inner + (outer - inner) * crack;
 
-                var line = new PathF();
-                line.MoveTo(BurstX + inner * MathF.Cos(rad), BurstY + inner * MathF.Sin(rad));
-                line.LineTo(BurstX + tip * MathF.Cos(rad), BurstY + tip * MathF.Sin(rad));
-                canvas.DrawPath(line);
+                cracks.MoveTo(BurstX + inner * MathF.Cos(rad), BurstY + inner * MathF.Sin(rad));
+                cracks.LineTo(BurstX + tip * MathF.Cos(rad), BurstY + tip * MathF.Sin(rad));
             }
+
+            canvas.DrawPath(cracks);
 
             // A fratura circular que separa o miolo da borda.
             canvas.Alpha = appear * crack * 0.5f;
@@ -332,8 +371,14 @@ public sealed class LockSealDrawable : IDrawable
     /// </summary>
     private static void DrawShards(ICanvas canvas, float burstT, float burst, float appear)
     {
-        foreach (var s in Shards)
+        for (var i = 0; i < Shards.Length; i++)
         {
+            var s = Shards[i];
+
+            var alpha = appear * (1f - EaseInCubic(Segment(burstT, 0f, s.Life)));
+            if (alpha <= 0.004f)
+                continue; // caco já apagado: nada a desenhar
+
             var rad = (s.MidDeg + s.Deviation) * MathF.PI / 180f;
             var midRad = s.MidDeg * MathF.PI / 180f;
 
@@ -346,7 +391,7 @@ public sealed class LockSealDrawable : IDrawable
             var cy = BurstY + pivot * MathF.Sin(midRad);
 
             canvas.SaveState();
-            canvas.Alpha = appear * (1f - EaseInCubic(Segment(burstT, 0f, s.Life)));
+            canvas.Alpha = alpha;
             canvas.Translate(dx, dy);
             canvas.Rotate(s.Spin * burst, cx, cy);
 
@@ -355,7 +400,7 @@ public sealed class LockSealDrawable : IDrawable
             canvas.Scale(shrink, shrink);
             canvas.Translate(-cx, -cy);
 
-            canvas.ClipPath(BuildSector(s), WindingMode.NonZero);
+            canvas.ClipPath(SectorPaths[i], WindingMode.NonZero);
             DrawMarkFull(canvas);
             canvas.RestoreState();
         }
@@ -371,6 +416,15 @@ public sealed class LockSealDrawable : IDrawable
 
     private static readonly Shard[] Shards = BuildShards();
     private static readonly DebrisBit[] DebrisTable = BuildDebris();
+
+    // Geometria que não muda de frame para frame, construída uma vez. Reconstruir estes
+    // caminhos a cada frame custava ~238 KB por frame só na exclusão (16 cacos, cada um
+    // redesenhando a marca inteira) - lixo suficiente para o coletor pausar no meio da
+    // animação e ela parecer travada.
+    private static readonly PathF FullShacklePath = BuildShackle(1f);
+    private static readonly PathF BodyPath = BuildBody();
+    private static readonly PathF KeyholeTailPath = BuildKeyholeTail();
+    private static readonly PathF[] SectorPaths = BuildSectorPaths();
 
     /// <summary>
     /// Sorteio determinístico (não Random): a animação roda igual toda vez, o que a torna
@@ -463,10 +517,10 @@ public sealed class LockSealDrawable : IDrawable
     private static void DrawMarkFull(ICanvas canvas)
     {
         SetShackleStroke(canvas, Pink);
-        canvas.DrawPath(BuildShackle(1f));
+        canvas.DrawPath(FullShacklePath);
 
         canvas.FillColor = OffWhite;
-        canvas.FillPath(BuildBody());
+        canvas.FillPath(BodyPath);
 
         DrawKeyhole(canvas, Navy);
     }
@@ -479,11 +533,23 @@ public sealed class LockSealDrawable : IDrawable
         canvas.StrokeColor = color;
         canvas.StrokeSize = 6.5f;
         canvas.StrokeLineCap = LineCap.Round;
+        canvas.DrawPath(KeyholeTailPath);
+    }
 
+    private static PathF BuildKeyholeTail()
+    {
         var tail = new PathF();
         tail.MoveTo(64f, 86f);
         tail.CurveTo(57.5f, 89.5f, 57.5f, 96f, 64f, 99.5f);
-        canvas.DrawPath(tail);
+        return tail;
+    }
+
+    private static PathF[] BuildSectorPaths()
+    {
+        var paths = new PathF[Shards.Length];
+        for (var i = 0; i < paths.Length; i++)
+            paths[i] = BuildSector(Shards[i]);
+        return paths;
     }
 
     private static void SetShackleStroke(ICanvas canvas, Color color)

--- a/src/GDSB.MAUI/Views/LockSealDrawable.cs
+++ b/src/GDSB.MAUI/Views/LockSealDrawable.cs
@@ -12,8 +12,15 @@ public sealed class BrandMarkDrawable : IDrawable
     /// <summary>Desenha o disco navy atrás da marca. Desligue sobre superfície já escura.</summary>
     public bool ShowBadge { get; set; } = true;
 
+    /// <summary>
+    /// Desenha a haste erguida, como um cadeado aberto. É a mesma marca - só o estado muda -
+    /// e serve para a tela de criar cofre: um cofre novo ainda não foi selado. A tela de
+    /// desbloqueio usa a marca fechada, então as duas se opõem sem virar símbolos diferentes.
+    /// </summary>
+    public bool Open { get; set; }
+
     public void Draw(ICanvas canvas, RectF dirtyRect)
-        => LockSealDrawable.DrawStaticMark(canvas, dirtyRect, ShowBadge);
+        => LockSealDrawable.DrawStaticMark(canvas, dirtyRect, ShowBadge, Open);
 }
 
 /// <summary>Qual momento o selo está confirmando.</summary>
@@ -118,7 +125,7 @@ public sealed class LockSealDrawable : IDrawable
     /// A marca completa e parada, no mesmo enquadramento das animações. Usada pelo
     /// <see cref="BrandMarkDrawable"/>.
     /// </summary>
-    internal static void DrawStaticMark(ICanvas canvas, RectF dirtyRect, bool withBadge)
+    internal static void DrawStaticMark(ICanvas canvas, RectF dirtyRect, bool withBadge, bool open = false)
     {
         var size = Math.Min(dirtyRect.Width, dirtyRect.Height);
         if (size <= 0)
@@ -133,9 +140,35 @@ public sealed class LockSealDrawable : IDrawable
         if (withBadge)
             DrawBadge(canvas, 1f, 1f, Pink, 0.34f);
 
-        DrawMarkFull(canvas);
+        if (open)
+        {
+            // Mesma haste, erguida e girada no ponto onde o rabo do G encosta no corpo -
+            // é o mesmo movimento com que ela destrava na animação de exclusão, parado no
+            // início. Só o corpo e a fechadura ficam no lugar.
+            canvas.SaveState();
+            canvas.Translate(0f, -OpenShackleLift);
+            canvas.Rotate(OpenShackleAngle, 84f, 48f);
+            SetShackleStroke(canvas, Pink);
+            canvas.DrawPath(FullShacklePath);
+            canvas.RestoreState();
+
+            canvas.FillColor = OffWhite;
+            canvas.FillPath(BodyPath);
+            DrawKeyhole(canvas, Navy);
+        }
+        else
+        {
+            DrawMarkFull(canvas);
+        }
+
         canvas.RestoreState();
     }
+
+    // Quanto a haste sobe e gira na marca aberta. Valores escolhidos renderizando a marca
+    // com o limite do quadro à vista: acima de 18 de elevação o topo do G começa a ser
+    // cortado, e abaixo disso a diferença para a marca fechada não se lê a 72px.
+    private const float OpenShackleLift = 18f;
+    private const float OpenShackleAngle = -32f;
 
     // ---------------------------------------------------------------- criação
 

--- a/src/GDSB.MAUI/Views/LockSealDrawable.cs
+++ b/src/GDSB.MAUI/Views/LockSealDrawable.cs
@@ -2,8 +2,21 @@ using Microsoft.Maui.Graphics;
 
 namespace GDSB.MAUI.Views;
 
+/// <summary>Qual momento o selo está confirmando.</summary>
+public enum LockSealMode
+{
+    /// <summary>Item novo: a marca se monta e a haste trava.</summary>
+    Create,
+
+    /// <summary>Item existente alterado: o anel fecha a volta e a marca pulsa.</summary>
+    Update,
+
+    /// <summary>Item removido: a marca racha e estilhaça.</summary>
+    Delete,
+}
+
 /// <summary>
-/// Desenha a marca GDSB como um cadeado que fecha, para confirmar a criação de um segredo.
+/// Desenha a marca GDSB animada, para confirmar criação, edição e exclusão de um segredo.
 ///
 /// A geometria é a mesma dos SVGs da marca (Resources/AppIcon/appiconfg.svg), num espaço
 /// lógico de 128x128 que é escalado para o tamanho real do GraphicsView:
@@ -17,16 +30,22 @@ namespace GDSB.MAUI.Views;
 /// (64,42) - por isso o arco é percorrido no sentido negativo por ~290°, deixando a abertura
 /// à direita, onde entra o rabo do G.
 ///
+/// Arcos são traçados por amostragem em vez das APIs de arco do canvas: com traço grosso e
+/// pontas redondas a poligonal não se nota, e evita depender da convenção de ângulo/sentido
+/// de cada rasterizador.
+///
 /// A fechadura é pintada com a cor do disco de fundo em vez de recortada por winding rule:
 /// o resultado é idêntico sobre o disco opaco e não depende de EvenOdd no rasterizador de
 /// cada plataforma.
 /// </summary>
 public sealed class LockSealDrawable : IDrawable
 {
-    // Marca
     private static readonly Color Pink = Color.FromArgb("#D936D3");
+    private static readonly Color PinkLight = Color.FromArgb("#F27BEB");
     private static readonly Color OffWhite = Color.FromArgb("#FCFCFC");
     private static readonly Color Navy = Color.FromArgb("#00186E");
+    private static readonly Color Danger = Color.FromArgb("#FF5A6A");
+    private static readonly Color Muted = Color.FromArgb("#6E77A8");
 
     private const float ArcCenterX = 64f;
     private const float ArcCenterY = 42f;
@@ -37,11 +56,19 @@ public sealed class LockSealDrawable : IDrawable
     private const float ArcStartDeg = -36.87f;
     private const float ArcSweepDeg = -290.04f;
 
-    // Altura de onde a haste cai até assentar no corpo.
+    // Altura de onde a haste cai até assentar no corpo, na criação.
     private const float ShackleTravel = 15f;
 
-    /// <summary>0 = nada desenhado, 1 = cadeado fechado e assentado.</summary>
+    // Origem da explosão e raio que separa o miolo da borda, na exclusão.
+    private const float BurstX = 64f;
+    private const float BurstY = 60f;
+    private const float BurstMidRadius = 36f;
+
+    /// <summary>0 = início da animação, 1 = fim.</summary>
     public float Progress { get; set; }
+
+    /// <summary>Qual das três animações desenhar.</summary>
+    public LockSealMode Mode { get; set; } = LockSealMode.Create;
 
     public void Draw(ICanvas canvas, RectF dirtyRect)
     {
@@ -57,112 +84,414 @@ public sealed class LockSealDrawable : IDrawable
             dirtyRect.Y + (dirtyRect.Height - size) / 2f);
         canvas.Scale(size / 128f, size / 128f);
 
-        DrawBadge(canvas, p);
-        DrawShackle(canvas, p);
-        DrawBody(canvas, p);
-        DrawRingPulse(canvas, p);
+        switch (Mode)
+        {
+            case LockSealMode.Update:
+                DrawUpdateSeal(canvas, p);
+                break;
+            case LockSealMode.Delete:
+                DrawDeleteSeal(canvas, p);
+                break;
+            default:
+                DrawCreateSeal(canvas, p);
+                break;
+        }
 
         canvas.RestoreState();
     }
 
-    /// <summary>Disco navy que segura a marca, igual ao contêiner do ícone.</summary>
-    private static void DrawBadge(ICanvas canvas, float p)
+    // ---------------------------------------------------------------- criação
+
+    private static void DrawCreateSeal(ICanvas canvas, float p)
     {
-        var t = EaseOutCubic(Segment(p, 0f, 0.22f));
-        if (t <= 0f)
+        var badge = EaseOutCubic(Segment(p, 0f, 0.22f));
+        if (badge > 0f)
+            DrawBadge(canvas, badge, 0.72f + 0.28f * badge, Pink, 0.34f);
+
+        // A haste desce e "sela": o arco é traçado progressivamente enquanto cai, com um
+        // pequeno repique no fim (o estalo do cadeado).
+        var draw = Segment(p, 0.16f, 0.50f);
+        if (draw > 0f)
+        {
+            var seat = EaseOutBack(Segment(p, 0.16f, 0.62f));
+
+            canvas.SaveState();
+            canvas.Translate(0f, -ShackleTravel * (1f - seat));
+            SetShackleStroke(canvas, Pink);
+            canvas.DrawPath(BuildShackle(EaseOutCubic(draw)));
+            canvas.RestoreState();
+        }
+
+        var body = EaseOutCubic(Segment(p, 0.10f, 0.36f));
+        if (body > 0f)
+        {
+            canvas.SaveState();
+            canvas.Alpha = body;
+            // Nasce um pouco achatado e cresce até o tamanho certo, como se assentasse.
+            ScaleAbout(canvas, 64f, 64f, 0.86f + 0.14f * body);
+
+            canvas.FillColor = OffWhite;
+            canvas.FillPath(BuildBody());
+
+            var keyhole = EaseOutCubic(Segment(p, 0.46f, 0.70f));
+            if (keyhole > 0f)
+            {
+                canvas.Alpha = body * keyhole;
+                DrawKeyhole(canvas, Navy);
+            }
+
+            canvas.RestoreState();
+        }
+
+        // Anel magenta que expande e some, marcando o instante em que trancou.
+        var ring = Segment(p, 0.52f, 0.95f);
+        if (ring > 0f && ring < 1f)
+        {
+            var eased = EaseOutCubic(ring);
+            canvas.SaveState();
+            canvas.Alpha = 0.5f * (1f - eased);
+            canvas.StrokeColor = Pink;
+            canvas.StrokeSize = 2.2f;
+            canvas.DrawCircle(64f, 64f, 48f + 22f * eased);
+            canvas.RestoreState();
+        }
+    }
+
+    // ----------------------------------------------------------------- edição
+
+    /// <summary>
+    /// O cadeado nunca se abre: o segredo já existia e continua trancado - o que mudou foi o
+    /// conteúdo. Um anel percorre 360° e, ao fechar, a marca pulsa e a fechadura acende.
+    /// </summary>
+    private static void DrawUpdateSeal(ICanvas canvas, float p)
+    {
+        var appear = EaseOutCubic(Segment(p, 0f, 0.14f));
+        if (appear <= 0f)
             return;
 
-        var scale = 0.72f + 0.28f * t;
+        DrawBadge(canvas, appear, 0.94f + 0.06f * appear, Pink, 0.34f);
 
         canvas.SaveState();
-        canvas.Alpha = t;
+        canvas.Alpha = appear;
+        // Pulso curto no instante em que o anel fecha.
+        ScaleAbout(canvas, 64f, 64f, 1f + 0.055f * MathF.Sin(MathF.PI * Segment(p, 0.58f, 0.86f)));
+
+        SetShackleStroke(canvas, Pink);
+        canvas.DrawPath(BuildShackle(1f));
+
+        canvas.FillColor = OffWhite;
+        canvas.FillPath(BuildBody());
+
+        DrawKeyhole(canvas, Navy);
+
+        var flash = MathF.Sin(MathF.PI * Segment(p, 0.55f, 0.90f));
+        if (flash > 0f)
+        {
+            canvas.Alpha = appear * flash * 0.85f;
+            DrawKeyhole(canvas, PinkLight);
+        }
+
+        canvas.RestoreState();
+
+        var sweep = EaseOutCubic(Segment(p, 0.10f, 0.62f));
+        if (sweep > 0f)
+        {
+            canvas.SaveState();
+            // Depois de fechar a volta, o anel desaparece.
+            canvas.Alpha = appear * (sweep >= 1f ? 1f - EaseOutCubic(Segment(p, 0.72f, 1f)) : 1f);
+            canvas.StrokeColor = PinkLight;
+            canvas.StrokeSize = 3f;
+            canvas.StrokeLineCap = LineCap.Round;
+            canvas.DrawPath(BuildArc(64f, 64f, 54f, -90f, 360f * sweep));
+            canvas.RestoreState();
+        }
+
+        var ripple = Segment(p, 0.62f, 1f);
+        if (ripple > 0f && ripple < 1f)
+        {
+            var eased = EaseOutCubic(ripple);
+            canvas.SaveState();
+            canvas.Alpha = 0.42f * (1f - eased);
+            canvas.StrokeColor = PinkLight;
+            canvas.StrokeSize = 2f;
+            canvas.DrawCircle(64f, 64f, 54f + 16f * eased);
+            canvas.RestoreState();
+        }
+    }
+
+    // -------------------------------------------------------------- exclusão
+
+    /// <summary>
+    /// A marca treme, racha e se parte em cacos de tamanhos diferentes, cada um com rumo,
+    /// giro e gravidade próprios. Termina com a tela vazia.
+    /// </summary>
+    private static void DrawDeleteSeal(ICanvas canvas, float p)
+    {
+        var appear = EaseOutCubic(Segment(p, 0f, 0.10f));
+        var burstT = Segment(p, 0.20f, 0.94f);
+        var burst = EaseOutCubic(burstT);
+
+        // O disco sai cedo: com o miolo estilhaçado, um navy sólido no fundo vira um buraco.
+        var badge = appear * (1f - EaseOutCubic(Segment(p, 0.18f, 0.44f)));
+        if (badge > 0.002f)
+            DrawBadge(canvas, badge, 1f + 0.07f * EaseOutCubic(Segment(p, 0.15f, 0.32f)), Danger, 0.45f);
+
+        if (burstT <= 0f)
+        {
+            DrawTensionPhase(canvas, p, appear);
+        }
+        else if (burstT < 1f)
+        {
+            DrawShards(canvas, burstT, burst, appear);
+        }
+
+        // Sem clarão: um círculo sólido com alpha baixo sobre fundo escuro vira mancha, não
+        // brilho - precisaria de composição aditiva. A onda de choque e os cacos já bastam.
+
+        var shock = Segment(p, 0.21f, 0.60f);
+        if (shock > 0f && shock < 1f)
+        {
+            var eased = EaseOutCubic(shock);
+            canvas.SaveState();
+            canvas.Alpha = 0.6f * (1f - eased);
+            canvas.StrokeColor = Danger;
+            canvas.StrokeSize = 3.4f * (1f - eased) + 0.8f;
+            // Nasce já fora da marca, para não cortar o desenho.
+            canvas.DrawCircle(BurstX, BurstY, 34f + 68f * eased);
+            canvas.RestoreState();
+        }
+
+        var debris = Segment(p, 0.20f, 1f);
+        if (debris > 0f && debris < 1f)
+        {
+            var eased = EaseOutCubic(debris);
+            canvas.SaveState();
+            canvas.FillColor = Muted;
+            canvas.Alpha = 0.8f * (1f - eased);
+
+            foreach (var d in DebrisTable)
+            {
+                var rad = d.AngleDeg * MathF.PI / 180f;
+                var dist = eased * 104f * d.Speed;
+                canvas.FillCircle(
+                    BurstX + dist * MathF.Cos(rad),
+                    BurstY + dist * MathF.Sin(rad) + 56f * d.Gravity * eased * eased,
+                    Math.Max(0.3f, d.Radius * (1f - 0.7f * eased)));
+            }
+
+            canvas.RestoreState();
+        }
+    }
+
+    /// <summary>Antes de partir: a marca treme e as fraturas abrem.</summary>
+    private static void DrawTensionPhase(ICanvas canvas, float p, float appear)
+    {
+        var shake = EaseOutCubic(Segment(p, 0.02f, 0.20f));
+
+        canvas.SaveState();
+        canvas.Alpha = appear;
+        canvas.Translate(MathF.Sin(p * 95f) * 2.4f * shake, MathF.Sin(p * 74f) * 1.5f * shake);
+
+        DrawMarkFull(canvas);
+
+        var crack = Segment(p, 0.11f, 0.20f);
+        if (crack > 0f)
+        {
+            canvas.StrokeColor = Navy;
+            canvas.StrokeSize = 1.5f;
+            canvas.StrokeLineCap = LineCap.Round;
+            canvas.Alpha = appear * crack * 0.85f;
+
+            // As fraturas não chegam ao centro: 16 linhas convergindo viravam um borrão.
+            foreach (var s in Shards)
+            {
+                var rad = s.StartDeg * MathF.PI / 180f;
+                var inner = Math.Max(s.InnerRadius, 9f);
+                var outer = Math.Min(s.OuterRadius, 58f);
+                var tip = inner + (outer - inner) * crack;
+
+                var line = new PathF();
+                line.MoveTo(BurstX + inner * MathF.Cos(rad), BurstY + inner * MathF.Sin(rad));
+                line.LineTo(BurstX + tip * MathF.Cos(rad), BurstY + tip * MathF.Sin(rad));
+                canvas.DrawPath(line);
+            }
+
+            // A fratura circular que separa o miolo da borda.
+            canvas.Alpha = appear * crack * 0.5f;
+            canvas.StrokeSize = 1.2f;
+            canvas.DrawCircle(BurstX, BurstY, BurstMidRadius);
+        }
+
+        canvas.RestoreState();
+    }
+
+    /// <summary>
+    /// Cada caco é a marca de verdade recortada num setor: aplica-se a transformação do caco,
+    /// recorta-se pelo setor e desenha-se a marca inteira. Como recorte e desenho recebem a
+    /// mesma transformação, o visível é exatamente aquele pedaço deslocado.
+    /// </summary>
+    private static void DrawShards(ICanvas canvas, float burstT, float burst, float appear)
+    {
+        foreach (var s in Shards)
+        {
+            var rad = (s.MidDeg + s.Deviation) * MathF.PI / 180f;
+            var midRad = s.MidDeg * MathF.PI / 180f;
+
+            var dx = burst * 80f * s.Speed * MathF.Cos(rad) + s.Drift * burst;
+            var dy = burst * 80f * s.Speed * MathF.Sin(rad) + 62f * s.Gravity * burst * burst;
+
+            // Gira em torno do próprio centro aproximado, não da origem da explosão.
+            var pivot = (s.InnerRadius + Math.Min(s.OuterRadius, 60f)) / 2f;
+            var cx = BurstX + pivot * MathF.Cos(midRad);
+            var cy = BurstY + pivot * MathF.Sin(midRad);
+
+            canvas.SaveState();
+            canvas.Alpha = appear * (1f - EaseInCubic(Segment(burstT, 0f, s.Life)));
+            canvas.Translate(dx, dy);
+            canvas.Rotate(s.Spin * burst, cx, cy);
+
+            var shrink = 1f - s.Shrink * burst;
+            canvas.Translate(cx, cy);
+            canvas.Scale(shrink, shrink);
+            canvas.Translate(-cx, -cy);
+
+            canvas.ClipPath(BuildSector(s), WindingMode.NonZero);
+            DrawMarkFull(canvas);
+            canvas.RestoreState();
+        }
+    }
+
+    // ------------------------------------------------------------ tabela dos cacos
+
+    private readonly record struct Shard(
+        float InnerRadius, float OuterRadius, float StartDeg, float EndDeg, float MidDeg,
+        float Deviation, float Speed, float Gravity, float Spin, float Drift, float Life, float Shrink);
+
+    private readonly record struct DebrisBit(float AngleDeg, float Speed, float Gravity, float Radius);
+
+    private static readonly Shard[] Shards = BuildShards();
+    private static readonly DebrisBit[] DebrisTable = BuildDebris();
+
+    /// <summary>
+    /// Sorteio determinístico (não Random): a animação roda igual toda vez, o que a torna
+    /// testável. Em double de propósito - em float a precisão do produto grande muda a parte
+    /// fracionária e os valores deixariam de bater com o protótipo.
+    /// </summary>
+    private static float Hash(int i, int salt)
+    {
+        var x = Math.Sin(i * 127.1 + salt * 311.7) * 43758.5453;
+        return (float)(x - Math.Floor(x));
+    }
+
+    /// <summary>
+    /// Duas faixas radiais: o miolo quebra em 5 pedaços grandes e a borda em 11 lascas finas,
+    /// então os cacos têm tamanhos claramente diferentes. Os passos somam 360° em cada faixa.
+    /// </summary>
+    private static Shard[] BuildShards()
+    {
+        (float Inner, float Outer, int[] Steps)[] bands =
+        [
+            (0f, BurstMidRadius, [70, 62, 78, 66, 84]),
+            (BurstMidRadius, 250f, [34, 28, 41, 25, 37, 30, 44, 26, 33, 29, 33]),
+        ];
+
+        var shards = new List<Shard>();
+        var id = 0;
+
+        foreach (var band in bands)
+        {
+            var angle = -180f;
+            foreach (var step in band.Steps)
+            {
+                var start = angle;
+                var end = angle + step;
+                angle = end;
+
+                shards.Add(new Shard(
+                    band.Inner, band.Outer, start, end, (start + end) / 2f,
+                    Deviation: (Hash(id, 1) - 0.5f) * 74f,
+                    Speed: 0.42f + Hash(id, 2) * 1.22f,
+                    Gravity: 0.45f + Hash(id, 3) * 1.45f,
+                    Spin: (Hash(id, 4) - 0.5f) * 300f,
+                    Drift: (Hash(id, 5) - 0.5f) * 42f,
+                    Life: 0.70f + Hash(id, 6) * 0.30f,
+                    Shrink: 0.18f + Hash(id, 7) * 0.30f));
+
+                id++;
+            }
+        }
+
+        return [.. shards];
+    }
+
+    private static DebrisBit[] BuildDebris()
+    {
+        var bits = new DebrisBit[22];
+        for (var i = 0; i < bits.Length; i++)
+        {
+            bits[i] = new DebrisBit(
+                Hash(i, 11) * 360f - 180f,
+                0.4f + Hash(i, 12) * 1.3f,
+                0.5f + Hash(i, 13) * 1.5f,
+                1.3f + Hash(i, 14) * 2.2f);
+        }
+
+        return bits;
+    }
+
+    // ------------------------------------------------------------------ formas
+
+    /// <summary>Disco navy que segura a marca, igual ao contêiner do ícone.</summary>
+    private static void DrawBadge(ICanvas canvas, float alpha, float scale, Color ring, float ringAlpha)
+    {
+        canvas.SaveState();
+        canvas.Alpha = alpha;
         ScaleAbout(canvas, 64f, 64f, scale);
 
         canvas.FillColor = Navy;
         canvas.FillCircle(64f, 64f, 60f);
 
-        canvas.StrokeColor = Pink.WithAlpha(0.34f);
+        canvas.Alpha = alpha * ringAlpha;
+        canvas.StrokeColor = ring;
         canvas.StrokeSize = 1.6f;
         canvas.DrawCircle(64f, 64f, 60f);
 
         canvas.RestoreState();
     }
 
-    /// <summary>
-    /// A haste desce e "sela": o arco é traçado progressivamente enquanto cai, com um
-    /// pequeno repique no fim (o estalo do cadeado).
-    /// </summary>
-    private static void DrawShackle(ICanvas canvas, float p)
+    /// <summary>A marca completa e assentada - a base dos cacos e do selo de edição.</summary>
+    private static void DrawMarkFull(ICanvas canvas)
     {
-        var draw = Segment(p, 0.16f, 0.50f);
-        if (draw <= 0f)
-            return;
-
-        var seat = EaseOutBack(Segment(p, 0.16f, 0.62f));
-        var offsetY = -ShackleTravel * (1f - seat);
-
-        canvas.SaveState();
-        canvas.Translate(0f, offsetY);
-
-        canvas.StrokeColor = Pink;
-        canvas.StrokeSize = ArcStroke;
-        canvas.StrokeLineCap = LineCap.Round;
-        canvas.StrokeLineJoin = LineJoin.Round;
-        canvas.DrawPath(BuildShackle(EaseOutCubic(draw)));
-
-        canvas.RestoreState();
-    }
-
-    /// <summary>Corpo branco com a fechadura, que aparece quando a haste está quase assentada.</summary>
-    private static void DrawBody(ICanvas canvas, float p)
-    {
-        var t = EaseOutCubic(Segment(p, 0.10f, 0.36f));
-        if (t <= 0f)
-            return;
-
-        canvas.SaveState();
-        canvas.Alpha = t;
-        // Nasce um pouco achatado e cresce até o tamanho certo, como se assentasse.
-        ScaleAbout(canvas, 64f, 64f, 0.86f + 0.14f * t);
+        SetShackleStroke(canvas, Pink);
+        canvas.DrawPath(BuildShackle(1f));
 
         canvas.FillColor = OffWhite;
         canvas.FillPath(BuildBody());
 
-        var keyhole = EaseOutCubic(Segment(p, 0.46f, 0.70f));
-        if (keyhole > 0f)
-        {
-            canvas.Alpha = t * keyhole;
-            canvas.FillColor = Navy;
-            canvas.FillCircle(64f, 79f, 8f);
-
-            canvas.StrokeColor = Navy;
-            canvas.StrokeSize = 6.5f;
-            canvas.StrokeLineCap = LineCap.Round;
-
-            var tail = new PathF();
-            tail.MoveTo(64f, 86f);
-            tail.CurveTo(57.5f, 89.5f, 57.5f, 96f, 64f, 99.5f);
-            canvas.DrawPath(tail);
-        }
-
-        canvas.RestoreState();
+        DrawKeyhole(canvas, Navy);
     }
 
-    /// <summary>Anel magenta que expande e some, marcando o instante em que trancou.</summary>
-    private static void DrawRingPulse(ICanvas canvas, float p)
+    private static void DrawKeyhole(ICanvas canvas, Color color)
     {
-        var t = Segment(p, 0.52f, 0.95f);
-        if (t <= 0f || t >= 1f)
-            return;
+        canvas.FillColor = color;
+        canvas.FillCircle(64f, 79f, 8f);
 
-        var eased = EaseOutCubic(t);
+        canvas.StrokeColor = color;
+        canvas.StrokeSize = 6.5f;
+        canvas.StrokeLineCap = LineCap.Round;
 
-        canvas.SaveState();
-        canvas.Alpha = 0.5f * (1f - eased);
-        canvas.StrokeColor = Pink;
-        canvas.StrokeSize = 2.2f;
-        canvas.DrawCircle(64f, 64f, 48f + 22f * eased);
-        canvas.RestoreState();
+        var tail = new PathF();
+        tail.MoveTo(64f, 86f);
+        tail.CurveTo(57.5f, 89.5f, 57.5f, 96f, 64f, 99.5f);
+        canvas.DrawPath(tail);
+    }
+
+    private static void SetShackleStroke(ICanvas canvas, Color color)
+    {
+        canvas.StrokeColor = color;
+        canvas.StrokeSize = ArcStroke;
+        canvas.StrokeLineCap = LineCap.Round;
+        canvas.StrokeLineJoin = LineJoin.Round;
     }
 
     /// <summary>Arco da haste, traçado de 0 a <paramref name="fraction"/> da varredura total.</summary>
@@ -214,6 +543,76 @@ public sealed class LockSealDrawable : IDrawable
         return path;
     }
 
+    /// <summary>Arco aberto, para o anel que varre a volta na edição.</summary>
+    private static PathF BuildArc(float cx, float cy, float radius, float startDeg, float sweepDeg)
+    {
+        var path = new PathF();
+        var steps = Math.Max(2, (int)MathF.Ceiling(MathF.Abs(sweepDeg) / 4f));
+
+        for (var i = 0; i <= steps; i++)
+        {
+            var rad = (startDeg + sweepDeg * i / steps) * MathF.PI / 180f;
+            var x = cx + radius * MathF.Cos(rad);
+            var y = cy + radius * MathF.Sin(rad);
+
+            if (i == 0)
+                path.MoveTo(x, y);
+            else
+                path.LineTo(x, y);
+        }
+
+        return path;
+    }
+
+    /// <summary>Setor anelar que recorta um caco. Com raio interno 0 vira uma fatia comum.</summary>
+    private static PathF BuildSector(Shard s)
+    {
+        var path = new PathF();
+        var span = s.EndDeg - s.StartDeg;
+        var steps = Math.Max(2, (int)MathF.Ceiling(MathF.Abs(span) / 4f));
+
+        var startRad = s.StartDeg * MathF.PI / 180f;
+        var hasHole = s.InnerRadius >= 0.01f;
+
+        if (hasHole)
+        {
+            path.MoveTo(
+                BurstX + s.InnerRadius * MathF.Cos(startRad),
+                BurstY + s.InnerRadius * MathF.Sin(startRad));
+            path.LineTo(
+                BurstX + s.OuterRadius * MathF.Cos(startRad),
+                BurstY + s.OuterRadius * MathF.Sin(startRad));
+        }
+        else
+        {
+            path.MoveTo(BurstX, BurstY);
+        }
+
+        for (var i = 0; i <= steps; i++)
+        {
+            var rad = (s.StartDeg + span * i / steps) * MathF.PI / 180f;
+            path.LineTo(
+                BurstX + s.OuterRadius * MathF.Cos(rad),
+                BurstY + s.OuterRadius * MathF.Sin(rad));
+        }
+
+        if (hasHole)
+        {
+            for (var i = steps; i >= 0; i--)
+            {
+                var rad = (s.StartDeg + span * i / steps) * MathF.PI / 180f;
+                path.LineTo(
+                    BurstX + s.InnerRadius * MathF.Cos(rad),
+                    BurstY + s.InnerRadius * MathF.Sin(rad));
+            }
+        }
+
+        path.Close();
+        return path;
+    }
+
+    // ----------------------------------------------------------------- auxiliares
+
     private static void ScaleAbout(ICanvas canvas, float cx, float cy, float scale)
     {
         canvas.Translate(cx, cy);
@@ -230,6 +629,8 @@ public sealed class LockSealDrawable : IDrawable
         var u = 1f - t;
         return 1f - u * u * u;
     }
+
+    private static float EaseInCubic(float t) => t * t * t;
 
     /// <summary>Passa um pouco do ponto final e volta - é o repique da haste ao trancar.</summary>
     private static float EaseOutBack(float t)

--- a/src/GDSB.MAUI/Views/LockSealDrawable.cs
+++ b/src/GDSB.MAUI/Views/LockSealDrawable.cs
@@ -1,0 +1,242 @@
+using Microsoft.Maui.Graphics;
+
+namespace GDSB.MAUI.Views;
+
+/// <summary>
+/// Desenha a marca GDSB como um cadeado que fecha, para confirmar a criação de um segredo.
+///
+/// A geometria é a mesma dos SVGs da marca (Resources/AppIcon/appiconfg.svg), num espaço
+/// lógico de 128x128 que é escalado para o tamanho real do GraphicsView:
+///
+///   haste (arco do G) : círculo de centro (64,42) e raio 24, traço 11, pontas arredondadas
+///   corpo (D deitado) : meio-disco de centro (64,64) e raio 42
+///   fechadura         : círculo (64,79) raio 8 + rabo
+///
+/// O centro/raio da haste foram derivados do arco SVG "M83.2,27.6 A24,24 0 1 0 84.1,55.1":
+/// a corda vai de (83.2,27.6) a (84.1,55.1), e com large-arc=1/sweep=0 o centro cai em
+/// (64,42) - por isso o arco é percorrido no sentido negativo por ~290°, deixando a abertura
+/// à direita, onde entra o rabo do G.
+///
+/// A fechadura é pintada com a cor do disco de fundo em vez de recortada por winding rule:
+/// o resultado é idêntico sobre o disco opaco e não depende de EvenOdd no rasterizador de
+/// cada plataforma.
+/// </summary>
+public sealed class LockSealDrawable : IDrawable
+{
+    // Marca
+    private static readonly Color Pink = Color.FromArgb("#D936D3");
+    private static readonly Color OffWhite = Color.FromArgb("#FCFCFC");
+    private static readonly Color Navy = Color.FromArgb("#00186E");
+
+    private const float ArcCenterX = 64f;
+    private const float ArcCenterY = 42f;
+    private const float ArcRadius = 24f;
+    private const float ArcStroke = 11f;
+
+    // Início e varredura do arco, em graus (sentido negativo = a abertura fica à direita).
+    private const float ArcStartDeg = -36.87f;
+    private const float ArcSweepDeg = -290.04f;
+
+    // Altura de onde a haste cai até assentar no corpo.
+    private const float ShackleTravel = 15f;
+
+    /// <summary>0 = nada desenhado, 1 = cadeado fechado e assentado.</summary>
+    public float Progress { get; set; }
+
+    public void Draw(ICanvas canvas, RectF dirtyRect)
+    {
+        var size = Math.Min(dirtyRect.Width, dirtyRect.Height);
+        if (size <= 0)
+            return;
+
+        var p = Math.Clamp(Progress, 0f, 1f);
+
+        canvas.SaveState();
+        canvas.Translate(
+            dirtyRect.X + (dirtyRect.Width - size) / 2f,
+            dirtyRect.Y + (dirtyRect.Height - size) / 2f);
+        canvas.Scale(size / 128f, size / 128f);
+
+        DrawBadge(canvas, p);
+        DrawShackle(canvas, p);
+        DrawBody(canvas, p);
+        DrawRingPulse(canvas, p);
+
+        canvas.RestoreState();
+    }
+
+    /// <summary>Disco navy que segura a marca, igual ao contêiner do ícone.</summary>
+    private static void DrawBadge(ICanvas canvas, float p)
+    {
+        var t = EaseOutCubic(Segment(p, 0f, 0.22f));
+        if (t <= 0f)
+            return;
+
+        var scale = 0.72f + 0.28f * t;
+
+        canvas.SaveState();
+        canvas.Alpha = t;
+        ScaleAbout(canvas, 64f, 64f, scale);
+
+        canvas.FillColor = Navy;
+        canvas.FillCircle(64f, 64f, 60f);
+
+        canvas.StrokeColor = Pink.WithAlpha(0.34f);
+        canvas.StrokeSize = 1.6f;
+        canvas.DrawCircle(64f, 64f, 60f);
+
+        canvas.RestoreState();
+    }
+
+    /// <summary>
+    /// A haste desce e "sela": o arco é traçado progressivamente enquanto cai, com um
+    /// pequeno repique no fim (o estalo do cadeado).
+    /// </summary>
+    private static void DrawShackle(ICanvas canvas, float p)
+    {
+        var draw = Segment(p, 0.16f, 0.50f);
+        if (draw <= 0f)
+            return;
+
+        var seat = EaseOutBack(Segment(p, 0.16f, 0.62f));
+        var offsetY = -ShackleTravel * (1f - seat);
+
+        canvas.SaveState();
+        canvas.Translate(0f, offsetY);
+
+        canvas.StrokeColor = Pink;
+        canvas.StrokeSize = ArcStroke;
+        canvas.StrokeLineCap = LineCap.Round;
+        canvas.StrokeLineJoin = LineJoin.Round;
+        canvas.DrawPath(BuildShackle(EaseOutCubic(draw)));
+
+        canvas.RestoreState();
+    }
+
+    /// <summary>Corpo branco com a fechadura, que aparece quando a haste está quase assentada.</summary>
+    private static void DrawBody(ICanvas canvas, float p)
+    {
+        var t = EaseOutCubic(Segment(p, 0.10f, 0.36f));
+        if (t <= 0f)
+            return;
+
+        canvas.SaveState();
+        canvas.Alpha = t;
+        // Nasce um pouco achatado e cresce até o tamanho certo, como se assentasse.
+        ScaleAbout(canvas, 64f, 64f, 0.86f + 0.14f * t);
+
+        canvas.FillColor = OffWhite;
+        canvas.FillPath(BuildBody());
+
+        var keyhole = EaseOutCubic(Segment(p, 0.46f, 0.70f));
+        if (keyhole > 0f)
+        {
+            canvas.Alpha = t * keyhole;
+            canvas.FillColor = Navy;
+            canvas.FillCircle(64f, 79f, 8f);
+
+            canvas.StrokeColor = Navy;
+            canvas.StrokeSize = 6.5f;
+            canvas.StrokeLineCap = LineCap.Round;
+
+            var tail = new PathF();
+            tail.MoveTo(64f, 86f);
+            tail.CurveTo(57.5f, 89.5f, 57.5f, 96f, 64f, 99.5f);
+            canvas.DrawPath(tail);
+        }
+
+        canvas.RestoreState();
+    }
+
+    /// <summary>Anel magenta que expande e some, marcando o instante em que trancou.</summary>
+    private static void DrawRingPulse(ICanvas canvas, float p)
+    {
+        var t = Segment(p, 0.52f, 0.95f);
+        if (t <= 0f || t >= 1f)
+            return;
+
+        var eased = EaseOutCubic(t);
+
+        canvas.SaveState();
+        canvas.Alpha = 0.5f * (1f - eased);
+        canvas.StrokeColor = Pink;
+        canvas.StrokeSize = 2.2f;
+        canvas.DrawCircle(64f, 64f, 48f + 22f * eased);
+        canvas.RestoreState();
+    }
+
+    /// <summary>Arco da haste, traçado de 0 a <paramref name="fraction"/> da varredura total.</summary>
+    private static PathF BuildShackle(float fraction)
+    {
+        var path = new PathF();
+
+        // 2° por segmento é suficiente: com traço 11 e pontas redondas a poligonal não se nota.
+        var steps = Math.Max(2, (int)MathF.Ceiling(MathF.Abs(ArcSweepDeg) * fraction / 2f));
+
+        for (var i = 0; i <= steps; i++)
+        {
+            var deg = ArcStartDeg + ArcSweepDeg * fraction * i / steps;
+            var rad = deg * MathF.PI / 180f;
+            var x = ArcCenterX + ArcRadius * MathF.Cos(rad);
+            var y = ArcCenterY + ArcRadius * MathF.Sin(rad);
+
+            if (i == 0)
+                path.MoveTo(x, y);
+            else
+                path.LineTo(x, y);
+        }
+
+        // O rabo do G só entra quando o arco já fechou por inteiro.
+        if (fraction >= 0.999f)
+        {
+            path.LineTo(84.1f, 45f);
+            path.LineTo(71f, 45f);
+        }
+
+        return path;
+    }
+
+    /// <summary>Meio-disco inferior: "M22,64 h84 a42,42 0 0 1 -84,0 z".</summary>
+    private static PathF BuildBody()
+    {
+        var path = new PathF();
+        path.MoveTo(22f, 64f);
+        path.LineTo(106f, 64f);
+
+        const int steps = 48;
+        for (var i = 1; i <= steps; i++)
+        {
+            var rad = MathF.PI * i / steps; // 0 -> pi, passando por baixo (y cresce para baixo)
+            path.LineTo(64f + 42f * MathF.Cos(rad), 64f + 42f * MathF.Sin(rad));
+        }
+
+        path.Close();
+        return path;
+    }
+
+    private static void ScaleAbout(ICanvas canvas, float cx, float cy, float scale)
+    {
+        canvas.Translate(cx, cy);
+        canvas.Scale(scale, scale);
+        canvas.Translate(-cx, -cy);
+    }
+
+    /// <summary>Recorta [from,to] do progresso global e devolve 0..1 dentro dessa janela.</summary>
+    private static float Segment(float p, float from, float to)
+        => Math.Clamp((p - from) / (to - from), 0f, 1f);
+
+    private static float EaseOutCubic(float t)
+    {
+        var u = 1f - t;
+        return 1f - u * u * u;
+    }
+
+    /// <summary>Passa um pouco do ponto final e volta - é o repique da haste ao trancar.</summary>
+    private static float EaseOutBack(float t)
+    {
+        const float c1 = 1.1f;
+        const float c3 = c1 + 1f;
+        var u = t - 1f;
+        return 1f + c3 * u * u * u + c1 * u * u;
+    }
+}


### PR DESCRIPTION
## Summary
Apply the complete brand identity from the design prototype, implementing the lock design (fechadura) with the full color system.

## Changes

**Icons and Branding:**
- Update app icon (appicon.svg) with navy background (#00186E)
- Update foreground mark (appiconfg.svg) with the lock design:
  - Magenta arc (#D936D3) 
  - White D-shaped body (#FCFCFC)
  - Keyhole cutout (circle + shaft)
- Update splash screen with the same mark design at larger scale
- Update CSPROJ to use navy background color (#00186E) for icon and splash

**Color Palette (Colors.xaml):**
- Add new brand colors:
  - BrandNavy (#00186E) - primary brand color
  - BrandViolet (#400880) - gradient base
  - BrandPink (#D936D3) - primary accent
  - BrandWhite (#FCFCFC) - primary text
  - BrandPinkContrast (#C21FBC) - button fill with AA contrast
  - BrandPinkText (#F27BEB) - pink text with AA contrast
- Update dark theme surfaces:
  - SurfaceDark (#060B24) - main background
  - SurfaceCardDark (#0E1540) - card background
  - BorderDark (#232B63) - borders and dividers
- Update text colors:
  - TextPrimaryDark (#FCFCFC)
  - TextSecondaryDark (#A9B0D6)
  - TextMutedDark (#6E77A8)
- Update functional colors:
  - FavoriteGold (#FFC53D)
  - Danger (#FF5A6A)
- Add solid color brushes for all brand colors
- Add BrandGradientBrush (violet to magenta)

**Android Platform (colors.xml):**
- Update colorPrimary to #D936D3 (magenta)
- Update colorPrimaryDark to #400880 (violet)
- Update colorAccent to #C21FBC (magenta with contrast)

## Test Plan
- [x] Build project with .NET SDK 10.0 (restores dependencies without errors)
- [x] Verify XAML syntax is valid (Colors.xaml loads correctly)
- [x] Verify SVG icon files are valid
- [x] Confirm CSPROJ configuration changes don't break build
- Manual testing on Android/iOS/Windows once deployed

---
_Generated by [Claude Code](https://claude.ai/code/session_012UAfh63WR5oULYPmy3phAS)_