### PR TITLE
Fases 1 e 2: arquivo antes da senha + backups fora da pasta do cofre

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,6 +256,10 @@ Generated_Code/
 # because we have git ;-)
 _UpgradeReport_Files/
 Backup*/
+# Exceção: pastas de código-fonte do GDSB chamadas "Backup" (IVaultBackupStore e afins) - não são
+# backups de upgrade do Visual Studio.
+!src/GDSB.Infrastructure/Backup/
+!tests/GDSB.Infrastructure.Tests/Backup/
 UpgradeLog*.XML
 UpgradeLog*.htm
 ServiceFabricBackup/

--- a/claude-context.md
+++ b/claude-context.md
@@ -118,15 +118,20 @@ Três frentes vindas do uso real:
 | # | Fase | Status | PR |
 |---|------|--------|-----|
 | 0 | Reset do contexto (este arquivo + artifact do plano) | ✅ Concluída | [#13](https://github.com/betinn/GDSB.MAUI/pull/13) |
-| 1 | Desbloqueio: arquivo antes da senha | 🔜 Próxima | — |
-| 2 | Backups fora da pasta do cofre (`IVaultBackupStore`) | ⬜ Planejada | — |
-| 3 | Proteções configuráveis por cofre (`VaultSettings`) | ⬜ Planejada | — |
+| 1 | Desbloqueio: arquivo antes da senha | ✅ Concluída | [#15](https://github.com/betinn/GDSB.MAUI/pull/15) |
+| 2 | Backups fora da pasta do cofre (`IVaultBackupStore`) | ✅ Concluída | [#15](https://github.com/betinn/GDSB.MAUI/pull/15) |
+| 3 | Proteções configuráveis por cofre (`VaultSettings`) | 🔜 Próxima | — |
 | 4 | Tela de edição do cofre | ⬜ Planejada | — |
 | 5 | Recuperação de backup | ⬜ Planejada | — |
 | 6 | Fechamento (README, contexto, testes, build) | ⬜ Planejada | — |
 
 Dependências: **2 antes de 5** (a tela de recuperação lê o store criado na fase 2) e **3 antes de 4**
 (a tela de edição edita o `VaultSettings` criado na fase 3). A fase 1 é independente das demais.
+
+As fases 1 e 2 foram implementadas juntas no PR #15 porque a sessão que as fez foi configurada com
+uma única branch para as duas — não é o padrão daqui pra frente. Essa sessão não tinha Android SDK
+disponível (rede bloqueava `dl.google.com`); o build Android e o roteiro manual da fase 1 ficaram
+pendentes de verificação antes do merge — ver o PR para detalhes.
 
 ### Decisões já fechadas com o usuário
 

--- a/src/GDSB.Domain/Entities/VaultBackupInfo.cs
+++ b/src/GDSB.Domain/Entities/VaultBackupInfo.cs
@@ -1,0 +1,23 @@
+namespace GDSB.Domain.Entities
+{
+    public enum VaultBackupKind
+    {
+        // Backup "corrente": sobrescrito a cada Save, guarda a versão de antes da última gravação.
+        Rolling,
+
+        // Backup da migração v1 -> v2: preserva o original importado, nunca sobrescrito depois.
+        LegacyV1,
+    }
+
+    // Id é o caminho do backup dentro do IVaultBackupStore - opaco pra quem consome (só serve pra
+    // devolver pro store em Read/Delete), mas também já é um caminho de arquivo real, então
+    // IProfileFileService.Open aceita direto, sem nenhuma API nova.
+    public record VaultBackupInfo(
+        string Id,
+        string DisplayName,
+        string VaultName,
+        string OriginLocation,
+        VaultBackupKind Kind,
+        DateTime CreatedAtUtc,
+        long SizeBytes);
+}

--- a/src/GDSB.Domain/Interfaces/IVaultBackupStore.cs
+++ b/src/GDSB.Domain/Interfaces/IVaultBackupStore.cs
@@ -1,0 +1,23 @@
+using GDSB.Domain.Entities;
+
+namespace GDSB.Domain.Interfaces
+{
+    // Store único de backups, fora da pasta do cofre nas duas plataformas (ver
+    // FileSystemVaultBackupStore, em GDSB.Infrastructure). ProfileFileService usa Store durante o
+    // Save; a tela de recuperação (fase 5) usa List/Read/Delete/DeleteAllFor.
+    public interface IVaultBackupStore
+    {
+        // Grava previousBytes (o conteúdo do cofre de antes da sobrescrita) como backup de
+        // originLocation e devolve o VaultBackupInfo resultante. Rolling sobrescreve o backup
+        // anterior do mesmo cofre; LegacyV1 nunca sobrescreve um já existente.
+        VaultBackupInfo Store(string originLocation, string vaultName, byte[] previousBytes, VaultBackupKind kind);
+
+        IReadOnlyList<VaultBackupInfo> List();
+
+        byte[] Read(VaultBackupInfo info);
+
+        void Delete(VaultBackupInfo info);
+
+        void DeleteAllFor(string originLocation);
+    }
+}

--- a/src/GDSB.Domain/Interfaces/IVaultFileSystem.cs
+++ b/src/GDSB.Domain/Interfaces/IVaultFileSystem.cs
@@ -10,10 +10,5 @@ namespace GDSB.Domain.Interfaces
         bool Exists(string location);
         byte[] ReadAllBytes(string location);
         void WriteAllBytes(string location, byte[] data);
-
-        // Onde guardar o backup de "location" antes de uma sobrescrita. Não é necessariamente
-        // "ao lado" do arquivo original — um content:// URI do Android não tem pasta-mãe acessível
-        // a partir de um documento avulso, então esse backup vive no armazenamento privado do app.
-        string GetBackupLocation(string location, string suffix);
     }
 }

--- a/src/GDSB.Infrastructure/Backup/FileSystemVaultBackupStore.cs
+++ b/src/GDSB.Infrastructure/Backup/FileSystemVaultBackupStore.cs
@@ -1,0 +1,143 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using GDSB.Domain.Entities;
+using GDSB.Domain.Interfaces;
+
+namespace GDSB.Infrastructure.Backup
+{
+    // Store único de backups nas duas plataformas: root é sempre um diretório privado do app
+    // (FileSystem.AppDataDirectory/vault-backups, ver MauiProgram) - nunca mais "ao lado" do
+    // cofre, nem no Windows. O hash da origin vira o nome da pasta, o que mantém a estabilidade
+    // por cofre que o Android já tinha antes (dois cofres de mesmo nome não colidem); o nome
+    // legível (BuildName) fica só no arquivo em si e no meta.json, que é o que a tela de
+    // recuperação (fase 5) mostra.
+    public class FileSystemVaultBackupStore(string root) : IVaultBackupStore
+    {
+        private const string MetaFileName = "meta.json";
+
+        public VaultBackupInfo Store(string originLocation, string vaultName, byte[] previousBytes, VaultBackupKind kind)
+        {
+            var folder = FolderFor(originLocation);
+            Directory.CreateDirectory(folder);
+
+            var suffix = kind == VaultBackupKind.LegacyV1 ? VaultBackupNaming.LegacySuffix : VaultBackupNaming.RollingSuffix;
+            var fileName = VaultBackupNaming.BuildName($"{vaultName}.GDSBX", suffix);
+            var filePath = Path.Combine(folder, fileName);
+
+            var meta = ReadMeta(folder) ?? new FolderMeta(originLocation, new Dictionary<string, EntryMeta>());
+
+            // LegacyV1 preserva o original importado - nunca sobrescreve um já existente. Rolling
+            // sempre sobrescreve (é sempre "a versão de antes do último save").
+            if (kind == VaultBackupKind.LegacyV1
+                && File.Exists(filePath)
+                && meta.Entries.TryGetValue(fileName, out var existingEntry))
+            {
+                return new VaultBackupInfo(
+                    filePath, fileName, existingEntry.VaultName, meta.OriginLocation,
+                    existingEntry.Kind, existingEntry.CreatedAtUtc, new FileInfo(filePath).Length);
+            }
+
+            File.WriteAllBytes(filePath, previousBytes);
+
+            var createdAtUtc = DateTime.UtcNow;
+            meta = meta with { OriginLocation = originLocation };
+            meta.Entries[fileName] = new EntryMeta(vaultName, kind, createdAtUtc);
+            WriteMeta(folder, meta);
+
+            return new VaultBackupInfo(filePath, fileName, vaultName, originLocation, kind, createdAtUtc, previousBytes.LongLength);
+        }
+
+        public IReadOnlyList<VaultBackupInfo> List()
+        {
+            var results = new List<VaultBackupInfo>();
+
+            if (!Directory.Exists(root))
+                return results;
+
+            foreach (var folder in Directory.GetDirectories(root))
+            {
+                var meta = ReadMeta(folder);
+                if (meta is null)
+                    continue;
+
+                foreach (var (fileName, entry) in meta.Entries)
+                {
+                    var filePath = Path.Combine(folder, fileName);
+                    if (!File.Exists(filePath))
+                        continue;
+
+                    results.Add(new VaultBackupInfo(
+                        filePath,
+                        fileName,
+                        entry.VaultName,
+                        meta.OriginLocation,
+                        entry.Kind,
+                        entry.CreatedAtUtc,
+                        new FileInfo(filePath).Length));
+                }
+            }
+
+            return results;
+        }
+
+        public byte[] Read(VaultBackupInfo info) => File.ReadAllBytes(info.Id);
+
+        public void Delete(VaultBackupInfo info)
+        {
+            if (File.Exists(info.Id))
+                File.Delete(info.Id);
+
+            var folder = Path.GetDirectoryName(info.Id);
+            if (folder is null)
+                return;
+
+            var meta = ReadMeta(folder);
+            if (meta is null)
+                return;
+
+            meta.Entries.Remove(Path.GetFileName(info.Id));
+            RemoveFolderIfEmpty(folder, meta);
+        }
+
+        public void DeleteAllFor(string originLocation)
+        {
+            var folder = FolderFor(originLocation);
+            if (Directory.Exists(folder))
+                Directory.Delete(folder, recursive: true);
+        }
+
+        private string FolderFor(string originLocation)
+        {
+            var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(originLocation)));
+            return Path.Combine(root, hash);
+        }
+
+        private void RemoveFolderIfEmpty(string folder, FolderMeta meta)
+        {
+            if (meta.Entries.Count == 0)
+            {
+                Directory.Delete(folder, recursive: true);
+                return;
+            }
+
+            WriteMeta(folder, meta);
+        }
+
+        private static FolderMeta? ReadMeta(string folder)
+        {
+            var metaPath = Path.Combine(folder, MetaFileName);
+            if (!File.Exists(metaPath))
+                return null;
+
+            return JsonSerializer.Deserialize<FolderMeta>(File.ReadAllText(metaPath));
+        }
+
+        private static void WriteMeta(string folder, FolderMeta meta) =>
+            File.WriteAllText(Path.Combine(folder, MetaFileName), JsonSerializer.Serialize(meta));
+
+        private sealed record FolderMeta(string OriginLocation, Dictionary<string, EntryMeta> Entries);
+
+        private sealed record EntryMeta(string VaultName, VaultBackupKind Kind, DateTime CreatedAtUtc);
+    }
+}

