### PR TITLE
docs(context): reset do claude-context.md para a nova rodada de fases

### DIFF
--- a/claude-context.md
+++ b/claude-context.md
@@ -1,176 +1,168 @@
 # Contexto do projeto — GDSB.MAUI
 
-> Este arquivo existe para que qualquer sessão de Claude Code (claude.ai/code) tenha, desde o primeiro prompt, todo o contexto combinado com o usuário — sem precisar reexplicar nada. Mantenha-o atualizado: veja "Como manter este arquivo" no final.
+> Este arquivo é o **ponto de entrada** de qualquer sessão de Claude Code neste repositório. Leia-o
+> inteiro antes do primeiro comando: ele diz o que é o projeto, como preparar a máquina, onde está o
+> plano em execução e em que fase ele parou.
 
 ## O que é o GDSB
 
-App de gerenciamento de senhas: guarda credenciais criptografadas em um arquivo local `.GDSBX`. Existe uma versão desktop mais completa (tem insert/update). A versão MAUI (celular/tablet) hoje só abre e decifra arquivos existentes — não tem insert, update, delete ou save implementados. O usuário usa bastante em um tablet grande (Samsung S10 Ultra), então comportamento responsivo é requisito real, não opcional.
+App de gerenciamento de senhas para Android e Windows: guarda credenciais criptografadas em um
+arquivo local `.GDSBX`. Existe uma versão desktop separada (fora do escopo deste repositório). O
+usuário usa bastante em um tablet grande (Samsung S10 Ultra) e no celular, então comportamento
+responsivo é requisito real, não opcional.
 
 Estrutura da solução:
-- `src/GDSB.Domain` — entidades (`Profile`, `SecretBox`) e interfaces.
-- `src/GDSB.Infrastructure` — implementação da criptografia (`Encryption/FileDecryptionService.cs` é o código atual, fraco — ver diagnóstico abaixo).
-- `src/GDSB.MAUI` — o app mobile em si (Views, Services de plataforma para file picker).
 
-## Diagnóstico da criptografia atual (não é aproveitável)
+- `src/GDSB.Domain` — entidades (`Profile`, `SecretBox`) e interfaces de serviço.
+- `src/GDSB.Infrastructure` — criptografia (v2 e leitor legado v1) e acesso a arquivo.
+- `src/GDSB.MAUI.ViewModels` — ViewModels e as abstrações de plataforma (clipboard, navegação,
+  preferências, launcher, alertas) que os tornam testáveis sem o runtime do MAUI. É um projeto
+  `net10.0` "puro": não pode referenciar `GDSB.MAUI` (dependência circular), por isso as rotas do
+  Shell aparecem como string literal e precisam bater com os nomes registrados em `AppShell.xaml.cs`.
+- `src/GDSB.MAUI` — o app em si: Views, Shell e as implementações de plataforma (Android/Windows).
+- `tests/GDSB.Infrastructure.Tests` e `tests/GDSB.MAUI.Tests` — xUnit, com fakes escritos à mão
+  (sem biblioteca de mock).
 
-Localização: `src/GDSB.Infrastructure/Encryption/FileDecryptionService.cs`.
+## Como rodar o projeto
 
-- **IV fixo hardcoded no código-fonte**, reaproveitado em toda criptografia já feita pelo app.
-- **Sem KDF real**: a "chave" é a senha em ASCII repetida ciclicamente até 32 bytes (`GetPasswordStringIntoByte`) — sem salt, sem iterações. Brute force offline é trivial, e senhas iguais em arquivos diferentes geram a mesma chave.
-- `Encoding.ASCII` corrompe silenciosamente acentos (comuns em senha PT-BR), colapsando senhas diferentes na mesma chave.
-- **Sem autenticação/integridade** (AES-CBC puro, sem HMAC/AEAD) — um arquivo adulterado não é detectado.
-- A "dupla camada" de AES existente (chave/IV interno guardados junto do texto cifrado) não agrega segurança real, porque ambos ficam protegidos só pela camada externa, que é a fraca.
+### 1. Instalar o .NET 10 SDK
 
-Conclusão já validada com o usuário: **não é para ajustar, é para reescrever** — mantendo um leitor legado só para importar arquivos antigos (ver Fase 2).
+```bash
+# Linux/macOS — instala em ~/.dotnet, sem precisar de root
+curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+chmod +x /tmp/dotnet-install.sh
+/tmp/dotnet-install.sh --channel 10.0
+export DOTNET_ROOT="$HOME/.dotnet"
+export PATH="$DOTNET_ROOT:$PATH"
+dotnet --version   # deve imprimir 10.x
+```
 
-## Decisões fechadas com o usuário
+```powershell
+# Windows
+winget install Microsoft.DotNet.SDK.10
+```
 
-1. **Desktop**: será refeito depois, como projeto separado. O MAUI não fica preso ao formato de arquivo fraco de hoje — só mantém um leitor "legacy" isolado para importar `.GDSBX` v1, migrando para o novo formato ao salvar.
-2. **Nível de segurança**: uso real no dia a dia (não é só estudo). Vale KDF forte, auto-lock, limpeza de clipboard e biometria.
-3. **Arquitetura**: MVVM completo com `CommunityToolkit.Mvvm`, substituindo a lógica hoje presa em code-behind.
-4. **Plataforma prioritária**: Android primeiro, para entregar o CRUD completo de ponta a ponta.
-5. **Visual**: tema escuro reaproveitando os tokens já existentes em `Resources/Styles/Colors.xaml` (`Primary #512BD4`, `PrimaryDark #ac99ea`, `Tertiary #2B0B98`, `MidnightBlue`, `Gray950`/`OffBlack`) + fonte Open Sans (já empacotada no app, em `Resources/Fonts`). Cores novas aprovadas: dourado `#F5B93E` (favorito) e vermelho `#E5484D` (ações destrutivas). Existe um protótipo interativo aprovado (link abaixo) — a implementação deve seguir esse visual, não reinventar.
-6. **Responsivo**: breakpoint por **largura de tela**, não por tipo de dispositivo (`DeviceIdiom`). Abaixo de ~700-800dp: lista + bottom-sheet (celular). Acima disso: mestre-detalhe com painel lateral (tablet) — o mesmo formulário de item é reaproveitado nos dois layouts, só muda o container ao redor dele.
-7. **Biometria**: item firme (não mais opcional) da Fase 5. A senha mestra continua sendo a única fonte da chave de criptografia — a biometria apenas destrava, via Android Keystore / iOS Keychain, uma cópia já derivada dessa chave. Senha mestra sempre disponível como fallback. Amarrado ao último cofre aberto (não precisa de seleção de perfil — uso real é um perfil único por dispositivo).
+### 2. Rodar os testes (não precisa de workload nenhum)
 
-## Documentos de referência
+```bash
+dotnet test tests/GDSB.Infrastructure.Tests/GDSB.Infrastructure.Tests.csproj
+dotnet test tests/GDSB.MAUI.Tests/GDSB.MAUI.Tests.csproj
+```
 
