### PR TITLE
Corrige ordem senha/arquivo no Unlock e nome do backup do cofre

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ offset  tamanho  campo
 
 Arquivos `.GDSBX` antigos (v1) continuam abrindo normalmente: o formato é detectado automaticamente
 e, ao salvar pela primeira vez, o arquivo é migrado para v2 de forma transparente, com o original
-preservado em um backup `.v1.bak` ao lado.
+preservado em um backup `bkp_<nome-do-cofre>.GDSBX.v1.bak` ao lado (o prefixo `bkp_`, e não um
+sufixo no fim do nome, é o que deixa o backup reconhecível mesmo com o nome do cofre truncado numa
+listagem de arquivos de tela pequena). O mesmo prefixo vale para o `.bak` "rolante" gravado a cada
+save seguinte.
 
 ## Funcionalidades
 

--- a/claude-context.md
+++ b/claude-context.md
@@ -76,7 +76,12 @@ Ao final de cada fase (PR aberto ou mergeado):
 
 ## Estado atual
 
-**Fases 0 a 6 concluídas.** A Fase 1 foi mergeada na `main` (PR #4). As Fases 2 e 3 foram mergeadas via PR [#5](https://github.com/betinn/GDSB.MAUI/pull/5). A Fase 4 foi mergeada via PR [#6](https://github.com/betinn/GDSB.MAUI/pull/6). A Fase 5 foi mergeada via PR [#7](https://github.com/betinn/GDSB.MAUI/pull/7). A Fase 6 está nesta branch, PR [#10](https://github.com/betinn/GDSB.MAUI/pull/10).
+**Fases 0 a 6 concluídas e mergeadas na `main`** (Fase 1: PR #4; Fases 2 e 3: PR [#5](https://github.com/betinn/GDSB.MAUI/pull/5); Fase 4: PR [#6](https://github.com/betinn/GDSB.MAUI/pull/6); Fase 5: PR [#7](https://github.com/betinn/GDSB.MAUI/pull/7); Fase 6: PR [#10](https://github.com/betinn/GDSB.MAUI/pull/10)).
+
+### Melhorias de UX pós-Fase-6 (fora do roadmap de fases)
+
+- **Ordem invertida no Unlock (sem biometria)**: `UnlockViewModel.UnlockAsync` pedia a senha mestra antes de abrir o seletor de arquivo, o que o usuário achou confuso — normalmente é o arquivo que identifica qual cofre está sendo aberto, não a senha. Invertido: agora escolhe o arquivo primeiro e só valida/usa a senha depois (o campo de senha continua sempre visível na tela, só a ordem das duas verificações no código mudou). Fluxo de biometria não muda (já não depende dessa ordem — usa a location lembrada direto).
+- **Prefixo `bkp_` nos arquivos de backup**: `LocalFileSystem.GetBackupLocation`/`AndroidSafFileSystem.GetBackupLocation` (caminho local, fora do content://) geravam o backup só com um sufixo no fim (`<cofre>.GDSBX.bak`/`.v1.bak`) — numa listagem de arquivos com pouco espaço horizontal (celular), um nome de cofre médio/grande já trunca antes de mostrar o sufixo, e o backup fica indistinguível do arquivo real. Mudou pra prefixo no início do nome do arquivo (`bkp_<cofre>.GDSBX.bak`), sempre visível independente de truncamento. Aplicado também ao nome baseado em hash usado no armazenamento privado do Android para location `content://` (esse não é visível ao usuário, mas mantém consistência). `ProfileFileServiceTests` ajustado (helper `BackupPathFor`) pro novo formato.
 
 ### Fase 6 — polimento geral
 

--- a/src/GDSB.Infrastructure/LocalFileSystem.cs
+++ b/src/GDSB.Infrastructure/LocalFileSystem.cs
@@ -12,6 +12,15 @@ namespace GDSB.Infrastructure
 
         public void WriteAllBytes(string location, byte[] data) => File.WriteAllBytes(location, data);
 
-        public string GetBackupLocation(string location, string suffix) => location + suffix;
+        // O prefixo "bkp_" (em vez de só um sufixo no fim) é de propósito: numa listagem de
+        // arquivos com pouco espaço horizontal (celular), um nome de cofre médio/grande já
+        // trunca o final antes de mostrar ".bak"/.".v1.bak", e o backup fica indistinguível do
+        // arquivo real. No início do nome, a marca aparece sempre, truncamento ou não.
+        public string GetBackupLocation(string location, string suffix)
+        {
+            var directory = Path.GetDirectoryName(location);
+            var backupFileName = "bkp_" + Path.GetFileName(location) + suffix;
+            return string.IsNullOrEmpty(directory) ? backupFileName : Path.Combine(directory, backupFileName);
+        }
     }
 }

--- a/src/GDSB.MAUI.ViewModels/ViewModels/UnlockViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/UnlockViewModel.cs
@@ -132,12 +132,8 @@ namespace GDSB.MAUI.ViewModels
         {
             ErrorMessage = null;
 
-            if (string.IsNullOrEmpty(Password))
-            {
-                ErrorMessage = EmptyPasswordMessage;
-                return;
-            }
-
+            // Escolher o arquivo primeiro (e só depois cobrar a senha) é mais natural do que o
+            // inverso: o usuário identifica o cofre pelo arquivo, não decorando a ordem dos campos.
             string? location;
             try
             {
@@ -151,6 +147,12 @@ namespace GDSB.MAUI.ViewModels
 
             if (string.IsNullOrEmpty(location))
                 return;
+
+            if (string.IsNullOrEmpty(Password))
+            {
+                ErrorMessage = EmptyPasswordMessage;
+                return;
+            }
 
             await OpenAndNavigateAsync(location, Password, offerBiometricOptIn: true);
         }

--- a/src/GDSB.MAUI/Platforms/Android/Services/AndroidSafFileSystem.cs
+++ b/src/GDSB.MAUI/Platforms/Android/Services/AndroidSafFileSystem.cs
@@ -61,16 +61,24 @@ namespace GDSB.MAUI.Platforms.Android.Services
             stream.Write(data, 0, data.Length);
         }
 
+        // O prefixo "bkp_" (em vez de só um sufixo no fim) é de propósito: numa listagem de
+        // arquivos com pouco espaço horizontal (celular), um nome de cofre médio/grande já trunca
+        // o final antes de mostrar ".bak"/".v1.bak", e o backup fica indistinguível do arquivo
+        // real. No início do nome, a marca aparece sempre, truncamento ou não.
         public string GetBackupLocation(string location, string suffix)
         {
             if (!IsContentUri(location))
-                return location + suffix;
+            {
+                var directory = Path.GetDirectoryName(location);
+                var backupFileName = "bkp_" + Path.GetFileName(location) + suffix;
+                return string.IsNullOrEmpty(directory) ? backupFileName : Path.Combine(directory, backupFileName);
+            }
 
             var backupDir = Path.Combine(FileSystem.AppDataDirectory, "vault-backups");
             Directory.CreateDirectory(backupDir);
 
             var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(location)));