--- a/src/GDSB.Infrastructure/Backup/VaultBackupNaming.cs
+++ b/src/GDSB.Infrastructure/Backup/VaultBackupNaming.cs
@@ -1,0 +1,21 @@
+namespace GDSB.Infrastructure.Backup
+{
+    // Nome de exibição do arquivo de backup. O prefixo resolve a truncagem em tela pequena (o que
+    // se perde é o fim do nome, não o começo); o sufixo continua existindo pra nunca confundir um
+    // backup com um cofre de verdade. IsBackupName aceita o prefixo OU qualquer um dos sufixos
+    // porque também precisa reconhecer backups antigos, gravados do lado do cofre no formato velho
+    // (só sufixo, sem o prefixo "BKP - ").
+    public static class VaultBackupNaming
+    {
+        public const string Prefix = "BKP - ";
+        public const string RollingSuffix = ".bak";
+        public const string LegacySuffix = ".v1.bak";
+
+        public static string BuildName(string vaultFileName, string suffix) => $"{Prefix}{vaultFileName}{suffix}";
+
+        public static bool IsBackupName(string fileName) =>
+            fileName.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase)
+            || fileName.EndsWith(LegacySuffix, StringComparison.OrdinalIgnoreCase)
+            || fileName.EndsWith(RollingSuffix, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/GDSB.Infrastructure/LocalFileSystem.cs
+++ b/src/GDSB.Infrastructure/LocalFileSystem.cs
@@ -11,7 +11,5 @@ namespace GDSB.Infrastructure
         public byte[] ReadAllBytes(string location) => File.ReadAllBytes(location);
 
         public void WriteAllBytes(string location, byte[] data) => File.WriteAllBytes(location, data);
-
-        public string GetBackupLocation(string location, string suffix) => location + suffix;
     }
 }

--- a/src/GDSB.Infrastructure/ProfileFileService.cs
+++ b/src/GDSB.Infrastructure/ProfileFileService.cs
@@ -10,10 +10,12 @@ namespace GDSB.Infrastructure
     // v1 é texto JSON, então nunca bate com o magic) e delega pro serviço certo. Save sempre
     // grava em v2. Toda leitura/gravação passa por IVaultFileSystem: esta classe nunca assume
     // que "location" é um caminho de arquivo de verdade (no Android pode ser um content:// URI).