-Estes três links têm todo o detalhe que não está reproduzido aqui — leia-os antes de começar cada fase (`WebFetch` funciona nessas URLs, mesmo sendo `claude.ai/code/artifact/...`):
+### 3. Compilar o app (aí sim precisa do workload MAUI)
 
-- **Protótipo visual interativo** (celular + tablet, 5 telas, aprovado): https://claude.ai/code/artifact/a754f86c-2575-4697-9956-691ee5a884f9
-- **Roadmap macro** (visão das 7 fases com status): https://claude.ai/code/artifact/0e94da44-68c8-45b3-8cb5-0a6a7ea33026
-- **Plano de execução detalhado** (arquivos a criar/editar, decisões técnicas como o layout de bytes do formato v2, tarefas e critério de "pronto" — uma seção `#fase-N` por fase): https://claude.ai/code/artifact/4a2ac1b9-5602-4f30-a848-05083fc03e72
+```bash
+dotnet workload restore src/GDSB.MAUI/GDSB.MAUI.csproj -p:GdsbAndroidOnly=true
+dotnet build   src/GDSB.MAUI/GDSB.MAUI.csproj -p:GdsbAndroidOnly=true
+```
 
-## As fases
+No Linux, use sempre `-p:GdsbAndroidOnly=true` — sem isso o MSBuild tenta também os alvos de iOS e
+macCatalyst. No Windows/macOS, omitir a flag compila todos os alvos. O build Android também exige o
+Android SDK instalado.
 
