### PR TITLE
docs(plano): restringir a oferta de "salvar como" ao ponto de desbloq…

### DIFF
--- a/claude-context.md
+++ b/claude-context.md
@@ -138,8 +138,12 @@ Não relitigar durante a implementação — o detalhamento de cada uma está no
 - Selecionar um arquivo que é backup mostra um popup **apenas informativo**, sem bloquear.
 - Nova tela de recuperação na tela inicial: recriar um cofre a partir de um backup ou excluir backups.
 - Ao trocar a senha mestra, oferecer também a exclusão dos backups antigos (opção do usuário).
-- Renomear = nome interno (`Profile.Nome`) + botão "Salvar como" arquivo novo. O arquivo em disco
-  nunca é renomeado.
+- Renomear = nome interno (`Profile.Nome`) + oferta de "Salvar como" arquivo novo. O arquivo em
+  disco nunca é renomeado.
+- Na tela de edição (Fase 4), só **nome** e **senha mestra** — o que mexe no ponto de desbloqueio do
+  cofre (a chave derivada e a identidade do arquivo) — oferecem gravar num arquivo novo, e só depois
+  de a gravação no arquivo atual ter dado certo. Mudar as proteções grava no próprio arquivo, sem
+  prompt e sem seletor.
 - Trocar a senha com biometria ativa **re-sela** o atalho automaticamente com a senha nova.
 
 ---


### PR DESCRIPTION
…ueio

Na Fase 4, "Salvar como um arquivo novo" era um dos blocos fixos da tela de edição, disponível a qualquer momento. Isso pedia um seletor de arquivo até para quem só tinha mexido num switch de clipboard.

Passa a valer a regra: só nome e senha mestra mexem no ponto de desbloqueio do cofre — a senha muda a chave derivada, e o nome faz o arquivo em disco divergir do cofre que ele guarda —, e só essas duas disparam a oferta, que vira condicional e acontece depois de a gravação no arquivo atual ter dado certo. As proteções (limpeza de clipboard, auto-lock) são conteúdo interno: gravam no próprio arquivo, sem prompt.

O detalhamento da regra, os três blocos restantes da tela e os casos de teste correspondentes estão no artifact do plano; aqui fica a decisão na lista de decisões fechadas.


Claude-Session: https://claude.ai/code/session_01YUHy547K7efnkeKHJmWEF8