+    // Backups vão sempre pro IVaultBackupStore (fora da pasta do cofre nas duas plataformas).
     public class ProfileFileService(
         IFileDecryptionService legacyFileDecryptionService,
         IFileCryptoServiceV2 fileCryptoServiceV2,
-        IVaultFileSystem fileSystem) : IProfileFileService
+        IVaultFileSystem fileSystem,
+        IVaultBackupStore backupStore) : IProfileFileService
     {
         private static readonly byte[] V2Magic = { (byte)'G', (byte)'D', (byte)'S', (byte)'B' };
 
@@ -40,14 +42,14 @@ namespace GDSB.Infrastructure
 
         public void Save(string location, Profile profile, string password)
         {
-            BackupBeforeOverwrite(location);
+            BackupBeforeOverwrite(location, profile.Nome);
 
             var json = JsonSerializer.Serialize(profile);
             var fileBytes = fileCryptoServiceV2.Encrypt(json, password);
             fileSystem.WriteAllBytes(location, fileBytes);
         }
 
-        private void BackupBeforeOverwrite(string location)
+        private void BackupBeforeOverwrite(string location, string vaultName)
         {
             if (!fileSystem.Exists(location))
                 return;
@@ -61,18 +63,11 @@ namespace GDSB.Infrastructure
             if (currentBytes.Length == 0)
                 return;
 
-            if (IsV2Format(currentBytes))
-            {
-                // Backup "corrente": sempre a versão de antes do último save, sobrescrito a cada vez.
-                var backupLocation = fileSystem.GetBackupLocation(location, ".bak");
-                fileSystem.WriteAllBytes(backupLocation, currentBytes);
-                return;
-            }
-
-            // Backup da migração v1 -> v2: preserva o original importado, nunca sobrescrito depois.
-            var legacyBackupLocation = fileSystem.GetBackupLocation(location, ".v1.bak");
-            if (!fileSystem.Exists(legacyBackupLocation))
-                fileSystem.WriteAllBytes(legacyBackupLocation, currentBytes);
+            // Rolling ("corrente", sempre a versão de antes do último save) ou LegacyV1 (o
+            // original importado) - qual das duas, e se ela sobrescreve uma já existente, é regra
+            // do próprio IVaultBackupStore.
+            var kind = IsV2Format(currentBytes) ? VaultBackupKind.Rolling : VaultBackupKind.LegacyV1;
+            backupStore.Store(location, vaultName, currentBytes, kind);
         }
 
         private static bool IsV2Format(byte[] fileBytes) =>

--- a/src/GDSB.MAUI.ViewModels/GDSB.MAUI.ViewModels.csproj
+++ b/src/GDSB.MAUI.ViewModels/GDSB.MAUI.ViewModels.csproj
@@ -13,6 +13,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\GDSB.Domain\GDSB.Domain.csproj" />
+    <!-- Só pra VaultBackupNaming.IsBackupName (UnlockViewModel) - GDSB.Infrastructure não
+         referencia este projeto de volta, então não fecha ciclo (diferente de GDSB.MAUI). -->
+    <ProjectReference Include="..\GDSB.Infrastructure\GDSB.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/GDSB.MAUI.ViewModels/Interfaces/IFilePickerService.cs
+++ b/src/GDSB.MAUI.ViewModels/Interfaces/IFilePickerService.cs
@@ -6,12 +6,15 @@ using System.Threading.Tasks;
 
 namespace GDSB.MAUI.Interfaces
 {
-    // O retorno de ambos os métodos é opaco de propósito - um caminho de arquivo real (Windows)
-    // ou algo específico de plataforma (no Android, um content:// URI persistido do Storage Access
-    // Framework) - quem consome só repassa pra IProfileFileService, nunca interpreta o valor.
+    // Location é opaca de propósito - um caminho de arquivo real (Windows) ou algo específico de
+    // plataforma (no Android, um content:// URI persistido do Storage Access Framework) - quem
+    // consome só repassa pra IProfileFileService, nunca interpreta o valor. DisplayName já vem
+    // pronto pra mostrar na UI (no Android, Location não é legível).
+    public record PickedFile(string Location, string DisplayName);
+
     public interface IFilePickerService
     {
-        Task<string> PickFileNameAsync();
+        Task<PickedFile?> PickFileNameAsync();
 
         Task<string> PickSaveLocationAsync(string suggestedName);
     }

--- a/src/GDSB.MAUI.ViewModels/ViewModels/UnlockViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/UnlockViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using GDSB.Domain.Interfaces;
+using GDSB.Infrastructure.Backup;
 using GDSB.MAUI.Interfaces;
 using GDSB.MAUI.Services;
 using System.Security.Cryptography;
@@ -19,12 +20,18 @@ namespace GDSB.MAUI.ViewModels
         private const string GenericErrorMessage = "Senha incorreta ou arquivo corrompido.";
         private const string EmptyPasswordMessage = "Digite a senha mestra do cofre.";
         private const string FilePickerErrorMessage = "Não foi possível abrir o seletor de arquivos.";
+        private const string BackupFileAlertTitle = "Isto é um backup";
+        private const string BackupFileAlertMessage =
+            "Este arquivo parece ser um backup gerado automaticamente pelo GDSB. Você ainda pode " +
+            "abri-lo normalmente com a senha mestra do cofre.";
+        private const string BackupFileAlertCancel = "Entendi";
 
         private readonly IProfileFileService _profileFileService;
         private readonly IFilePickerService _filePickerService;
         private readonly INavigationService _navigationService;
         private readonly IBiometricUnlockService _biometricUnlockService;
         private readonly IPreferencesService _preferencesService;
+        private readonly IAlertService _alertService;
 
         public UnlockViewModel(
             IProfileFileService profileFileService,
@@ -32,6 +39,7 @@ namespace GDSB.MAUI.ViewModels
             INavigationService navigationService,
             IBiometricUnlockService biometricUnlockService,
             IPreferencesService preferencesService,
+            IAlertService alertService,
             BiometricOptInCoordinator biometricOptIn)
         {
             _profileFileService = profileFileService;
@@ -39,12 +47,21 @@ namespace GDSB.MAUI.ViewModels
             _navigationService = navigationService;
             _biometricUnlockService = biometricUnlockService;
             _preferencesService = preferencesService;
+            _alertService = alertService;
             BiometricOptIn = biometricOptIn;
         }
 
         // Exposto pra UnlockPage.xaml hospedar a BiometricOptInView (BindingContext="{Binding
         // BiometricOptIn}") - ver GDSB.MAUI.ViewModels.BiometricOptInCoordinator.
         public BiometricOptInCoordinator BiometricOptIn { get; }
+
+        [ObservableProperty]
+        private string? selectedVaultLocation;
+
+        [ObservableProperty]
+        private string? selectedVaultFileName;
+
+        public bool HasSelectedVault => !string.IsNullOrEmpty(SelectedVaultLocation);
 
         [ObservableProperty]
         private string password = string.Empty;
@@ -89,6 +106,40 @@ namespace GDSB.MAUI.ViewModels
             Password = string.Empty;
             ErrorMessage = null;
             IsPasswordHidden = true;
+            SelectedVaultLocation = null;
+            SelectedVaultFileName = null;
+        }
+
+        // "Trocar arquivo": some do lugar do nome escolhido e volta ao estado inicial - mesmo
+        // efeito de reabrir a UnlockPage do zero.
+        [RelayCommand]
+        private void ClearSelectedVault() => ClearPassword();
+
+        [RelayCommand]
+        private async Task PickVaultAsync()
+        {
+            ErrorMessage = null;
+
+            PickedFile? picked;
+            try
+            {
+                picked = await _filePickerService.PickFileNameAsync();
+            }
+            catch (Exception)
+            {
+                ErrorMessage = FilePickerErrorMessage;
+                return;
+            }
+
+            if (picked is null)
+                return;
+
+            SelectedVaultLocation = picked.Location;
+            SelectedVaultFileName = picked.DisplayName;
+
+            // Um backup também é um cofre válido - o aviso é só informativo, nunca bloqueia.
+            if (VaultBackupNaming.IsBackupName(picked.DisplayName))
+                await _alertService.DisplayAlertAsync(BackupFileAlertTitle, BackupFileAlertMessage, BackupFileAlertCancel);
         }
 
         // Chamado sempre que a UnlockPage passa a ser a tela mostrada - no OnAppearing (abrir o
@@ -104,7 +155,7 @@ namespace GDSB.MAUI.ViewModels
         {
             await RefreshBiometricAvailabilityAsync();
 
-            if (CanUseBiometric && CanUnlock())
+            if (CanUseBiometric && CanUnlockWithBiometric())
                 await UnlockWithBiometricAsync();
         }
 
@@ -138,24 +189,13 @@ namespace GDSB.MAUI.ViewModels
                 return;
             }
 
-            string? location;
-            try
-            {
-                location = await _filePickerService.PickFileNameAsync();
-            }
-            catch (Exception)
-            {
-                ErrorMessage = FilePickerErrorMessage;
-                return;
-            }
-
-            if (string.IsNullOrEmpty(location))
+            if (!HasSelectedVault)
                 return;
 
-            await OpenAndNavigateAsync(location, Password, offerBiometricOptIn: true);
+            await OpenAndNavigateAsync(SelectedVaultLocation!, Password, offerBiometricOptIn: true);
         }
 
-        [RelayCommand(CanExecute = nameof(CanUnlock))]
+        [RelayCommand(CanExecute = nameof(CanUnlockWithBiometric))]
         private async Task UnlockWithBiometricAsync()
         {
             var lastLocation = _preferencesService.GetString(BiometricOptInCoordinator.LastLocationPreferenceKey, null);
@@ -256,7 +296,12 @@ namespace GDSB.MAUI.ViewModels
             BiometricVaultName = string.Empty;
         }
 