-| # | Fase | Status |
-|---|------|--------|
-| 0 | Diagnóstico e decisões | ✅ Concluída |
-| 1 | Fundação de criptografia nova (Domain + Infrastructure, AES-256-GCM + PBKDF2/Argon2id, formato v2) | ✅ Concluída — PR [#4](https://github.com/betinn/GDSB.MAUI/pull/4) mergeado |
-| 2 | Leitor legado (v1) + migração automática ao salvar | ✅ Concluída — PR [#5](https://github.com/betinn/GDSB.MAUI/pull/5) |
-| 3 | Refactor MVVM + nova UI (Android primeiro) + breakpoint responsivo | ✅ Concluída — PR [#5](https://github.com/betinn/GDSB.MAUI/pull/5) |
-| 4 | CRUD completo (criar cofre, insert/update/delete, save) + acesso a arquivo com suporte real a sync (Android) | ✅ Concluída — PR [#6](https://github.com/betinn/GDSB.MAUI/pull/6) |
-| 5 | Segurança de uso real (auto-lock, clipboard, biometria) | ✅ Concluída — PR [#7](https://github.com/betinn/GDSB.MAUI/pull/7) |
-| 6 | Polimento geral (remover Newtonsoft, testes, README) | ✅ Concluída — PR [#10](https://github.com/betinn/GDSB.MAUI/pull/10) |
+## Formato de arquivo
 
-Fora de escopo: reescrita do app desktop para o formato v2 — projeto futuro separado.
+Arquivos novos são gravados em **AES-256-GCM**, com a chave derivada da senha mestra via
+PBKDF2-HMAC-SHA256 (salt e nonce aleatórios a cada gravação, autenticação integrada). O cabeçalho é
+auto-descritivo:
+
+```
+offset  tamanho  campo
+0       4 bytes  magic = "GDSB"
+4       1 byte   versão do formato = 0x02
+5       1 byte   KDF id (0x01 = PBKDF2-HMAC-SHA256; 0x02 reservado p/ Argon2id)
+6       4 bytes  iterações do KDF (uint32, little-endian)
+10      16 bytes salt
+26      12 bytes nonce do AES-GCM
+38      16 bytes tag de autenticação do AES-GCM
+54      restante ciphertext (JSON do Profile, cifrado)
+```
+
+Arquivos `.GDSBX` antigos (v1) continuam abrindo: o formato é detectado pelos 4 primeiros bytes
+(`ProfileFileService`) e, ao salvar pela primeira vez, o arquivo é migrado para v2 de forma
+transparente, com o original preservado num backup.
+
+**Regra permanente:** nenhuma mudança pode reintroduzir o comportamento antigo de criptografia (IV
+fixo, senha ASCII ciclada como chave, ausência de autenticação) — nem em código de produção, nem em
+teste, nem como fallback.
+
+---
+
+## Plano em execução
+
+O plano completo desta rodada — contexto, decisões fechadas, plano macro, plano micro por fase
+(arquivos a criar/alterar) e roteiro de verificação — vive neste documento:
+
+**➜ https://claude.ai/code/artifact/00e12b9d-b9d9-4c72-9a4e-e111477c329d**
+
+Ele é a fonte da verdade. `WebFetch` funciona nessa URL. Leia a fase que você vai executar lá antes
+de escrever qualquer código; aqui embaixo fica só o resumo de status, para você se localizar rápido.
+
+### Objetivo da rodada
+
+Três frentes vindas do uso real:
+
+1. **Ordem do desbloqueio.** Hoje o app pede a senha antes de abrir o seletor de arquivo. Inverter:
+   escolher o arquivo primeiro, e só então liberar o campo de senha. Não se aplica ao modo com
+   biometria ligada, onde o bloco manual já some inteiro.
+2. **Backups.** Hoje o Windows grava `<cofre>.GDSBX.bak` ao lado do original — numa pasta
+   sincronizada isso aparece no celular e, com nome longo, a tela pequena trunca justamente o final.
+   Equalizar pelo comportamento do Android (backup em diretório do app), renomear para
+   `BKP - <arquivo>.bak` e dar ao app uma tela de recuperação/limpeza de backups.
+3. **Edição de cofre.** Não existe como renomear o cofre nem trocar a senha mestra depois de criado,
+   e as proteções (limpeza de clipboard, auto-lock) são constantes fixas. Criar uma tela de edição e
+   tornar as proteções configuráveis **por perfil** (gravadas dentro do próprio arquivo do cofre).
+
+### Status das fases
+
+| # | Fase | Status | PR |
+|---|------|--------|-----|
+| 0 | Reset do contexto (este arquivo + artifact do plano) | 🔜 Próxima | — |
+| 1 | Desbloqueio: arquivo antes da senha | ⬜ Planejada | — |
+| 2 | Backups fora da pasta do cofre (`IVaultBackupStore`) | ⬜ Planejada | — |
+| 3 | Proteções configuráveis por cofre (`VaultSettings`) | ⬜ Planejada | — |
+| 4 | Tela de edição do cofre | ⬜ Planejada | — |
+| 5 | Recuperação de backup | ⬜ Planejada | — |
+| 6 | Fechamento (README, contexto, testes, build) | ⬜ Planejada | — |
+
+Dependências: **2 antes de 5** (a tela de recuperação lê o store criado na fase 2) e **3 antes de 4**
+(a tela de edição edita o `VaultSettings` criado na fase 3). A fase 1 é independente das demais.
+
+### Decisões já fechadas com o usuário
+
+Não relitigar durante a implementação — o detalhamento de cada uma está no artifact.
+
+- Backup se chama `BKP - <nome do arquivo>.bak` (prefixo resolve a truncagem; sufixo `.bak`/`.v1.bak`
+  impede confusão com um cofre).
+- Backup nunca mais ao lado do cofre, nem no Windows.
+- Selecionar um arquivo que é backup mostra um popup **apenas informativo**, sem bloquear.
+- Nova tela de recuperação na tela inicial: recriar um cofre a partir de um backup ou excluir backups.
+- Ao trocar a senha mestra, oferecer também a exclusão dos backups antigos (opção do usuário).
+- Renomear = nome interno (`Profile.Nome`) + botão "Salvar como" arquivo novo. O arquivo em disco
+  nunca é renomeado.
+- Trocar a senha com biometria ativa **re-sela** o atalho automaticamente com a senha nova.
+
+---
 
 ## Como trabalhar
 
-- Uma branch por fase, criada a partir da `main` (ex.: `fase-1-criptografia-nova`).
-- Um PR por fase. Use a tabela de arquivos e o "Pronto quando" da seção correspondente no plano de execução como checklist do PR.
-- Ao terminar a implementação da fase (código pronto e commitado), **abra o PR automaticamente, sem perguntar antes** — isso é parte padrão do fluxo, não uma ação que precisa de confirmação. O PR fica aberto para review do usuário; não é para fazer merge sozinho.
-- Não fique monitorando o PR por conta própria depois de aberto — isso gasta token à toa. Se precisar de ajuste, o usuário avisa.
-- Não pule fases: a 2 depende da 1, a 3 depende da 2 (o `IProfileFileService` unificado), a 4 depende da 3 (ViewModels prontos), a 5 e a 6 podem ser paralelas entre si depois da 4.
-- Nenhuma fase deve reintroduzir o comportamento antigo de criptografia (IV fixo, senha ciclada) nem em teste nem em fallback.
-- Ao abrir o PR da fase, sempre inclua um comentário (descrição do PR) explicando as atualizações feitas e o objetivo da implementação — não abrir PR "mudo", mesmo quando o título já é autoexplicativo.
+- **Uma branch por fase**, criada a partir da `main` (ex.: `fase-2-backup-store`).
+- **Um PR por fase.** Use a lista de arquivos e o "Pronto quando" da fase, no artifact, como
+  checklist do PR.
+- Ao terminar a implementação da fase (código pronto e commitado), **abra o PR automaticamente, sem
+  perguntar antes** — é parte padrão do fluxo. O PR fica aberto para review do usuário; não faça
+  merge sozinho.
+- O PR nunca é "mudo": a descrição sempre explica o que mudou e por quê.
+- **Não fique monitorando o PR** depois de aberto — gasta token à toa. Se precisar de ajuste, o
+  usuário avisa.
+- Não pule fases nem inverta as dependências listadas acima.
 
 ## Como manter este arquivo
 
-Ao final de cada fase (PR aberto ou mergeado):
+Ao final de cada fase (PR aberto):
 
-1. Atualize a tabela "As fases" acima (status e, se quiser, o link do PR).
-2. Atualize a seção "Estado atual" logo abaixo com o que mudou.
-3. Atualize o **roadmap macro** e o **plano de execução** publicados nos links acima — dá para revisar e republicar um artifact de outra sessão apontando a mesma URL (veja a doc de artifacts do Claude Code: "Update an artifact from a different session: give Claude its URL"). Troque o badge da fase concluída de "Planejada"/"Próxima" para "Concluída" e avance o badge "Próxima" para a fase seguinte, nos dois documentos.
-4. Faça commit deste arquivo (`claude-context.md`, raiz do repositório) junto com o PR da fase.
-
-## Estado atual
-
-**Fases 0 a 6 concluídas.** A Fase 1 foi mergeada na `main` (PR #4). As Fases 2 e 3 foram mergeadas via PR [#5](https://github.com/betinn/GDSB.MAUI/pull/5). A Fase 4 foi mergeada via PR [#6](https://github.com/betinn/GDSB.MAUI/pull/6). A Fase 5 foi mergeada via PR [#7](https://github.com/betinn/GDSB.MAUI/pull/7). A Fase 6 está nesta branch, PR [#10](https://github.com/betinn/GDSB.MAUI/pull/10).
-
-### Fase 6 — polimento geral
-
-- **Newtonsoft.Json removido**: `LegacyV1FileDecryptionService` passou a usar `System.Text.Json` (com `PropertyNameCaseInsensitive = true`) só para o `JsonConvert.DeserializeObject` que restava; a referência ao pacote saiu de `GDSB.Infrastructure.csproj`.
-- **`.claude/` removido do repositório**: `.claude/scripts/setup-android-build.sh` e `.claude/hooks/session-start.sh` eram scripts de conveniência só para preparar *este* ambiente de sessão (nunca usados pelos workflows do GitHub Actions, que usam `actions/setup-dotnet` + `dotnet workload restore` normalmente) e estavam gerando apontamentos de code smell no SonarQube por serem scripts shell sem tratamento de erro/lint de shell. Como não sobrava mais nada útil em `.claude/settings.json` (só o hook agora removido), o diretório inteiro saiu do repo. Preparar o ambiente Android neste tipo de sessão volta a ser manual (workload + SDK mínimo), documentado só no histórico do PR, não mais versionado.
-- **Cobertura de teste dos ViewModels**: para testar `UnlockViewModel`/`VaultViewModel`/`CreateVaultViewModel` sem o runtime do MAUI (critério "pronto quando" da fase), as chamadas estáticas a `Microsoft.Maui.Storage.Preferences` e `Microsoft.Maui.ApplicationModel.Launcher` viraram abstrações injetáveis (`IPreferencesService`, `IAppLauncherService`, implementadas em `GDSB.MAUI/Services/`) — mesmo padrão de `IClipboardService`/`IAlertService`/`INavigationService` já criado na Fase 3. Isso exigiu extrair os ViewModels (e as interfaces de serviço puras que eles usam) para um projeto novo, `src/GDSB.MAUI.ViewModels` (net10.0 "puro", sem `UseMaui`), porque o projeto `GDSB.MAUI` só tem TargetFrameworks de plataforma (`net10.0-android`/`ios`/`maccatalyst`/`windows`) e um projeto de teste não consegue referenciá-lo. `Microsoft.Maui.Controls` compila normalmente nesse TFM "puro" (só o pacote de referência, sem runtime de plataforma) — o que faltava não era o pacote, era só `Preferences`/`Launcher` chamando implementação real de plataforma em runtime. As rotas do Shell usadas dentro dos ViewModels (`nameof(VaultPage)` etc.) viraram string literal, já que este projeto novo não pode referenciar `GDSB.MAUI` (dependência circular) — precisam continuar batendo com os nomes registrados em `AppShell.xaml.cs`. `BiometricOptInCoordinator.RememberVault`/`ForgetVault` deixaram de ser `static` (dependiam de `Preferences.Default` direto) e passaram a ser chamados na instância (`BiometricOptIn.RememberVault(...)`), já injetada em `UnlockViewModel`/`CreateVaultViewModel`. Testes novos em `tests/GDSB.MAUI.Tests` (fakes escritos à mão, sem biblioteca de mock, no mesmo estilo dos testes de Infrastructure) cobrem os fluxos principais de Unlock (senha errada, migração legada, biometria automática no `InitializeAsync`, opt-in) e Vault (busca/filtro, CRUD de item, copiar, abrir URL, layout responsivo).
-- **README.md reescrito**: descreve o app, a estrutura da solução, o formato de arquivo v2 (com o layout de bytes) e a lista de funcionalidades atuais, no lugar do changelog antigo que só falava da versão 1.0 somente-leitura.
-- Build Android validado localmente de ponta a ponta (workload + SDK mínimo, mesmo procedimento que estava no script removido) com `-p:GdsbAndroidOnly=true`: 0 erros, warnings pré-existentes (NU1608 de versão de dependência transitiva do AndroidX, mais um `CS8600` de nulidade em `LegacyV1FileDecryptionService` corrigido nesta fase). `dotnet test` das duas suítes (Infrastructure + MAUI) passando.
-- **`.github/workflows/sonarcloud.yml` removido**: o job `sonarcloud` (scanner via CI, `dotnet sonarscanner begin/end`) falhava sempre com `ERROR: You are running CI analysis while Automatic Analysis is enabled` — não é um problema de dois jobs *nossos* rodando ao mesmo tempo (não dava pra "resolver" só sequenciando steps), é o projeto no SonarCloud estar configurado com o método "Automatic Analysis" (análise via GitHub App do próprio SonarCloud, dispara sozinha a cada push/PR, sem precisar de nenhum workflow) — os dois métodos de análise (automático vs. via CI) são mutuamente exclusivos por design do SonarCloud, e não dá pra desligar um deles por código/API sem acesso de admin ao dashboard do projeto. Como a Automatic Analysis já funciona e decora o PR sozinha (check `SonarCloud Code Analysis`, Quality Gate + issues), e a suíte de testes não estava configurada pra exportar cobertura em nenhum dos dois caminhos mesmo, remover o workflow de CI não perde nada — só sequenciar os jobs manteria o mesmo erro, porque o conflito é com uma análise que não é acionada pelo GitHub Actions do repositório.
-
-### Fase 5 — segurança de uso real
-
-- **Auto-lock por inatividade**: `Services/IIdleLockService`/`IdleLockService` escuta `OnSleep`/`OnResume` (gancho novo em `App.xaml.cs`, que passou a receber `IIdleLockService` no construtor). O relógio é medido só no intervalo entre sair e voltar do background (`OnSleep` marca o instante, `OnResume` compara com `DateTime.UtcNow`) — não existe timer rodando o tempo todo. Passado o limite (`IdleLockService.LockAfter`, 2 minutos), força `INavigationService.GoHomeAsync()`. Como `VaultPage`/`CreateVaultPage` são páginas `Transient` (`MauiProgram.RegisterPages`, decisão da Fase 3), voltar pro Unlock já derruba a instância anterior do ViewModel — e o `Profile`/senha que ela segurava — em vez de só escondê-la.
-- **Expiração do clipboard**: `ClipboardService.SetTextAsync` agora agenda uma limpeza ~20s depois de cada cópia (`Task.Run` + `Task.Delay`, cancelado se uma cópia nova acontecer antes). Só limpa se o clipboard ainda tiver exatamente o texto copiado — se o usuário copiou outra coisa nesse meio-tempo (dentro ou fora do app), a limpeza automática não mexe nela.
-- **Biometria (Android, prioridade da fase; Windows, extensão)**: `GDSB.Domain.Interfaces.IBiometricUnlockService` é a abstração (`IsAvailableAsync`, `IsEnabledAsync`, `StoreKeyAsync(byte[])`, `TryUnlockAsync()`, `DisableAsync`). O que fica selado nunca é a chave de criptografia do cofre (essa continua derivada por arquivo via PBKDF2+salt, Fase 1) nem a senha em texto puro fora do hardware protegido — é a senha mestra, cifrada com uma chave simétrica que só existe dentro do Android Keystore, gerada com `SetUserAuthenticationRequired(true)`: nem o próprio app consegue usá-la sem passar de novo pelo `BiometricPrompt` (`Platforms/Android/Services/BiometricUnlockService`, usa `Xamarin.AndroidX.Biometric`). No Windows (`Platforms/Windows/Services/BiometricUnlockService`), o mesmo papel é feito por `UserConsentVerifier` (Windows Hello) autorizando a leitura de um arquivo protegido por DPAPI (`ProtectedData`, escopo `CurrentUser`) — prioridade menor, não bloqueou a entrega no Android.
-  - **Amarrado ao último cofre aberto**: `UnlockViewModel` grava a location do cofre em `Preferences` (`gdsb.lastVaultLocation`) a cada `Open` bem-sucedido — sem isso não haveria como saber qual arquivo reabrir ao usar o atalho biométrico, já que não existe seleção de perfil (decisão de escopo: um cofre por aparelho). `Preferences` é usado direto ali, sem uma interface própria, pelo mesmo motivo de `Launcher` em `VaultViewModel.OpenUrlAsync`: é um detalhe de sessão, não algo que os fluxos hoje testados precisam mockar.
-  - **Opt-in explícito, uma vez só**: depois do primeiro `Open`/`CreateVault` bem-sucedido em que a biometria está disponível e ainda não habilitada, o app pergunta uma vez se o usuário quer ativar o atalho — aceitando ou recusando, a pergunta não volta a aparecer (`Preferences["gdsb.biometricPrompted"]`). A pergunta é um overlay próprio (`Views/BiometricOptInView.xaml`, dialog nas cores do app, não um `DisplayAlert` nativo — o alerta do sistema não dá pra tematizar) com o ViewModel em `ViewModels/BiometricOptInCoordinator.cs` (`IsVisible` + `AcceptCommand`/`DeclineCommand`, resolvidos via `TaskCompletionSource<bool>` que `MaybeOfferAsync` aguarda). O coordinator é compartilhado — `UnlockViewModel` e `CreateVaultViewModel` recebem sua própria instância via DI (`Transient`) e expõem `BiometricOptIn` pra suas páginas hospedarem a mesma `BiometricOptInView`, em vez de duplicar o diálogo e a lógica de opt-in nos dois lugares. Aceitando, os bytes UTF-8 da senha digitada são selados e zerados da memória logo em seguida (`CryptographicOperations.ZeroMemory`).
-  - **Chave invalidada não tem tratamento especial** (decisão do plano): se o Android invalidar a chave do Keystore (ex.: nova digital cadastrada), `TryUnlockAsync` pega a `KeyPermanentlyInvalidatedException`, limpa o segredo selado (que já ficou inútil) e devolve `null` — a UI (`UnlockViewModel.UnlockWithBiometricAsync`) só reavalia o estado e volta pro campo de senha, sem alerta ou fluxo de recuperação dedicado.
-  - **Dispara sozinha, sem precisar tocar em nada**: `UnlockViewModel.InitializeAsync` (chamado do `OnAppearing` da `UnlockPage`, no lugar do antigo `RefreshBiometricAvailabilityAsync` direto) atualiza o estado e, se `CanUseBiometric` for true, já chama `UnlockWithBiometricAsync` sozinho — o usuário não precisa tocar em "Desbloquear com biometria". O botão continua visível mesmo assim, pra quando o usuário cancelar o prompt do sistema sem querer (ou ele falhar por qualquer motivo) e precisar tentar novamente manualmente.
-  - **Mostra pra qual cofre a biometria está mirando**: como agora ela dispara sozinha, `UnlockPage.xaml` mostra o nome do cofre (`Profile.Nome`, gravado em `Preferences["gdsb.lastVaultName"]` a cada `Open` bem-sucedido) acima do botão — assim o usuário sabe, antes de o sensor abrir, qual cofre vai ser aberto. Só o nome, não a location: o path real (principalmente o `content://` do Android/SAF) é longo e ilegível pra quem usa o app, não ajuda em nada a identificar o cofre.
-  - **Bug corrigido: disparo automático não acontecia de verdade** — o auto-disparo (item acima) só funcionava clicando manualmente no botão; sozinho, na abertura do app ou voltando de background, o `BiometricPrompt` falhava silenciosamente ou nem chegava a aparecer. Duas causas, as duas em `Platforms/Android/Services/BiometricUnlockService.cs`/`UnlockPage.xaml.cs`:
-    - **Prompt chamado antes da janela ter foco**: `BiometricPrompt.Authenticate` exige a janela da Activity em foco; chamado logo que a `UnlockPage` aparece (antes do foco ser garantido), o Android rejeita ou ignora silenciosamente — só "funcionava" no toque manual porque a essa altura a janela já estava em foco havia tempo. `MainActivity` ganhou o evento estático `WindowFocusChanged` (de `OnWindowFocusChanged`); `AuthenticateAsync` agora espera esse evento (com teto de 5s, pra nunca travar) antes de chamar `Authenticate`, só quando a janela ainda não estiver em foco.
-    - **Nenhum gancho pra "voltar de background"**: `OnAppearing` só dispara em navegação de verdade (abrir o app, `GoHomeAsync` etc.) — sair do app e voltar sem passar pelo timeout do auto-lock nunca fazia a `UnlockPage` "aparecer" de novo, então a biometria nunca era reoferecida sozinha. `UnlockPage` agora também assina `Window.Resumed` (entre `OnAppearing`/`OnDisappearing`), rechamando `UnlockViewModel.InitializeAsync()` toda vez que o app volta ao primeiro plano enquanto a UnlockPage é a tela mostrada — cobre exatamente os três momentos pedidos: abrir o app, estar parado no Unlock, e voltar de background. `InitializeAsync` ganhou o guard `CanUnlock()` pra não disparar duas vezes se `OnAppearing` e o primeiro `Window.Resumed` caírem quase juntos na abertura do app.
-  - **Bug corrigido: mismatch cofre/senha ao trocar de cofre com biometria ativa** — antes, com a biometria habilitada pro cofre A, dava pra abrir manualmente o cofre B (campo de senha sempre visível ao lado do atalho) ou criar um cofre C do zero sem que isso desligasse o atalho; a biometria continuava selada com a senha de A, então a tentativa seguinte tentava abrir B/C com a senha de A e falhava. Duas correções, uma pra cada caminho:
-    - **Abrir outro cofre manualmente**: os dois fluxos viraram mutuamente exclusivos. Com `CanUseBiometric` true, `UnlockPage.xaml` esconde o campo de senha e o botão "Abrir cofre" por completo (`UnlockViewModel.ShowManualUnlock => !CanUseBiometric`) — só sobra "Desbloquear com biometria" (agora com o mesmo peso visual de ação principal, `PrimaryActionButtonStyle`) e "Trocar cofre" (`ChangeVaultCommand`, `SecondaryActionButtonStyle`), que chama `IBiometricUnlockService.DisableAsync` e `BiometricOptInCoordinator.ForgetVault()` (limpa location/nome/"já perguntei" em `Preferences`).
-    - **Criar um cofre novo**: `CreateVaultViewModel.CreateVaultAsync`, depois de salvar o cofre novo com sucesso, também chama `DisableAsync` + `ForgetVault()` e então `BiometricOptInCoordinator.RememberVault(location, profile.Nome)` + `BiometricOptIn.MaybeOfferAsync(enteredPassword)` — o cofre recém-criado nunca herda o atalho de outro, e já sai oferecendo o opt-in pra si mesmo se a biometria estiver disponível.
-    - Em ambos os casos, o próximo `Open`/`CreateVault` bem-sucedido (do mesmo cofre de novo ou de outro) volta a oferecer o opt-in do zero, sempre mirando o cofre certo.
-- **Bump de `SupportedOSPlatformVersion` do Android, 21 → 23**: o manifest da `androidx.lifecycle-runtime` puxada por `Xamarin.AndroidX.Biometric` já declara `minSdk 23` — biometria com `BiometricPrompt`/Keystore realmente não existe abaixo disso. `MainActivity`/`AndroidManifest.xml` não precisaram de mais nada além da permissão nova `android.permission.USE_BIOMETRIC`.
-
-Testes: `dotnet test tests/GDSB.Infrastructure.Tests` → **12/12 passando**, sem nenhuma mudança nessa suíte (Fase 5 não mexeu em `GDSB.Domain`/`GDSB.Infrastructure` além da interface nova `IBiometricUnlockService`, que não tem implementação testada por unit test — os serviços de biometria são 100% ligados a API de plataforma, Keystore/BiometricPrompt ou Windows Hello, sem como exercitar de verdade fora de um dispositivo real; cobertura automatizada de ViewModel fica pra Fase 6, como já previsto no plano).
-
-Build Android: limpo, **0 erros**. Novos warnings `NU1608` (versão de pacote fora do intervalo esperado) aparecem por causa das dependências transitivas do `Xamarin.AndroidX.Biometric` — são ruído normal de bindings AndroidX no Xamarin/.NET for Android, não indicam um problema real; os 6 warnings pré-existentes de sempre continuam, nenhum novo warning de C#/XAML. Gera APK assinado.
-
-**Falta antes de considerar Fase 5 100% validada na prática** (mesma limitação já registrada nas Fases 3 e 4): teste manual num dispositivo/emulador Android real com sensor de biometria — o `BiometricPrompt`/Android Keystore só pode ser exercitado de verdade lá, não neste ambiente de CI. Roteiro sugerido: abrir um cofre A com senha manual, confirmar que o overlay de opt-in aparece com as cores do app (não o alerta nativo do sistema) e aceitar; fechar (matar o processo) e reabrir o app do zero, confirmando que o sensor de biometria já aparece sozinho, sem precisar tocar em nada, mostrando antes só o nome do cofre A (sem path); com o app aberto na tela de Unlock, mandar pra background (botão home, trocar de app) e voltar, confirmando que o sensor dispara de novo sozinho mesmo sem ter passado o timeout do auto-lock; cancelar o prompt do sistema de propósito e confirmar que "Desbloquear com biometria" continua ali pra tentar de novo; tocar em "Trocar cofre", abrir um cofre B diferente e confirmar que o opt-in é oferecido de novo (agora mirando B) — voltar ao Unlock depois disso deve disparar a biometria pra B, nunca tentar A; com a biometria de A ativa, usar "Criar um cofre novo" pra criar um cofre C e confirmar que o opt-in aparece pra C assim que ele é criado (não mais pra A); deixar o app em background mais de 2 minutos e confirmar que volta pro Unlock (e que a biometria dispara sozinha de novo); copiar uma senha e confirmar que o clipboard esvazia sozinho depois de ~20s.
-
-### Fase 4 — o que mudou além do que estava no plano original
-
-Durante a implementação, descobrimos que o plano original (CRUD "de path string") não sobrevivia ao requisito real do usuário: o mesmo arquivo `.GDSBX` precisa continuar editável em Android **e** Windows quando vive numa pasta sincronizada (Google Drive, OneDrive) — perder o vínculo com o arquivo original ao salvar (ou pior, perder o cofre inteiro se o app for desinstalado) anula o propósito do app. Isso forçou uma mudança de arquitetura maior que o previsto, decidida com o usuário antes de implementar:
-
-- **O bug que isso corrigiu (já existia nas Fases 2/3, não só na 4):** no Android, `Microsoft.Maui.Storage.FilePicker` (usado até aqui pra abrir cofre) **copia o conteúdo escolhido para o cache do app** e devolve o caminho dessa cópia — não do arquivo original — porque `content://` (como o Android expõe arquivos de provedores como Drive/OneDrive) não pode ser aberto com `File.*` do .NET. Qualquer `Save` feito depois (inclusive a migração automática v1→v2 da Fase 2) ia só pra cópia em cache; o arquivo sincronizado de verdade nunca via a mudança.
-- **A correção:** `GDSB.Domain.Interfaces.IVaultFileSystem` é a nova abstração que `ProfileFileService` (Infrastructure) usa pra ler/gravar bytes — ele não sabe mais se "location" é um path real ou outra coisa. `GDSB.Infrastructure.LocalFileSystem` (usa `File.*` direto) é o default e o que os testes usam; `Platforms/Android/Services/AndroidSafFileSystem` trata uma location que comece com `content://` via `ContentResolver` (`OpenInputStream`/`OpenOutputStream("wt")`), senão cai pro comportamento de `File.*`.
-- **Android trocou de picker:** `Platforms/Android/Services/FilePickerService` não usa mais `Microsoft.Maui.Storage.FilePicker` — dispara `Intent.ActionOpenDocument`/`ActionCreateDocument` (Storage Access Framework) direto, pede permissão persistente (`ContentResolver.TakePersistableUriPermission`) e devolve o `content://` URI como string opaca. `MainActivity` ganhou uma ponte de `OnActivityResult` (`RegisterDocumentPickCallback`) pra entregar o resultado do intent de volta pro serviço. Isso faz o picker aparecer com Google Drive/OneDrive como destino (eles implementam `DocumentsProvider`), então o usuário pode literalmente escolher "salvar no Drive".
-- **Trade-off aceito e documentado:** SAF não dá acesso à pasta-mãe de um documento avulso (só de uma *árvore* escolhida via `ACTION_OPEN_DOCUMENT_TREE`, que traria bem mais complexidade). Por isso, no Android, o backup `.bak`/`.v1.bak` de uma location `content://` **não fica ao lado do arquivo original** — fica no armazenamento privado do app (`FileSystem.AppDataDirectory/vault-backups`, nome derivado de um hash do URI). No Windows, o backup continua ao lado do arquivo real (pasta sincronizada inclusa), sem mudança.
-- **Windows não precisou de nada disso:** `StorageFile.Path` do `FileSavePicker`/`FileOpenPicker` já é um caminho de arquivo real, mesmo dentro de uma pasta do OneDrive — o problema é específico do modelo de storage do Android.
-- Isso também tocou o leitor legado: `IFileDecryptionService.GetProfileDecrypted` passou a receber o **conteúdo já lido** (`string fileContent`) em vez de um `filePath` e fazer `File.ReadAllText` sozinho — mantém a classe sem nenhuma dependência de sistema de arquivos, coerente com o resto da abstração.
-
-### Fase 4 — CRUD em si
-
-- **Criar cofre novo**: `CreateVaultPage`/`CreateVaultViewModel` — nome do cofre, senha mestra (mínimo 8 caracteres) + confirmação, escolhe onde salvar via `IFilePickerService.PickSaveLocationAsync`, cria um `Profile` vazio e salva. Link "Criar um cofre novo" na `UnlockPage`.
-- **Insert/update/delete de item**: `VaultViewModel` ganhou modo de edição (`IsEditingItem`, campos `Edit*` como rascunho) usado tanto por "Novo item" (`AddNewItemCommand`, sem `SelectedItem`) quanto por "Editar" (`EditItemCommand`, carrega os campos do item selecionado). `ItemEditorView` mostra ou o modo visualização (como antes) ou o formulário de edição — nunca os dois. Validação simples: nome e senha do item são obrigatórios. Favoritar, editar, adicionar e excluir agora terminam todos em `IProfileFileService.Save` (antes só a migração salvava; favoritar/excluir eram só em memória).
-- **Backup a cada save**: `ProfileFileService.Save` agora sempre faz backup antes de sobrescrever, não só na migração v1→v2: se o conteúdo atual já é v2, guarda em `.bak` (sobrescrito a cada save — é sempre "a versão de antes da última"); se ainda é v1, continua indo pra `.v1.bak` (preservado, nunca sobrescrito, como já era).
-- **Layout largo (tablet)**: o painel lateral do editor agora abre tanto para um item selecionado quanto para "Novo item" sem seleção (`ShowItemEditor`/`ShowEmptyState`, no lugar de `HasSelectedItem`/`HasNoSelection`) — sem essa troca, criar item no tablet caía na mensagem de "nada selecionado".
-
-Testes: `dotnet test tests/GDSB.Infrastructure.Tests` → **11/11 passando** (os 10 anteriores + 1 novo: `Save_OverwritingV2File_CreatesRollingBakOfPreviousVersion`, cobrindo o `.bak` "rolante"). `LegacyV1FileDecryptionServiceTests`/`ProfileFileServiceTests` ajustados pra nova assinatura (conteúdo em vez de path, `IVaultFileSystem` injetado).
-
-Build Android: limpo, **0 erros**, os mesmos 6 warnings pré-existentes de sempre (nenhum novo). Gera APK assinado. Faltou reexecutar o script de setup (`API_LEVEL` foi de 34 pra 36 nesta sessão — ver seção de build abaixo) e depois o build completo — os dois já confirmados aqui.
-
-**Falta antes de considerar Fase 4 100% validada na prática:** teste manual num emulador/dispositivo Android real — criar um cofre novo escolhendo uma pasta do Google Drive/OneDrive como destino, fechar e reabrir o app, confirmar que a edição aparece no arquivo de verdade (não só que o app não trava). O build valida compilação + XAML + empacotamento, não o fluxo do SAF na prática (o `Intent.ActionCreateDocument`/`ActionOpenDocument` só pode ser exercitado de verdade num dispositivo/emulador com Google Play Services ou o app de Arquivos, que não existem neste ambiente de CI).
-
-- **Fase 1** (mergeada): `IFileCryptoServiceV2`, `InvalidPasswordOrCorruptFileException`, `GdsbFileHeader` (layout v2) e `AesGcmFileCryptoService` (PBKDF2-HMAC-SHA256 + AES-GCM).
-- **Fase 2**: o decifrador antigo virou `Encryption/Legacy/LegacyV1FileDecryptionService` (marcado `[Obsolete]`, só leitura). `IProfileFileService`/`ProfileFileService` detectam o formato pelo magic `GDSB` nos 4 primeiros bytes, delegam pro leitor certo e **sempre gravam em v2**, com backup do original em `<arquivo>.v1.bak` antes da primeira sobrescrita. `ProfileOpenResult.WasLegacyFormat` dispara a migração automática logo após o open.
-- **Fase 3**: DI unificado em `MauiProgram.cs` (o `ServiceProvider` estático paralelo do `App.xaml.cs` foi removido — só existe um container agora). `FileFinderDecrypter` → `UnlockPage`, `MainPage` → `VaultPage`, ambas Views finas sobre `UnlockViewModel`/`VaultViewModel` (CommunityToolkit.Mvvm 8.3.2). `ItemEditorView.xaml` é o mesmo formulário nos dois layouts. `VaultPage.OnSizeAllocated` compara a largura com `ResponsiveBreakpoints.TabletMinWidth` (700dp) e alterna lista+bottom-sheet ↔ mestre-detalhe — por largura, nunca por `DeviceIdiom`. Novos `IClipboardService`/`IAlertService`/`INavigationService` isolam as APIs estáticas do MAUI. Removidos `IFileDataService`/`FileDataService`, sem uso depois do refactor.
-- **Pós-Fase-3 (mesma branch)**:
-  - Migração `net8.0-*` → `net10.0-*` em **todos** os projetos (`GDSB.MAUI`, `GDSB.Domain`, `GDSB.Infrastructure`, `GDSB.Infrastructure.Tests`) — o SDK/workloads MAUI instalados pararam de suportar TFMs `net8.0-*` móveis. Detalhe na seção de build abaixo.
-  - **Bug de startup corrigido**: `App.xaml.cs` injetava `AppShell` direto no construtor, então o container de DI construía `AppShell`→`UnlockPage` (hidratando o XAML dela) **antes** de `App.InitializeComponent()` mesclar `Colors.xaml`/`Styles.xaml` em `Application.Resources` → crash `StaticResource not found` no primeiro `StaticResource` do XAML (`SurfaceDark`, em `UnlockPage.xaml`). Corrigido injetando `IServiceProvider` em `App` e resolvendo `AppShell` só depois de `InitializeComponent()`. **Regra daqui pra frente**: nunca injete direto no construtor de `App`/`AppShell` uma página cujo XAML use `StaticResource` de `App.xaml` — resolva via `IServiceProvider` depois de `InitializeComponent()`.
-  - Primeiro teste manual real do app (Windows) apontou 3 problemas de UX, todos corrigidos:
-    1. *Botões sem cursor de mão no hover (Windows)* — `Behaviors/HoverCursor.cs` (propriedade anexada cross-platform, no-op fora do Windows) + `Platforms/Windows/CursorMappings.cs` (aplica cursor de mão em **todo** `Button` automaticamente via handler mapper, e em `Label`/`Grid` marcados com `behaviors:HoverCursor.IsHand="True"` — usado nos links de URL e na linha inteira da lista). Usa reflection pra setar `UIElement.ProtectedCursor` (é `protected` no WinUI; sem API pública do MAUI pra isso ainda — técnica documentada da comunidade, não hack frágil específico deste app).
-    2. *Copiar usuário/senha sem feedback* — `VaultViewModel` dispara o evento `ToastRequested`; `VaultPage` anima um toast próprio (`Border`+`Label`, fade in/out via `FadeTo`) com "Usuário copiado"/"Senha copiada". Decisão: **não** usar `CommunityToolkit.Maui.Alerts.Toast` — a versão do pacote compatível com `net10.0` exige `Microsoft.Maui.Controls >= 10.0.60`, e o workload MAUI instalado nesta máquina está em `10.0.20`; evitar esse conflito de versão por enquanto.
-    3. *Bug visual no tablet* — no layout largo, o overlay do editor em bottom-sheet (só devia existir no layout compacto) vazava atrás do painel lateral, esticado até o fim da janela, porque seu `IsVisible` checava só `IsEditorOpen` sem considerar o layout. Corrigido com `VaultViewModel.IsCompactEditorOpen` (`IsEditorOpen && IsCompactLayout`).
-
-Testes: `dotnet test tests/GDSB.Infrastructure.Tests` → **10/10 passando** (4 da Fase 1 + 6 novos da Fase 2: leitura de um `.GDSBX` v1 fabricado pelo algoritmo legado, senha errada, flag de formato no `Open`, migração completa e idempotência do `.v1.bak`). Roda em `net10.0` desde a migração pós-Fase-3.
-
-Build: completo (Android + iOS + MacCatalyst + Windows) limpo, 0 erros — veja a seção seguinte para preparar o ambiente Android/Linux. **Testado manualmente rodando de verdade no Windows** (não só build): abre, desbloqueia, e os 3 pontos de UX acima foram confirmados corrigidos pelo usuário. Segue faltando o teste manual num emulador/dispositivo Android de verdade.
-
-## Como compilar o app Android neste ambiente
-
-**O build do `GDSB.MAUI.csproj` funciona aqui** — mas exige uma preparação, porque o SDK .NET que vem do apt do Ubuntu não traz os manifests de workload do Android/MAUI e o proxy de saída bloqueia `dl.google.com` (nada de `dotnet workload install maui` nem download do Android SDK pelo caminho normal).
-
-O script `.claude/scripts/setup-android-build.sh` resolve isso usando só hosts liberados (NuGet, arquivo do Ubuntu, `raw.githubusercontent.com`). Ele é idempotente e leva alguns minutos na primeira vez:
-
-```bash
-.claude/scripts/setup-android-build.sh
-
-dotnet build src/GDSB.MAUI/GDSB.MAUI.csproj -p:GdsbAndroidOnly=true \
-  -p:AndroidSdkDirectory=/opt/android-sdk \
-  -p:JavaSdkDirectory=/usr/lib/jvm/java-17-openjdk-amd64
-```
-
-O que ele faz: instala JDK 17; baixa do NuGet os manifests de workload (`android`, `maui`, `ios`, `maccatalyst` — os quatro, porque o do MAUI referencia os outros); instala o workload `maui-android`; pega `zipalign`/`apksigner` do pacote `android-sdk-build-tools` do Ubuntu; e monta um Android SDK mínimo em `/opt/android-sdk` com o `android.jar` oficial (de um espelho no GitHub, já que `dl.google.com` está bloqueado) — a versão da API é a constante `API_LEVEL` no topo do script, hoje 36 (ver nota abaixo). O `aapt2` real já vem dentro do pack do workload.
-
-`-p:GdsbAndroidOnly=true` é um opt-in adicionado ao `csproj` que restringe os TFMs ao Android: **iOS e MacCatalyst só compilam em macOS**, e sem isso o restore falha. Em Windows/macOS nada disto é necessário — a propriedade não é definida e o build normal compila todos os TFMs.
-
-Última verificação: build Android limpo com **0 erros** nesta sessão (Fase 4, ambiente Linux/Claude Code on the web, banda `10.0.100`), com todos os arquivos da Fase 4 (`AndroidSafFileSystem`, `FilePickerService` reescrito com SAF, `MainActivity` com a ponte de `OnActivityResult`, `CreateVaultPage`, edição completa em `ItemEditorView`). Os 6 warnings são os mesmos pré-existentes de sempre (nenhum novo). Gera o APK assinado em `src/GDSB.MAUI/bin/Debug/net10.0-android/`.
-
-> Nota: o projeto migrou de `net8.0-*` para `net10.0-*` em todos os projetos, `GDSB.Domain`/`GDSB.Infrastructure`/testes inclusive (o SDK/workloads MAUI instalados pararam de suportar TFMs `net8.0-*` móveis, e nesta máquina só há runtime `net10.0`). Nesta sessão o workload Android instalado (`36.1.69`) já exigia API level 36, não mais 34 — `API_LEVEL` no script foi atualizado de 34 para 36 (o espelho no GitHub tem android.jar da API 36 também). Se voltar a falhar por causa de `API_LEVEL`/`BUILD_TOOLS` no futuro, é o mesmo tipo de ajuste.
-
-**O que o build cobre e o que não cobre:** ele valida compilação de C#, o XAML (o XamlC roda e falharia com chave `StaticResource` inexistente ou tipo errado), recursos Android via aapt2, os wrappers Java e o empacotamento/assinatura. Não substitui **testar no emulador** — comportamento em tela, a troca de layout celular/tablet e a migração de um `.GDSBX` v1 real continuam precisando de teste manual.
+1. Atualize a tabela "Status das fases" acima (status e link do PR).
+2. Se algo do plano mudou no caminho, atualize também o artifact do plano — dá para republicar um
+   artifact de outra sessão passando a mesma URL (veja a doc de artifacts do Claude Code:
+   "Update an artifact from an earlier conversation").
+3. Faça commit deste arquivo junto com o PR da fase.

--- a/claude-context.md
+++ b/claude-context.md
@@ -117,8 +117,8 @@ Três frentes vindas do uso real:
 
 | # | Fase | Status | PR |
 |---|------|--------|-----|
-| 0 | Reset do contexto (este arquivo + artifact do plano) | 🔜 Próxima | — |
-| 1 | Desbloqueio: arquivo antes da senha | ⬜ Planejada | — |
+| 0 | Reset do contexto (este arquivo + artifact do plano) | ✅ Concluída | [#13](https://github.com/betinn/GDSB.MAUI/pull/13) |
+| 1 | Desbloqueio: arquivo antes da senha | 🔜 Próxima | — |
 | 2 | Backups fora da pasta do cofre (`IVaultBackupStore`) | ⬜ Planejada | — |
 | 3 | Proteções configuráveis por cofre (`VaultSettings`) | ⬜ Planejada | — |
 | 4 | Tela de edição do cofre | ⬜ Planejada | — |


### PR DESCRIPTION
## Objetivo

Preparar o contexto para uma nova rodada de trabalho no app. Este PR **não muda código** — só troca
o `claude-context.md` da raiz, que estava carregando o contexto já consumido da rodada anterior
(fases 0 a 6, todas mergeadas).

A ideia é que qualquer sessão nova, lendo só esse arquivo, consiga: preparar a máquina, achar o
plano da rodada atual e identificar em que fase ele parou e qual PR abrir em seguida — sem precisar
que nada seja reexplicado no prompt.

## O que mudou

**Removido** (contexto da rodada anterior, já concluída):

- o diagnóstico da criptografia v1 antiga e as decisões de escopo daquela rodada;
- os links dos três artifacts anteriores (protótipo visual, roadmap macro, plano de execução);
- o histórico detalhado das fases 1 a 6 e a seção de manutenção referente a elas.

**Mantido**, porque continua sendo contexto necessário:

- o que é o GDSB e a estrutura dos quatro projetos + dois de teste, incluindo por que
  `GDSB.MAUI.ViewModels` não pode referenciar `GDSB.MAUI`;
- o formato de arquivo v2 com o layout de bytes e a existência do leitor legado v1 — a rodada nova
  mexe em `ProfileFileService`;
- a regra permanente de nunca reintroduzir a criptografia antiga (IV fixo, senha ASCII ciclada,
  ausência de autenticação), nem em produção, nem em teste, nem como fallback;
- as regras de trabalho: uma branch e um PR por fase, PR aberto automaticamente com descrição, não
  monitorar o PR por conta própria.

**Adicionado:**

- **Como rodar o projeto** — instalação do .NET 10 SDK (script `dotnet-install.sh` no Linux/macOS,
  `winget` no Windows) e a distinção que faltava: os testes rodam sem workload nenhum, só o build do
  app precisa do workload MAUI, e no Linux sempre com `-p:GdsbAndroidOnly=true`.
- **Link para o plano da rodada nova**, publicado como artifact, com o detalhamento por fase
  (arquivos a criar/alterar, decisões técnicas e critério de "pronto quando").
- **Tabela de status das sete fases**, com as dependências entre elas (2 antes de 5, 3 antes de 4;
  a 1 é independente), e a lista de decisões já fechadas com o usuário, para não serem relitigadas
  durante a implementação.
- **Como manter o arquivo**: ao fim de cada fase, atualizar o status e o link do PR aqui e no
  artifact, e commitar junto com o PR da fase.

## Sobre a rodada que este contexto prepara

Três frentes, vindas do uso real do app:

1. **Ordem do desbloqueio.** Hoje o app pede a senha antes de abrir o seletor de arquivo. Inverter:
   escolher o arquivo primeiro, e só então liberar o campo de senha (não se aplica ao modo com
   biometria ligada, onde o bloco manual já some inteiro).
2. **Backups.** Hoje o Windows grava `<cofre>.GDSBX.bak` ao lado do original; numa pasta
   sincronizada isso aparece também no celular e, com nome longo, a tela pequena trunca justamente o
   final. Equalizar pelo comportamento que o Android já tinha (backup em diretório do app), renomear
   para `BKP - <arquivo>.bak` e dar ao app uma tela de recuperação/limpeza de backups.
3. **Edição de cofre.** Não existe como renomear o cofre nem trocar a senha mestra depois de criado,
   e as proteções (limpeza de clipboard, auto-lock) são constantes fixas no código. Criar a tela de
   edição e tornar as proteções configuráveis por perfil, gravadas dentro do próprio arquivo do
   cofre.

Nenhuma dessas mudanças está neste PR — cada uma vem no seu próprio PR, uma por fase.

## Verificação

Nenhum arquivo de código foi tocado (`claude-context.md` é o único arquivo do diff), então o
comportamento do app e a suíte de testes seguem inalterados.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUHy547K7efnkeKHJmWEF8)_