-            return Path.Combine(backupDir, hash + suffix);
+            return Path.Combine(backupDir, "bkp_" + hash + suffix);
         }
 
         private static bool IsContentUri(string location) =>

--- a/tests/GDSB.Infrastructure.Tests/ProfileFileServiceTests.cs
+++ b/tests/GDSB.Infrastructure.Tests/ProfileFileServiceTests.cs
@@ -13,6 +13,14 @@ namespace GDSB.Infrastructure.Tests
 
         private readonly ProfileFileService _sut = new(new LegacyV1FileDecryptionService(), new AesGcmFileCryptoService(), new LocalFileSystem());
 
+        // Espelha LocalFileSystem.GetBackupLocation: prefixo "bkp_" no nome do arquivo, não sufixo
+        // no fim do path inteiro - ver o porquê no comentário daquele método.
+        private static string BackupPathFor(string path, string suffix)
+        {
+            var directory = Path.GetDirectoryName(path)!;
+            return Path.Combine(directory, "bkp_" + Path.GetFileName(path) + suffix);
+        }
+
         private static Profile CreateSampleProfile() => new()
         {
             Nome = "Cofre de teste",
@@ -67,7 +75,7 @@ namespace GDSB.Infrastructure.Tests
         public void Save_OverwritingV1File_MigratesToV2AndCreatesBackup()
         {
             var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.GDSBX");
-            var backupPath = path + ".v1.bak";
+            var backupPath = BackupPathFor(path, ".v1.bak");
             try
             {
                 var profile = CreateSampleProfile();
@@ -94,7 +102,7 @@ namespace GDSB.Infrastructure.Tests
         public void Save_CalledTwiceAfterMigration_DoesNotOverwriteBackupAgain()
         {
             var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.GDSBX");
-            var backupPath = path + ".v1.bak";
+            var backupPath = BackupPathFor(path, ".v1.bak");
             try
             {
                 var profile = CreateSampleProfile();
@@ -121,7 +129,7 @@ namespace GDSB.Infrastructure.Tests
         public void Save_OverwritingV2File_CreatesRollingBakOfPreviousVersion()
         {
             var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.GDSBX");
-            var backupPath = path + ".bak";
+            var backupPath = BackupPathFor(path, ".bak");
             try
             {
                 var profile = CreateSampleProfile();
@@ -154,8 +162,8 @@ namespace GDSB.Infrastructure.Tests
             // FileSavePicker.PickSaveFileAsync cria o arquivo de destino vazio (0 bytes); no Android,
             // ActionCreateDocument via SAF faz o mesmo. Um arquivo vazio não é um cofre v1 a migrar.
             var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.GDSBX");
-            var v1BackupPath = path + ".v1.bak";
-            var bakPath = path + ".bak";
+            var v1BackupPath = BackupPathFor(path, ".v1.bak");
+            var bakPath = BackupPathFor(path, ".bak");
             try
             {
                 File.WriteAllBytes(path, Array.Empty<byte>());


### PR DESCRIPTION
## Resumo

Duas correções de UX pedidas pelo usuário para o fluxo de desbloqueio e para o backup de cofres, fora do roadmap de fases (veja `claude-context.md`, seção "Melhorias de UX pós-Fase-6").

- **Ordem invertida no Unlock (sem biometria)**: `UnlockViewModel.UnlockAsync` pedia a senha mestra antes de abrir o seletor de arquivo — ordem confusa, já que é o arquivo escolhido que identifica qual cofre está sendo aberto, não a senha. Agora o app abre o seletor de arquivo primeiro e só depois valida/usa a senha (o campo de senha continua sempre visível na tela; só a ordem das duas verificações no código mudou). O fluxo de biometria não muda, pois já não depende dessa ordem.
- **Prefixo `bkp_` nos arquivos de backup**: `LocalFileSystem.GetBackupLocation` e o caminho local de `AndroidSafFileSystem.GetBackupLocation` geravam o backup só com um sufixo no fim do nome (`<cofre>.GDSBX.bak` / `.v1.bak`). Numa listagem de arquivos com pouco espaço horizontal (celular), um nome de cofre médio/grande já trunca antes de mostrar o sufixo, deixando o backup indistinguível do arquivo real. Agora o backup leva o prefixo `bkp_` no início do nome do arquivo (`bkp_<cofre>.GDSBX.bak`), sempre visível independente de truncamento. O mesmo prefixo foi aplicado ao nome baseado em hash usado no armazenamento privado do Android para location `content://` (não é visível ao usuário, mas mantém consistência).

## Mudanças

- `src/GDSB.MAUI.ViewModels/ViewModels/UnlockViewModel.cs`: inverte a ordem seletor de arquivo → validação de senha em `UnlockAsync`.
- `src/GDSB.Infrastructure/LocalFileSystem.cs`: `GetBackupLocation` passa a prefixar `bkp_` no nome do arquivo em vez de só sufixar.
- `src/GDSB.MAUI/Platforms/Android/Services/AndroidSafFileSystem.cs`: mesmo prefixo `bkp_`, tanto no caminho local quanto no nome baseado em hash usado para location `content://`.
- `tests/GDSB.Infrastructure.Tests/ProfileFileServiceTests.cs`: ajustado para o novo formato de nome de backup (helper `BackupPathFor`).
- `README.md`: atualiza a menção ao nome do arquivo de backup.
- `claude-context.md`: registra as duas mudanças e corrige o status das fases (0–6 já mergeadas na `main`).

## Test plan

- [x] `dotnet test tests/GDSB.Infrastructure.Tests` — 12/12 passando.
- [x] `dotnet test tests/GDSB.MAUI.Tests` — 39/39 passando.
- [x] `dotnet build` limpo (0 erros, 0 warnings) em `GDSB.Infrastructure` e `GDSB.MAUI.ViewModels`.
- [ ] Build/teste manual do app Android — não executado nesta sessão (o script que preparava o toolchain Android foi removido do repositório na Fase 6); a mudança em `AndroidSafFileSystem.cs` segue exatamente o mesmo padrão já testado em `LocalFileSystem.cs`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015hjEv5JmZRdXfYFCWn8Ftx

---
_Generated by [Claude Code](https://claude.ai/code/session_015hjEv5JmZRdXfYFCWn8Ftx)_