-        private bool CanUnlock() => !IsBusy;
+        // UnlockCommand exige um arquivo escolhido; UnlockWithBiometricCommand não - a biometria
+        // mira sempre o cofre lembrado em Preferences (LastLocationPreferenceKey), sem depender de
+        // nenhuma seleção manual feita nesta tela.
+        private bool CanUnlock() => !IsBusy && HasSelectedVault;
+
+        private bool CanUnlockWithBiometric() => !IsBusy;
 
         partial void OnIsBusyChanged(bool value)
         {
@@ -264,6 +309,12 @@ namespace GDSB.MAUI.ViewModels
             UnlockWithBiometricCommand.NotifyCanExecuteChanged();
             OnPropertyChanged(nameof(CanInteract));
             OnPropertyChanged(nameof(UnlockButtonText));
+        }
+
+        partial void OnSelectedVaultLocationChanged(string? value)
+        {
+            OnPropertyChanged(nameof(HasSelectedVault));
+            UnlockCommand.NotifyCanExecuteChanged();
         }
 
         partial void OnErrorMessageChanged(string? value) => OnPropertyChanged(nameof(HasErrorMessage));

--- a/src/GDSB.MAUI/Converters/BoolToDimOpacityConverter.cs
+++ b/src/GDSB.MAUI/Converters/BoolToDimOpacityConverter.cs
@@ -1,0 +1,20 @@
+using System.Globalization;
+
+namespace GDSB.MAUI.Converters
+{
+    // Usado onde um bloco continua visível mas precisa parecer "desligado" enquanto uma condição
+    // não é satisfeita - ex.: o campo de senha antes de escolher o arquivo do cofre (ver
+    // UnlockPage.xaml). Diferente de IsVisible, o layout não pula de posição.
+    public class BoolToDimOpacityConverter : IValueConverter
+    {
+        public double EnabledOpacity { get; set; } = 1.0;
+
+        public double DisabledOpacity { get; set; } = 0.45;
+
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+            value is bool b && b ? EnabledOpacity : DisabledOpacity;
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+            throw new NotSupportedException();
+    }
+}

--- a/src/GDSB.MAUI/Converters/InvertedBoolConverter.cs
+++ b/src/GDSB.MAUI/Converters/InvertedBoolConverter.cs
@@ -1,0 +1,13 @@
+using System.Globalization;
+
+namespace GDSB.MAUI.Converters
+{
+    public class InvertedBoolConverter : IValueConverter
+    {
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+            value is bool b && !b;
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+            value is bool b && !b;
+    }
+}

--- a/src/GDSB.MAUI/MauiProgram.cs
+++ b/src/GDSB.MAUI/MauiProgram.cs
@@ -1,11 +1,13 @@
 using GDSB.Domain.Interfaces;
 using GDSB.Infrastructure;
+using GDSB.Infrastructure.Backup;
 using GDSB.Infrastructure.Encryption.Legacy;
 using GDSB.Infrastructure.Encryption.V2;
 using GDSB.MAUI.Interfaces;
 using GDSB.MAUI.Services;
 using GDSB.MAUI.ViewModels;
 using Microsoft.Extensions.Logging;
+using Microsoft.Maui.Storage;
 
 namespace GDSB.MAUI
 {
@@ -53,6 +55,11 @@ namespace GDSB.MAUI
             services.AddSingleton<IFileDecryptionService, LegacyV1FileDecryptionService>();
 #pragma warning restore CS0618
             services.AddSingleton<IFileCryptoServiceV2, AesGcmFileCryptoService>();
+            // FileSystem.AppDataDirectory funciona igual em Android e Windows - é isso que
+            // equaliza o comportamento do backup nas duas plataformas (no Windows ele deixa de
+            // cair dentro da pasta sincronizada do Drive/OneDrive).
+            services.AddSingleton<IVaultBackupStore>(_ =>
+                new FileSystemVaultBackupStore(Path.Combine(FileSystem.AppDataDirectory, "vault-backups")));
             services.AddSingleton<IProfileFileService, ProfileFileService>();
 
             services.AddSingleton<IClipboardService, ClipboardService>();

--- a/src/GDSB.MAUI/Platforms/Android/Services/AndroidSafFileSystem.cs
+++ b/src/GDSB.MAUI/Platforms/Android/Services/AndroidSafFileSystem.cs
@@ -1,16 +1,10 @@
-using System.Security.Cryptography;
-using System.Text;
 using GDSB.Domain.Interfaces;
-using Microsoft.Maui.Storage;
 
 namespace GDSB.MAUI.Platforms.Android.Services
 {
     // ProfileFileService (Infrastructure) só enxerga uma "location" opaca. Aqui ela é normalmente
     // um content:// URI do Storage Access Framework, escolhido/criado pelo FilePickerService deste
-    // projeto (ver lá o porquê). O backup (.bak/.v1.bak) de uma location content:// não pode morar
-    // "do lado" do arquivo original - SAF não dá acesso à pasta-mãe de um documento avulso - então
-    // fica no armazenamento privado do app, associado ao URI por um nome estável (hash), o que
-    // ainda assim sobrevive a saves seguintes do mesmo cofre.
+    // projeto (ver lá o porquê).
     public class AndroidSafFileSystem : IVaultFileSystem
     {
         private const string ContentScheme = "content://";
@@ -59,18 +53,6 @@ namespace GDSB.MAUI.Platforms.Android.Services
             using var stream = resolver.OpenOutputStream(uri!, "wt")
                 ?? throw new FileNotFoundException($"Não foi possível gravar o cofre em {location}.");
             stream.Write(data, 0, data.Length);
-        }
-
-        public string GetBackupLocation(string location, string suffix)
-        {
-            if (!IsContentUri(location))
-                return location + suffix;
-
-            var backupDir = Path.Combine(FileSystem.AppDataDirectory, "vault-backups");
-            Directory.CreateDirectory(backupDir);
-
-            var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(location)));
-            return Path.Combine(backupDir, hash + suffix);
         }
 
         private static bool IsContentUri(string location) =>

--- a/src/GDSB.MAUI/Platforms/Android/Services/FilePickerService.cs
+++ b/src/GDSB.MAUI/Platforms/Android/Services/FilePickerService.cs
@@ -1,5 +1,7 @@
+using System.Linq;
 using Android.App;
 using Android.Content;
+using Android.Provider;
 using GDSB.MAUI.Interfaces;
 using Microsoft.Maui.ApplicationModel;
 
@@ -18,13 +20,51 @@ namespace GDSB.MAUI.Platforms.Android.Services
         private const int RequestCreateDocument = 41002;
         private const string GdsbMimeType = "application/octet-stream";
 
-        public Task<string> PickFileNameAsync()
+        public async Task<PickedFile?> PickFileNameAsync()
         {
             var intent = new Intent(Intent.ActionOpenDocument);
             intent.AddCategory(Intent.CategoryOpenable);
             intent.SetType("*/*");
             intent.PutExtra(Intent.ExtraMimeTypes, new[] { GdsbMimeType });
-            return LaunchAndAwaitAsync(intent, RequestOpenDocument);
+            var location = await LaunchAndAwaitAsync(intent, RequestOpenDocument);
+
+            if (string.IsNullOrEmpty(location))
+                return null;
+
+            return new PickedFile(location, GetDisplayName(location));
+        }
+
+        // OpenableColumns.DisplayName é o nome "de exibição" do documento, que pode não ter
+        // relação nenhuma com o último segmento do content:// URI (provedores como o Google Drive
+        // usam IDs opacos ali) - sem essa query não dá pra mostrar o nome escolhido na tela nem
+        // reconhecer que o arquivo é um backup.
+        private static string GetDisplayName(string location)
+        {
+            try
+            {
+                var resolver = Platform.CurrentActivity?.ContentResolver
+                    ?? global::Android.App.Application.Context.ContentResolver;
+                var uri = global::Android.Net.Uri.Parse(location);
+
+                using var cursor = resolver?.Query(uri!, new[] { OpenableColumns.DisplayName }, null, null, null);
+                if (cursor is not null && cursor.MoveToFirst())
+                {
+                    var columnIndex = cursor.GetColumnIndex(OpenableColumns.DisplayName);
+                    if (columnIndex >= 0)
+                    {
+                        var name = cursor.GetString(columnIndex);
+                        if (!string.IsNullOrEmpty(name))
+                            return name;
+                    }
+                }
+            }
+            catch
+            {
+                // Cai pro fallback abaixo - vale mais mostrar algo do que quebrar o fluxo de abrir
+                // o cofre por causa de um nome de exibição que não veio.
+            }
+
+            return location.Split('/').LastOrDefault() ?? location;
         }
 
         public Task<string> PickSaveLocationAsync(string suggestedName)

--- a/src/GDSB.MAUI/Platforms/Windows/Services/FilePickerService.cs
+++ b/src/GDSB.MAUI/Platforms/Windows/Services/FilePickerService.cs
@@ -13,7 +13,7 @@ namespace GDSB.MAUI.Platforms.Windows.Services
     public class FilePickerService : IFilePickerService
     {
 
-        public async Task<string> PickFileNameAsync()
+        public async Task<PickedFile?> PickFileNameAsync()
         {
             var picker = new FileOpenPicker();
             picker.FileTypeFilter.Add(".GDSBX");
@@ -22,7 +22,7 @@ namespace GDSB.MAUI.Platforms.Windows.Services
             WinRT.Interop.InitializeWithWindow.Initialize(picker, hwnd);
 
             StorageFile file = await picker.PickSingleFileAsync();
-            return file?.Path ?? string.Empty;
+            return file is null ? null : new PickedFile(file.Path, file.Name);
         }
 
         public async Task<string> PickSaveLocationAsync(string suggestedName)

--- a/src/GDSB.MAUI/UnlockPage.xaml
+++ b/src/GDSB.MAUI/UnlockPage.xaml
@@ -3,9 +3,15 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:behaviors="clr-namespace:GDSB.MAUI.Behaviors"
              xmlns:views="clr-namespace:GDSB.MAUI.Views"
+             xmlns:converters="clr-namespace:GDSB.MAUI.Converters"
              x:Class="GDSB.MAUI.UnlockPage"
              Shell.NavBarIsVisible="False"
              BackgroundColor="{StaticResource SurfaceDark}">
+
+    <ContentPage.Resources>
+        <converters:InvertedBoolConverter x:Key="InvertedBoolConverter" />
+        <converters:BoolToDimOpacityConverter x:Key="BoolToDimOpacityConverter" />
+    </ContentPage.Resources>
 
     <Grid>
 
@@ -34,31 +40,69 @@
                              mútua, dava pra abrir manualmente um cofre B com uma biometria ainda
                              selada com a senha do cofre A, e a tentativa seguinte por biometria
                              abria B com a senha errada (a de A). -->
-                        <VerticalStackLayout Spacing="8" IsVisible="{Binding ShowManualUnlock}">
-                            <Label Text="SENHA MESTRA" Style="{StaticResource FieldLabelStyle}" />
-                            <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
-                                    StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="48">
-                                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
-                                    <Entry Grid.Column="0"
-                                           Placeholder="Digite sua senha mestra"
-                                           Text="{Binding Password}"
-                                           IsPassword="{Binding IsPasswordHidden}"
-                                           TextColor="{StaticResource TextPrimaryDark}"
-                                           PlaceholderColor="{StaticResource TextMutedDark}"
-                                           BackgroundColor="Transparent"
-                                           ReturnCommand="{Binding UnlockCommand}"
-                                           VerticalOptions="Center" />
-                                    <Button Grid.Column="1"
-                                            Text="{Binding EyeGlyph}"
-                                            Command="{Binding ToggleShowPasswordCommand}"
-                                            BackgroundColor="Transparent"
-                                            TextColor="{StaticResource TextSecondaryDark}"
-                                            FontSize="16"
-                                            Padding="0"
-                                            WidthRequest="36"
-                                            HeightRequest="36" />
-                                </Grid>
-                            </Border>
+                        <VerticalStackLayout Spacing="16" IsVisible="{Binding ShowManualUnlock}">
+
+                            <!-- Escolher o arquivo vem antes da senha: só depois de um cofre
+                                 selecionado é que faz sentido digitar a senha dele. -->
+                            <VerticalStackLayout Spacing="8">
+                                <Label Text="ARQUIVO DO COFRE" Style="{StaticResource FieldLabelStyle}" />
+                                <Button Text="Escolher arquivo do cofre"
+                                        Style="{StaticResource SecondaryActionButtonStyle}"
+                                        Command="{Binding PickVaultCommand}"
+                                        IsVisible="{Binding HasSelectedVault, Converter={StaticResource InvertedBoolConverter}}"
+                                        IsEnabled="{Binding CanInteract}" />
+
+                                <Border IsVisible="{Binding HasSelectedVault}"
+                                        BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
+                                        StrokeShape="RoundRectangle 12" Padding="14,10">
+                                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                                        <Label Grid.Column="0"
+                                               Text="{Binding SelectedVaultFileName}"
+                                               LineBreakMode="HeadTruncation"
+                                               MaxLines="1"
+                                               FontFamily="OpenSansSemibold" FontSize="14"
+                                               TextColor="{StaticResource TextPrimaryDark}"
+                                               VerticalOptions="Center" />
+                                        <Button Grid.Column="1"
+                                                Text="Trocar"
+                                                Command="{Binding ClearSelectedVaultCommand}"
+                                                BackgroundColor="Transparent"
+                                                TextColor="{StaticResource PrimaryDark}"
+                                                FontFamily="OpenSansSemibold" FontSize="13"
+                                                Padding="0" />
+                                    </Grid>
+                                </Border>
+                            </VerticalStackLayout>
+
+                            <VerticalStackLayout Spacing="8">
+                                <Label Text="SENHA MESTRA" Style="{StaticResource FieldLabelStyle}" />
+                                <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
+                                        StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="48"
+                                        IsEnabled="{Binding HasSelectedVault}"
+                                        Opacity="{Binding HasSelectedVault, Converter={StaticResource BoolToDimOpacityConverter}}">
+                                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+                                        <Entry Grid.Column="0"
+                                               Placeholder="Digite sua senha mestra"
+                                               Text="{Binding Password}"
+                                               IsPassword="{Binding IsPasswordHidden}"
+                                               TextColor="{StaticResource TextPrimaryDark}"
+                                               PlaceholderColor="{StaticResource TextMutedDark}"
+                                               BackgroundColor="Transparent"
+                                               ReturnCommand="{Binding UnlockCommand}"
+                                               VerticalOptions="Center" />
+                                        <Button Grid.Column="1"
+                                                Text="{Binding EyeGlyph}"
+                                                Command="{Binding ToggleShowPasswordCommand}"
+                                                BackgroundColor="Transparent"
+                                                TextColor="{StaticResource TextSecondaryDark}"
+                                                FontSize="16"
+                                                Padding="0"
+                                                WidthRequest="36"
+                                                HeightRequest="36" />
+                                    </Grid>
+                                </Border>
+                            </VerticalStackLayout>
+
                         </VerticalStackLayout>
 
                         <Label Text="{Binding ErrorMessage}"
@@ -70,7 +114,8 @@
                                 Style="{StaticResource PrimaryActionButtonStyle}"
                                 Command="{Binding UnlockCommand}"
                                 IsVisible="{Binding ShowManualUnlock}"
-                                IsEnabled="{Binding CanInteract}" />
+                                IsEnabled="{Binding HasSelectedVault}"
+                                Opacity="{Binding HasSelectedVault, Converter={StaticResource BoolToDimOpacityConverter}}" />
 
                         <!-- Ao abrir a UnlockPage, a biometria já dispara sozinha quando disponível
                              (UnlockViewModel.InitializeAsync) - este bloco mostra pra qual cofre ela

--- a/tests/GDSB.Infrastructure.Tests/Backup/FileSystemVaultBackupStoreTests.cs
+++ b/tests/GDSB.Infrastructure.Tests/Backup/FileSystemVaultBackupStoreTests.cs
@@ -1,0 +1,102 @@
+using System.Text;
+using GDSB.Domain.Entities;
+using GDSB.Infrastructure.Backup;
+using Xunit;
+
+namespace GDSB.Infrastructure.Tests.Backup
+{
+    public class FileSystemVaultBackupStoreTests : IDisposable
+    {
+        private const string Origin = "content://fake-vault";
+        private const string VaultName = "Cofre de teste";
+
+        private readonly string _root = Path.Combine(Path.GetTempPath(), $"gdsb-backups-{Guid.NewGuid():N}");
+        private readonly FileSystemVaultBackupStore _sut;
+
+        public FileSystemVaultBackupStoreTests()
+        {
+            _sut = new FileSystemVaultBackupStore(_root);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_root))
+                Directory.Delete(_root, recursive: true);
+        }
+
+        private static byte[] Bytes(string text) => Encoding.UTF8.GetBytes(text);
+
+        [Fact]
+        public void Store_Rolling_OverwritesPreviousBackup()
+        {
+            _sut.Store(Origin, VaultName, Bytes("versão 1"), VaultBackupKind.Rolling);
+            var second = _sut.Store(Origin, VaultName, Bytes("versão 2"), VaultBackupKind.Rolling);
+
+            var backup = Assert.Single(_sut.List());
+            Assert.Equal(second.Id, backup.Id);
+            Assert.Equal("versão 2", Encoding.UTF8.GetString(_sut.Read(backup)));
+        }
+
+        [Fact]
+        public void Store_LegacyV1_NeverOverwritesExistingBackup()
+        {
+            var first = _sut.Store(Origin, VaultName, Bytes("original v1"), VaultBackupKind.LegacyV1);
+            _sut.Store(Origin, VaultName, Bytes("tentativa de sobrescrever"), VaultBackupKind.LegacyV1);
+
+            var backup = Assert.Single(_sut.List());
+            Assert.Equal(first.Id, backup.Id);
+            Assert.Equal("original v1", Encoding.UTF8.GetString(_sut.Read(backup)));
+        }
+
+        [Fact]
+        public void List_ReturnsReadableNameAndOrigin()
+        {
+            _sut.Store(Origin, VaultName, Bytes("conteúdo"), VaultBackupKind.Rolling);
+
+            var backup = Assert.Single(_sut.List());
+            Assert.Equal(Origin, backup.OriginLocation);
+            Assert.Equal(VaultName, backup.VaultName);
+            Assert.StartsWith(VaultBackupNaming.Prefix, backup.DisplayName);
+            Assert.EndsWith(VaultBackupNaming.RollingSuffix, backup.DisplayName);
+        }
+
+        [Fact]
+        public void List_ReturnsBothKindsForSameOrigin()
+        {
+            _sut.Store(Origin, VaultName, Bytes("rolling"), VaultBackupKind.Rolling);
+            _sut.Store(Origin, VaultName, Bytes("legacy"), VaultBackupKind.LegacyV1);
+
+            var backups = _sut.List();
+
+            Assert.Equal(2, backups.Count);
+            Assert.Contains(backups, b => b.Kind == VaultBackupKind.Rolling);
+            Assert.Contains(backups, b => b.Kind == VaultBackupKind.LegacyV1);
+        }
+
+        [Fact]
+        public void Delete_RemovesOnlyThatBackup()
+        {
+            _sut.Store(Origin, VaultName, Bytes("rolling"), VaultBackupKind.Rolling);
+            var legacy = _sut.Store(Origin, VaultName, Bytes("legacy"), VaultBackupKind.LegacyV1);
+
+            _sut.Delete(legacy);
+
+            var remaining = Assert.Single(_sut.List());
+            Assert.Equal(VaultBackupKind.Rolling, remaining.Kind);
+            Assert.False(File.Exists(legacy.Id));
+        }
+
+        [Fact]
+        public void DeleteAllFor_RemovesEveryBackupOfThatOrigin()
+        {
+            _sut.Store(Origin, VaultName, Bytes("rolling"), VaultBackupKind.Rolling);
+            _sut.Store(Origin, VaultName, Bytes("legacy"), VaultBackupKind.LegacyV1);
+            _sut.Store("content://other-vault", "Outro cofre", Bytes("outro"), VaultBackupKind.Rolling);
+
+            _sut.DeleteAllFor(Origin);
+
+            var remaining = Assert.Single(_sut.List());
+            Assert.Equal("content://other-vault", remaining.OriginLocation);
+        }
+    }
+}

--- a/tests/GDSB.Infrastructure.Tests/ProfileFileServiceTests.cs
+++ b/tests/GDSB.Infrastructure.Tests/ProfileFileServiceTests.cs
@@ -1,4 +1,6 @@
 using GDSB.Domain.Entities;
+using GDSB.Domain.Interfaces;
+using GDSB.Infrastructure.Backup;
 using GDSB.Infrastructure.Encryption.Legacy;
 using GDSB.Infrastructure.Encryption.V2;
 using GDSB.Infrastructure.Tests.Legacy;
@@ -11,7 +13,15 @@ namespace GDSB.Infrastructure.Tests
     {
         private const string Password = "senha-do-cofre-123";
 
-        private readonly ProfileFileService _sut = new(new LegacyV1FileDecryptionService(), new AesGcmFileCryptoService(), new LocalFileSystem());
+        private readonly string _backupRoot = Path.Combine(Path.GetTempPath(), $"gdsb-backups-{Guid.NewGuid():N}");
+        private readonly IVaultBackupStore _backupStore;
+        private readonly ProfileFileService _sut;
+
+        public ProfileFileServiceTests()
+        {
+            _backupStore = new FileSystemVaultBackupStore(_backupRoot);
+            _sut = new(new LegacyV1FileDecryptionService(), new AesGcmFileCryptoService(), new LocalFileSystem(), _backupStore);
+        }
 
         private static Profile CreateSampleProfile() => new()
         {
@@ -67,7 +77,6 @@ namespace GDSB.Infrastructure.Tests
         public void Save_OverwritingV1File_MigratesToV2AndCreatesBackup()
         {
             var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.GDSBX");
-            var backupPath = path + ".v1.bak";
             try
             {
                 var profile = CreateSampleProfile();
@@ -76,8 +85,9 @@ namespace GDSB.Infrastructure.Tests
 
                 _sut.Save(path, profile, Password);
 
-                Assert.True(File.Exists(backupPath));
-                Assert.Equal(originalBytes, File.ReadAllBytes(backupPath));
+                var backup = Assert.Single(_backupStore.List(), b => b.OriginLocation == path);
+                Assert.Equal(VaultBackupKind.LegacyV1, backup.Kind);
+                Assert.Equal(originalBytes, _backupStore.Read(backup));
 
                 var reopened = _sut.Open(path, Password);
                 Assert.False(reopened.WasLegacyFormat);
@@ -86,7 +96,7 @@ namespace GDSB.Infrastructure.Tests
             finally
             {
                 File.Delete(path);
-                File.Delete(backupPath);
+                _backupStore.DeleteAllFor(path);
             }
         }
 
@@ -94,18 +104,23 @@ namespace GDSB.Infrastructure.Tests
         public void Save_CalledTwiceAfterMigration_DoesNotOverwriteBackupAgain()
         {
             var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.GDSBX");
-            var backupPath = path + ".v1.bak";
             try
             {
                 var profile = CreateSampleProfile();
                 LegacyV1FixtureBuilder.WriteV1File(path, profile, Password);
                 _sut.Save(path, profile, Password);
-                var backupAfterFirstSave = File.ReadAllBytes(backupPath);
+                var legacyBackup = Assert.Single(_backupStore.List(), b => b.OriginLocation == path);
+                var backupAfterFirstSave = _backupStore.Read(legacyBackup);
 
                 profile.Boxes[0].BoxName = "Netflix (editado)";
                 _sut.Save(path, profile, Password);
 
-                Assert.Equal(backupAfterFirstSave, File.ReadAllBytes(backupPath));
+                // O segundo Save já parte de um arquivo v2 (migrado no primeiro), então também
+                // cria um backup Rolling - o que importa aqui é que o LegacyV1 continua intacto.
+                var legacyBackupAfterSecondSave = Assert.Single(
+                    _backupStore.List(),
+                    b => b.OriginLocation == path && b.Kind == VaultBackupKind.LegacyV1);
+                Assert.Equal(backupAfterFirstSave, _backupStore.Read(legacyBackupAfterSecondSave));
 
                 var reopened = _sut.Open(path, Password);
                 Assert.Equal("Netflix (editado)", reopened.Profile.Boxes[0].BoxName);
@@ -113,7 +128,7 @@ namespace GDSB.Infrastructure.Tests
             finally
             {
                 File.Delete(path);
-                File.Delete(backupPath);
+                _backupStore.DeleteAllFor(path);
             }
         }
 
@@ -121,7 +136,6 @@ namespace GDSB.Infrastructure.Tests
         public void Save_OverwritingV2File_CreatesRollingBakOfPreviousVersion()
         {
             var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.GDSBX");
-            var backupPath = path + ".bak";
             try
             {
                 var profile = CreateSampleProfile();
@@ -130,20 +144,22 @@ namespace GDSB.Infrastructure.Tests
                 profile.Boxes[0].BoxName = "Netflix (editado)";
                 _sut.Save(path, profile, Password);
 
-                Assert.True(File.Exists(backupPath));
-                var backedUp = _sut.Open(backupPath, Password);
+                var backup = Assert.Single(_backupStore.List(), b => b.OriginLocation == path);
+                Assert.Equal(VaultBackupKind.Rolling, backup.Kind);
+                var backedUp = _sut.Open(backup.Id, Password);
                 Assert.Equal("Netflix", backedUp.Profile.Boxes[0].BoxName);
 
                 profile.Boxes[0].BoxName = "Netflix (editado de novo)";
                 _sut.Save(path, profile, Password);
 
-                var backedUpAgain = _sut.Open(backupPath, Password);
+                var backupAgain = Assert.Single(_backupStore.List(), b => b.OriginLocation == path);
+                var backedUpAgain = _sut.Open(backupAgain.Id, Password);
                 Assert.Equal("Netflix (editado)", backedUpAgain.Profile.Boxes[0].BoxName);
             }
             finally
             {
                 File.Delete(path);
-                File.Delete(backupPath);
+                _backupStore.DeleteAllFor(path);
             }
         }
 
@@ -154,16 +170,13 @@ namespace GDSB.Infrastructure.Tests
             // FileSavePicker.PickSaveFileAsync cria o arquivo de destino vazio (0 bytes); no Android,
             // ActionCreateDocument via SAF faz o mesmo. Um arquivo vazio não é um cofre v1 a migrar.
             var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.GDSBX");
-            var v1BackupPath = path + ".v1.bak";
-            var bakPath = path + ".bak";
             try
             {
                 File.WriteAllBytes(path, Array.Empty<byte>());
 
                 _sut.Save(path, CreateSampleProfile(), Password);
 
-                Assert.False(File.Exists(v1BackupPath));
-                Assert.False(File.Exists(bakPath));
+                Assert.DoesNotContain(_backupStore.List(), b => b.OriginLocation == path);
 
                 var reopened = _sut.Open(path, Password);
                 Assert.False(reopened.WasLegacyFormat);
@@ -171,8 +184,7 @@ namespace GDSB.Infrastructure.Tests
             finally
             {
                 File.Delete(path);
-                File.Delete(v1BackupPath);
-                File.Delete(bakPath);
+                _backupStore.DeleteAllFor(path);
             }
         }
     }

--- a/tests/GDSB.MAUI.Tests/Fakes/FakeFilePickerService.cs
+++ b/tests/GDSB.MAUI.Tests/Fakes/FakeFilePickerService.cs
@@ -4,7 +4,7 @@ namespace GDSB.MAUI.Tests.Fakes
 {
     internal sealed class FakeFilePickerService : IFilePickerService
     {
-        public string? PickFileNameResult { get; set; } = "content://fake-vault";
+        public PickedFile? PickFileNameResult { get; set; } = new("content://fake-vault", "cofre.GDSBX");
 
         public Exception? PickFileNameException { get; set; }
 
@@ -12,10 +12,10 @@ namespace GDSB.MAUI.Tests.Fakes
 
         public Exception? PickSaveLocationException { get; set; }
 
-        public Task<string> PickFileNameAsync() =>
+        public Task<PickedFile?> PickFileNameAsync() =>
             PickFileNameException is not null
                 ? throw PickFileNameException
-                : Task.FromResult(PickFileNameResult!);
+                : Task.FromResult(PickFileNameResult);
 
         public Task<string> PickSaveLocationAsync(string suggestedName) =>
             PickSaveLocationException is not null

--- a/tests/GDSB.MAUI.Tests/UnlockViewModelTests.cs
+++ b/tests/GDSB.MAUI.Tests/UnlockViewModelTests.cs
@@ -1,5 +1,6 @@
 using GDSB.Domain.Entities;
 using GDSB.Domain.Exceptions;
+using GDSB.MAUI.Interfaces;
 using GDSB.MAUI.Tests.Fakes;
 using GDSB.MAUI.ViewModels;
 using System.Text;
@@ -31,6 +32,7 @@ namespace GDSB.MAUI.Tests
                     NavigationService,
                     BiometricUnlockService,
                     PreferencesService,
+                    AlertService,
                     biometricOptIn);
             }
         }
@@ -50,34 +52,87 @@ namespace GDSB.MAUI.Tests
         }
 
         [Fact]
-        public async Task UnlockAsync_FilePickerThrows_SetsGenericFilePickerError()
+        public async Task UnlockAsync_PasswordWithoutVaultSelected_DoesNotUnlock()
         {
             var sut = new Sut();
             sut.ViewModel.Password = Password;
-            sut.FilePickerService.PickFileNameException = new InvalidOperationException("boom");
 
             await sut.ViewModel.UnlockCommand.ExecuteAsync(null);
 
-            Assert.Equal("Não foi possível abrir o seletor de arquivos.", sut.ViewModel.ErrorMessage);
+            Assert.False(sut.ViewModel.HasSelectedVault);
+            Assert.Empty(sut.NavigationService.NavigateToRootCalls);
         }
 
         [Fact]
-        public async Task UnlockAsync_FilePickerCancelled_DoesNothing()
+        public async Task PickVaultAsync_Success_SelectsVaultAndEnablesUnlock()
         {
             var sut = new Sut();
-            sut.ViewModel.Password = Password;
-            sut.FilePickerService.PickFileNameResult = string.Empty;
+            sut.FilePickerService.PickFileNameResult = new PickedFile(Location, "cofre.GDSBX");
 
-            await sut.ViewModel.UnlockCommand.ExecuteAsync(null);
+            await sut.ViewModel.PickVaultCommand.ExecuteAsync(null);
+
+            Assert.True(sut.ViewModel.HasSelectedVault);
+            Assert.Equal(Location, sut.ViewModel.SelectedVaultLocation);
+            Assert.Equal("cofre.GDSBX", sut.ViewModel.SelectedVaultFileName);
+            Assert.True(sut.ViewModel.UnlockCommand.CanExecute(null));
+            Assert.Empty(sut.AlertService.Calls);
+        }
+
+        [Fact]
+        public async Task PickVaultAsync_BackupFile_ShowsInformativeAlertButStillAllowsSelection()
+        {
+            var sut = new Sut();
+            sut.FilePickerService.PickFileNameResult = new PickedFile(Location, "BKP - cofre.GDSBX.bak");
+
+            await sut.ViewModel.PickVaultCommand.ExecuteAsync(null);
+
+            Assert.True(sut.ViewModel.HasSelectedVault);
+            Assert.Single(sut.AlertService.Calls);
+        }
+
+        [Fact]
+        public async Task PickVaultAsync_Throws_SetsGenericFilePickerError()
+        {
+            var sut = new Sut();
+            sut.FilePickerService.PickFileNameException = new InvalidOperationException("boom");
+
+            await sut.ViewModel.PickVaultCommand.ExecuteAsync(null);
+
+            Assert.Equal("Não foi possível abrir o seletor de arquivos.", sut.ViewModel.ErrorMessage);
+            Assert.False(sut.ViewModel.HasSelectedVault);
+        }
+
+        [Fact]
+        public async Task PickVaultAsync_Cancelled_DoesNothing()
+        {
+            var sut = new Sut();
+            sut.FilePickerService.PickFileNameResult = null;
+
+            await sut.ViewModel.PickVaultCommand.ExecuteAsync(null);
 
             Assert.Null(sut.ViewModel.ErrorMessage);
-            Assert.Empty(sut.NavigationService.NavigateToRootCalls);
+            Assert.False(sut.ViewModel.HasSelectedVault);
+        }
+
+        [Fact]
+        public async Task ClearSelectedVaultAsync_ResetsSelectionAndPassword()
+        {
+            var sut = new Sut();
+            sut.FilePickerService.PickFileNameResult = new PickedFile(Location, "cofre.GDSBX");
+            await sut.ViewModel.PickVaultCommand.ExecuteAsync(null);
+            sut.ViewModel.Password = Password;
+
+            sut.ViewModel.ClearSelectedVaultCommand.Execute(null);
+
+            Assert.False(sut.ViewModel.HasSelectedVault);
+            Assert.Equal(string.Empty, sut.ViewModel.Password);
         }
 
         [Fact]
         public async Task UnlockAsync_WrongPassword_SetsGenericErrorMessage()
         {
             var sut = new Sut();
+            await sut.ViewModel.PickVaultCommand.ExecuteAsync(null);
             sut.ViewModel.Password = "senha-errada";
             sut.ProfileFileService.OpenHandler = (_, _) => throw new InvalidPasswordOrCorruptFileException();
 
@@ -91,6 +146,7 @@ namespace GDSB.MAUI.Tests
         {
             var sut = new Sut();
             var profile = SampleProfile();
+            await sut.ViewModel.PickVaultCommand.ExecuteAsync(null);
             sut.ViewModel.Password = Password;
             sut.ProfileFileService.OpenHandler = (_, _) => new ProfileOpenResult(profile, WasLegacyFormat: false);
 
@@ -113,6 +169,7 @@ namespace GDSB.MAUI.Tests
         {
             var sut = new Sut();
             var profile = SampleProfile();
+            await sut.ViewModel.PickVaultCommand.ExecuteAsync(null);
             sut.ViewModel.Password = Password;
             sut.ProfileFileService.OpenHandler = (_, _) => new ProfileOpenResult(profile, WasLegacyFormat: true);
 


### PR DESCRIPTION
## Resumo

Esta sessão cobre as fases 1 e 2 do plano de rodada (ver `claude-context.md` e o artifact do plano). As duas fases foram feitas numa branch/PR só porque a sessão foi configurada para rodar as duas juntas — cada uma tem seu próprio commit abaixo, com o "Pronto quando" descrito no plano.

### Fase 1 — Desbloqueio: arquivo antes da senha

O campo de senha na `UnlockPage` só habilita depois de o usuário escolher o arquivo do cofre (hoje é o contrário: pede a senha antes do seletor de arquivo). Não afeta o fluxo com biometria ligada, que continua ignorando a seleção manual de arquivo por completo.

- `IFilePickerService.PickFileNameAsync()` agora devolve `PickedFile? (Location, DisplayName)` em vez de `string` — o Android só tinha um `content://` URI ilegível, sem como mostrar o nome escolhido ou reconhecer um backup.
- `UnlockViewModel` ganha `PickVaultCommand`/`ClearSelectedVaultCommand` e `SelectedVaultLocation`/`SelectedVaultFileName`/`HasSelectedVault`. `UnlockCommand` passa a exigir `HasSelectedVault`; `UnlockWithBiometricCommand` continua livre disso.
- Escolher um arquivo cujo nome bate com o padrão de backup (`VaultBackupNaming.IsBackupName`) mostra um aviso apenas informativo — ainda permite abrir.
- UI: botão "Escolher arquivo do cofre" antes do campo de senha; nome mostrado com truncagem pelo início (`HeadTruncation`) e botão "Trocar"; campo de senha e botão "Abrir cofre" ficam desabilitados/esmaecidos até haver seleção.

### Fase 2 — Backups fora da pasta do cofre

Equaliza o comportamento das duas plataformas pelo lado do Android: os backups deixam de ir para `<cofre>.GDSBX.bak`/`.v1.bak` ao lado do arquivo original (no Windows isso vazava para dentro de pastas sincronizadas do Drive/OneDrive) e passam a viver num store único, sempre em `FileSystem.AppDataDirectory/vault-backups` nas duas plataformas.

- `IVaultBackupStore` (Domain) + `FileSystemVaultBackupStore` (Infrastructure): layout `<root>/<sha256 da origin>/BKP - <cofre>.GDSBX{.bak,.v1.bak}`, com um `meta.json` por pasta. Rolling sempre sobrescreve; LegacyV1 nunca sobrescreve um backup já existente — essa regra agora vive no próprio store.
- `IVaultFileSystem` perde `GetBackupLocation`; `ProfileFileService` delega o backup para o `IVaultBackupStore`, usando `profile.Nome` como nome do cofre.
- `.gitignore`: abre uma exceção para as pastas `Backup` de código-fonte deste projeto — o padrão `Backup*/` do template do Visual Studio (pensado para pastas de backup de upgrade) estava silenciosamente ignorando `src/GDSB.Infrastructure/Backup/` e o `tests/.../Backup/` correspondente.

## Testes

```
dotnet test tests/GDSB.Infrastructure.Tests/GDSB.Infrastructure.Tests.csproj   # 18 passed
dotnet test tests/GDSB.MAUI.Tests/GDSB.MAUI.Tests.csproj                       # 43 passed
```

**Build Android não rodou nesta sessão**: o ambiente remoto bloqueia o download do Android SDK (`dl.google.com`) pela política de rede, então `dotnet build -p:GdsbAndroidOnly=true` não passa da etapa de resolução do SDK (`XA5300`), mesmo com o workload MAUI restaurado com sucesso. Os arquivos específicos de Android/XAML tocados (`AndroidSafFileSystem.cs`, `Platforms/Android/Services/FilePickerService.cs`, `UnlockPage.xaml`, os novos `Converters`) foram revisados manualmente linha a linha, mas recomendo compilar/testar num ambiente com Android SDK antes do merge — em especial o roteiro manual do plano (arquivo→senha, aviso de backup, backup fora da pasta).

## Test plan

- [x] `dotnet test tests/GDSB.Infrastructure.Tests`
- [x] `dotnet test tests/GDSB.MAUI.Tests`
- [ ] `dotnet build src/GDSB.MAUI/GDSB.MAUI.csproj -p:GdsbAndroidOnly=true` (não rodou nesta sessão — ver nota acima)
- [ ] Roteiro manual no Android (fluxo novo, aviso de backup, backup fora da pasta)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YCJLvEnokifk2v19UcubNx)_