### PR TITLE
Fases 1 e 2: retenção de backups versionados no domínio, store e telas

### DIFF
--- a/claude-context.md
+++ b/claude-context.md
@@ -124,7 +124,7 @@ explicar — na ordem inversa, as mesmas telas seriam reabertas duas vezes.
 | # | Fase | Frente | Depende de | Status | PR |
 |---|------|--------|------------|--------|-----|
 | 0 | Contexto e plano (este arquivo + artifact) | — | — | ✅ Concluída | — |
-| 1 | Retenção no domínio e no store | Backups | — | ⬜ A fazer | — |
+| 1 | Retenção no domínio e no store | Backups | — | ✅ Concluída | PR aberto nesta sessão |
 | 2 | Bloco BACKUPS nas telas | Backups | 1 | ⬜ A fazer | — |
 | 3 | Infra de ajuda e obrigatoriedade | Onboarding | — | ⬜ A fazer | — |
 | 4 | Tutorial de primeiro acesso | Onboarding | 3 | ⬜ A fazer | — |

--- a/claude-context.md
+++ b/claude-context.md
@@ -125,7 +125,7 @@ explicar — na ordem inversa, as mesmas telas seriam reabertas duas vezes.
 |---|------|--------|------------|--------|-----|
 | 0 | Contexto e plano (este arquivo + artifact) | — | — | ✅ Concluída | — |
 | 1 | Retenção no domínio e no store | Backups | — | ✅ Concluída | [#19](https://github.com/betinn/GDSB.MAUI/pull/19) |
-| 2 | Bloco BACKUPS nas telas | Backups | 1 | ⬜ A fazer | — |
+| 2 | Bloco BACKUPS nas telas | Backups | 1 | ✅ Concluída | [#19](https://github.com/betinn/GDSB.MAUI/pull/19) |
 | 3 | Infra de ajuda e obrigatoriedade | Onboarding | — | ⬜ A fazer | — |
 | 4 | Tutorial de primeiro acesso | Onboarding | 3 | ⬜ A fazer | — |
 | 5 | Cofre novo e segredo novo | Onboarding | 2, 3 | ⬜ A fazer | — |
@@ -142,6 +142,10 @@ Dependências:
 
 As fases **1** e **3** não dependem de nada e podem ser feitas em paralelo, em sessões diferentes.
 As fases 5 e 6 só abrem depois de 2 e 3, porque as duas colocam um "?" na sessão `BACKUPS`.
+
+**Exceção já usada:** as fases 1 e 2 foram implementadas e mergeadas juntas no PR #19, a pedido
+explícito do usuário ("elas se complementam"). A regra de "um PR por fase" (seção "Como
+trabalhar") continua valendo por padrão — só quebre de novo se o usuário pedir.
 
 ### Decisões já fechadas com o usuário
 

--- a/claude-context.md
+++ b/claude-context.md
@@ -124,7 +124,7 @@ explicar — na ordem inversa, as mesmas telas seriam reabertas duas vezes.
 | # | Fase | Frente | Depende de | Status | PR |
 |---|------|--------|------------|--------|-----|
 | 0 | Contexto e plano (este arquivo + artifact) | — | — | ✅ Concluída | — |
-| 1 | Retenção no domínio e no store | Backups | — | ✅ Concluída | PR aberto nesta sessão |
+| 1 | Retenção no domínio e no store | Backups | — | ✅ Concluída | [#19](https://github.com/betinn/GDSB.MAUI/pull/19) |
 | 2 | Bloco BACKUPS nas telas | Backups | 1 | ⬜ A fazer | — |
 | 3 | Infra de ajuda e obrigatoriedade | Onboarding | — | ⬜ A fazer | — |
 | 4 | Tutorial de primeiro acesso | Onboarding | 3 | ⬜ A fazer | — |

--- a/claude-context.md
+++ b/claude-context.md
@@ -182,8 +182,10 @@ Não relitigar durante a implementação — o detalhamento de cada uma está no
 
 ## Como trabalhar
 
-- **Uma branch por fase**, criada a partir da `main` (ex.: `fase-1-retencao-backups`). Quando a
-  sessão já vier com uma branch designada, use a designada.
+- **Uma branch por fase, sempre nomeada `fase-<N>-<nome-curto>`** (ex.: `fase-1-retencao-backups`),
+  criada a partir da `main`. Vale mesmo quando a sessão já vier com uma branch designada genérica
+  (tipo `claude/...`): crie a branch da fase a partir dela (ou da `main`) e faça o PR a partir da
+  branch com nome de fase, não da genérica.
 - **Um PR por fase.** Use a lista de arquivos e o "Pronto quando" da fase, no artifact, como
   checklist do PR.
 - Ao terminar a implementação da fase (código pronto e commitado), **abra o PR automaticamente, sem

--- a/claude-context.md
+++ b/claude-context.md
@@ -196,20 +196,31 @@ Não relitigar durante a implementação — o detalhamento de cada uma está no
   perguntar antes** — é parte padrão do fluxo. O PR fica aberto para review do usuário; não faça
   merge sozinho.
 - O PR nunca é "mudo": a descrição sempre explica o que mudou e por quê.
-- **Não fique monitorando o PR** depois de aberto — gasta token à toa. Se precisar de ajuste, o
-  usuário avisa.
+- **Não fique monitorando o PR** depois de aberto além do necessário pra fechar o ciclo do Sonar
+  (ver "Regra permanente" na seção SonarCloud, logo abaixo) — gasta token à toa. Fora isso, se
+  precisar de ajuste, o usuário avisa.
 - Não pule fases nem inverta as dependências listadas acima.
 
 ### SonarCloud
 
 O repositório roda o SonarCloud Code Analysis como check automático em todo push pro PR (não é um
 step do workflow do GitHub Actions — é uma integração via GitHub App, sem log acessível por aqui).
-Depois de qualquer push, confira o check antes de considerar a fase pronta: a Quality Gate pode
-passar (sem bloquear o merge) mesmo com **New Issues** abertas — "0 New issues" é o alvo, não só
-"Quality Gate passed". Para ver a lista, é preciso pedir pro usuário colar o conteúdo da aba
-"Issues" do PR no SonarCloud (`sonarcloud.io` está bloqueado pela rede deste ambiente, tanto por
-`WebFetch` quanto por `curl`/API, mesmo com token — confirmado de novo nesta sessão) — a mensagem
-do check só traz a contagem, não o detalhe.
+
+**Regra permanente:** depois de todo push num PR — e também ao abrir um PR novo — espere as
+workflows do GitHub Actions e o check do SonarCloud terminarem, leia o comentário que o
+`sonarqubecloud[bot]` posta no PR (isso funciona por aqui: é um comentário normal de PR, acessível
+pelas ferramentas de GitHub, mesmo com `sonarcloud.io` bloqueado pela rede deste ambiente) e
+corrija o que for corrigível — **mesmo que a Quality Gate passe**. O alvo é o código mais limpo
+possível, não só o check verde: "0 New issues" importa tanto quanto "Quality Gate passed", e vale
+apagar apontamentos mesmo quando eles não bloqueiam o merge. Ao corrigir, siga os "Achados
+recorrentes de falso positivo" catalogados logo abaixo (pragma comentado em vez de mudar
+comportamento) em vez de reinventar a correção a cada vez.
+
+O comentário do `sonarqubecloud[bot]` normalmente só traz a contagem/condições da Quality Gate
+(ex.: "4.6% Duplication on New Code (required ≤ 3%)"), não a lista de issues linha a linha. Pra ver
+o detalhe é preciso pedir pro usuário colar o conteúdo da aba "Issues" do PR no SonarCloud
+(`sonarcloud.io` está bloqueado pela rede deste ambiente, tanto por `WebFetch` quanto por
+`curl`/API, mesmo com token — confirmado de novo nesta sessão).
 
 Na rodada anterior, os 75 issues abertos do relatório de 2026-09-01 (2 vulnerabilidades, 1 bug,
 72 code smells) foram corrigidos junto com as fases 5 e 6, no PR #17. Como o Sonar continua

--- a/claude-context.md
+++ b/claude-context.md
@@ -243,6 +243,35 @@ o mesmo padrão já existe, sem supressão, em ViewModels mais antigos (`CanInte
 `UnlockViewModel`/`CreateVaultViewModel`, por exemplo), só não é reportado ali por ser código de
 antes da janela de "New Code" do Sonar.
 
+### Duplicação de código (métrica "Overall Code", não só "New Code")
+
+O bloco `Button.Triggers` + `DataTrigger` + 3 `Setter` (destacar um chip quando um valor bate) se
+repetia dezenas de vezes em `VaultPage.xaml`, `VaultSettingsPage.xaml` e `CreateVaultPage.xaml` —
+era a maior fonte de duplicação do projeto. Resolvido com dois componentes reutilizáveis, em vez de
+copiar o bloco de novo:
+
+- `GDSB.MAUI.Controls.SelectableChip` (`src/GDSB.MAUI/Controls/SelectableChip.cs`) — subclasse de
+  `Button` com a propriedade bindable `IsSelected`; aplica o destaque em C# (lendo as cores do
+  `Application.Current.Resources`) em vez de um `DataTrigger` por instância. **Cuidado**:
+  `BindableObject.SetDynamicResource`/`RemoveDynamicResource` são `internal` ao assembly do MAUI,
+  não públicos — por isso o controle usa `ClearValue` pra voltar ao valor da `Style` (que precisa
+  de `ApplyToDerivedTypes="True"`, já que o `TargetType` dela é `Button`, não `SelectableChip`).
+- `GDSB.MAUI.Converters.EqualsConverter` (registrado globalmente em `App.xaml`, não por página) —
+  compara o valor bindado com o `ConverterParameter` do chip (sempre como string, já que
+  `CommandParameter`/`ConverterParameter` do XAML sempre chegam como string).
+
+Uso: `<controls:SelectableChip ... IsSelected="{Binding X, Converter={StaticResource
+EqualsConverter}, ConverterParameter=20}" />` pra grupos de valor único (substitui o `DataTrigger`
+com `Value="20"`), ou `IsSelected="{Binding AlgumBool}"` direto pra chips de modo (substitui
+`Value="True"`). **Todo chip novo usa `SelectableChip`, nunca mais `Button` + `DataTrigger`.**
+
+Duplicação também apareceu entre `VaultSettingsViewModel` e `CreateVaultViewModel` (as duas telas
+espelham os mesmos campos de PROTEÇÕES/BACKUPS) — resolvida com a classe base
+`VaultProtectionsFormViewModelBase` (`src/GDSB.MAUI.ViewModels/ViewModels/`), que carrega as
+propriedades `[ObservableProperty]`, as listas de opções `static` e os comandos `Select*`
+compartilhados. `SaveProtectionsAsync`/`CreateVaultAsync` continuam em cada ViewModel — fazem
+coisas fundamentalmente diferentes com esses valores, não são candidatos a extração.
+
 ## Como manter este arquivo
 
 Ao final de cada fase (PR aberto):

--- a/src/GDSB.Domain/Entities/BackupRetentionPolicy.cs
+++ b/src/GDSB.Domain/Entities/BackupRetentionPolicy.cs
@@ -1,0 +1,23 @@
+namespace GDSB.Domain.Entities
+{
+    // Count precisa ser o primeiro valor: um JSON antigo sem a chave "BackupRetentionMode"
+    // desserializa no default de enum (0), que precisa continuar sendo o comportamento por
+    // quantidade, coerente com VaultSettings.BackupRetentionCount = 10.
+    public enum BackupRetentionMode
+    {
+        Count,
+        Days,
+    }
+
+    // Política de retenção de backups Rolling de um cofre, lida a partir de VaultSettings no
+    // momento do Save (ver ProfileFileService.BackupBeforeOverwrite). LegacyV1 nunca é podado e
+    // não é afetado por esta política (ver FileSystemVaultBackupStore).
+    public record BackupRetentionPolicy(BackupRetentionMode Mode, int Count, int Days)
+    {
+        // Teto rígido, válido nos dois modos - impede o modo por dias de crescer sem limite.
+        public const int HardCeiling = 100;
+
+        public static BackupRetentionPolicy From(VaultSettings settings) =>
+            new(settings.BackupRetentionMode, settings.BackupRetentionCount, settings.BackupRetentionDays);
+    }
+}

--- a/src/GDSB.Domain/Entities/VaultSettings.cs
+++ b/src/GDSB.Domain/Entities/VaultSettings.cs
@@ -13,5 +13,11 @@ namespace GDSB.Domain.Entities
         public bool AutoLockEnabled { get; set; } = true;
 
         public int AutoLockMinutes { get; set; } = 2;
+
+        public BackupRetentionMode BackupRetentionMode { get; set; } = BackupRetentionMode.Count;
+
+        public int BackupRetentionCount { get; set; } = 10;
+
+        public int BackupRetentionDays { get; set; } = 5;
     }
 }

--- a/src/GDSB.Domain/Interfaces/IVaultBackupStore.cs
+++ b/src/GDSB.Domain/Interfaces/IVaultBackupStore.cs
@@ -8,9 +8,10 @@ namespace GDSB.Domain.Interfaces
     public interface IVaultBackupStore
     {
         // Grava previousBytes (o conteúdo do cofre de antes da sobrescrita) como backup de
-        // originLocation e devolve o VaultBackupInfo resultante. Rolling sobrescreve o backup
-        // anterior do mesmo cofre; LegacyV1 nunca sobrescreve um já existente.
-        VaultBackupInfo Store(string originLocation, string vaultName, byte[] previousBytes, VaultBackupKind kind);
+        // originLocation e devolve o VaultBackupInfo resultante. Rolling acumula uma versão por
+        // save (nome com timestamp) e poda pelo retention logo em seguida; LegacyV1 nunca
+        // sobrescreve um já existente e nunca é podado.
+        VaultBackupInfo Store(string originLocation, string vaultName, byte[] previousBytes, VaultBackupKind kind, BackupRetentionPolicy retention);
 
         IReadOnlyList<VaultBackupInfo> List();
 

--- a/src/GDSB.Infrastructure/Backup/FileSystemVaultBackupStore.cs
+++ b/src/GDSB.Infrastructure/Backup/FileSystemVaultBackupStore.cs
@@ -12,40 +12,110 @@ namespace GDSB.Infrastructure.Backup
     // por cofre que o Android já tinha antes (dois cofres de mesmo nome não colidem); o nome
     // legível (BuildName) fica só no arquivo em si e no meta.json, que é o que a tela de
     // recuperação (fase 5) mostra.
-    public class FileSystemVaultBackupStore(string root) : IVaultBackupStore
+    public class FileSystemVaultBackupStore(string root, Func<DateTime>? utcNow = null) : IVaultBackupStore
     {
         private const string MetaFileName = "meta.json";
 
-        public VaultBackupInfo Store(string originLocation, string vaultName, byte[] previousBytes, VaultBackupKind kind)
+        // Injetável só em teste - é o que torna a poda por dias testável sem depender do relógio
+        // real da máquina.
+        private readonly Func<DateTime> _utcNow = utcNow ?? (() => DateTime.UtcNow);
+
+        public VaultBackupInfo Store(string originLocation, string vaultName, byte[] previousBytes, VaultBackupKind kind, BackupRetentionPolicy retention)
         {
             var folder = FolderFor(originLocation);
             Directory.CreateDirectory(folder);
 
-            var suffix = kind == VaultBackupKind.LegacyV1 ? VaultBackupNaming.LegacySuffix : VaultBackupNaming.RollingSuffix;
-            var fileName = VaultBackupNaming.BuildName($"{vaultName}.GDSBX", suffix);
-            var filePath = Path.Combine(folder, fileName);
-
             var meta = ReadMeta(folder) ?? new FolderMeta(originLocation, new Dictionary<string, EntryMeta>());
+            meta = meta with { OriginLocation = originLocation };
 
-            // LegacyV1 preserva o original importado - nunca sobrescreve um já existente. Rolling
-            // sempre sobrescreve (é sempre "a versão de antes do último save").
-            if (kind == VaultBackupKind.LegacyV1
-                && File.Exists(filePath)
-                && meta.Entries.TryGetValue(fileName, out var existingEntry))
+            if (kind == VaultBackupKind.LegacyV1)
             {
-                return new VaultBackupInfo(
-                    filePath, fileName, existingEntry.VaultName, meta.OriginLocation,
-                    existingEntry.Kind, existingEntry.CreatedAtUtc, new FileInfo(filePath).Length);
+                var fileName = VaultBackupNaming.BuildName($"{vaultName}.GDSBX", VaultBackupNaming.LegacySuffix);
+                var filePath = Path.Combine(folder, fileName);
+
+                // LegacyV1 preserva o original importado - nunca sobrescreve um já existente.
+                if (File.Exists(filePath) && meta.Entries.TryGetValue(fileName, out var existingEntry))
+                {
+                    return new VaultBackupInfo(
+                        filePath, fileName, existingEntry.VaultName, meta.OriginLocation,
+                        existingEntry.Kind, existingEntry.CreatedAtUtc, new FileInfo(filePath).Length);
+                }
+
+                File.WriteAllBytes(filePath, previousBytes);
+
+                var legacyCreatedAtUtc = _utcNow();
+                meta.Entries[fileName] = new EntryMeta(vaultName, kind, legacyCreatedAtUtc);
+                WriteMeta(folder, meta);
+
+                return new VaultBackupInfo(filePath, fileName, vaultName, originLocation, kind, legacyCreatedAtUtc, previousBytes.LongLength);
             }
 
-            File.WriteAllBytes(filePath, previousBytes);
+            // Rolling agora acumula uma versão por save, em vez de sobrescrever a anterior.
+            var createdAtUtc = _utcNow();
+            var (rollingFileName, rollingFilePath) = BuildUniqueRollingPath(folder, vaultName, createdAtUtc);
 
-            var createdAtUtc = DateTime.UtcNow;
-            meta = meta with { OriginLocation = originLocation };
-            meta.Entries[fileName] = new EntryMeta(vaultName, kind, createdAtUtc);
-            WriteMeta(folder, meta);
+            File.WriteAllBytes(rollingFilePath, previousBytes);
+            meta.Entries[rollingFileName] = new EntryMeta(vaultName, kind, createdAtUtc);
 
-            return new VaultBackupInfo(filePath, fileName, vaultName, originLocation, kind, createdAtUtc, previousBytes.LongLength);
+            var result = new VaultBackupInfo(rollingFilePath, rollingFileName, vaultName, originLocation, kind, createdAtUtc, previousBytes.LongLength);
+
+            Prune(folder, meta, retention);
+
+            return result;
+        }
+
+        // Dois saves no mesmo segundo geram o mesmo nome (timestamp com granularidade de
+        // segundo) - sufixa "(2)", "(3)"... antes da extensão até achar um caminho livre.
+        private static (string fileName, string filePath) BuildUniqueRollingPath(string folder, string vaultName, DateTime createdAtUtc)
+        {
+            var fileName = VaultBackupNaming.BuildName($"{vaultName}.GDSBX", VaultBackupNaming.RollingSuffix, createdAtUtc);
+            var filePath = Path.Combine(folder, fileName);
+            if (!File.Exists(filePath))
+                return (fileName, filePath);
+
+            var stem = fileName[..^VaultBackupNaming.RollingSuffix.Length];
+            for (var attempt = 2; ; attempt++)
+            {
+                var candidateName = $"{stem} ({attempt}){VaultBackupNaming.RollingSuffix}";
+                var candidatePath = Path.Combine(folder, candidateName);
+                if (!File.Exists(candidatePath))
+                    return (candidateName, candidatePath);
+            }
+        }
+
+        // Regras: só entradas Rolling entram na conta; LegacyV1 nunca é podado. Nos dois modos
+        // vale o teto rígido (HardCeiling) e o piso de nunca apagar a versão mais recente.
+        // Aproveita a passada para limpar do meta.json entradas cujo arquivo já sumiu.
+        private void Prune(string folder, FolderMeta meta, BackupRetentionPolicy retention)
+        {
+            foreach (var orphan in meta.Entries.Where(e => !File.Exists(Path.Combine(folder, e.Key))).Select(e => e.Key).ToList())
+                meta.Entries.Remove(orphan);
+
+            var rollingByRecency = meta.Entries
+                .Where(e => e.Value.Kind == VaultBackupKind.Rolling)
+                .OrderByDescending(e => e.Value.CreatedAtUtc)
+                .ToList();
+
+            var eligible = retention.Mode == BackupRetentionMode.Days
+                ? rollingByRecency.Where(e => e.Value.CreatedAtUtc >= _utcNow() - TimeSpan.FromDays(retention.Days))
+                : rollingByRecency.Take(Math.Max(retention.Count, 0));
+
+            var toKeep = eligible.Take(BackupRetentionPolicy.HardCeiling).Select(e => e.Key).ToHashSet();
+
+            // Piso: se a regra apagaria tudo, mantém pelo menos a versão mais recente.
+            if (toKeep.Count == 0 && rollingByRecency.Count > 0)
+                toKeep.Add(rollingByRecency[0].Key);
+
+            foreach (var (fileName, _) in rollingByRecency.Where(e => !toKeep.Contains(e.Key)))
+            {
+                var path = Path.Combine(folder, fileName);
+                if (File.Exists(path))
+                    File.Delete(path);
+
+                meta.Entries.Remove(fileName);
+            }
+
+            RemoveFolderIfEmpty(folder, meta);
         }
 
         public IReadOnlyList<VaultBackupInfo> List()

--- a/src/GDSB.Infrastructure/Backup/FileSystemVaultBackupStore.cs
+++ b/src/GDSB.Infrastructure/Backup/FileSystemVaultBackupStore.cs
@@ -74,12 +74,15 @@ namespace GDSB.Infrastructure.Backup
                 return (fileName, filePath);
 
             var stem = fileName[..^VaultBackupNaming.RollingSuffix.Length];
-            for (var attempt = 2; ; attempt++)
+            var attempt = 2;
+            while (true)
             {
                 var candidateName = $"{stem} ({attempt}){VaultBackupNaming.RollingSuffix}";
                 var candidatePath = Path.Combine(folder, candidateName);
                 if (!File.Exists(candidatePath))
                     return (candidateName, candidatePath);
+
+                attempt++;
             }
         }
 

--- a/src/GDSB.Infrastructure/Backup/VaultBackupNaming.cs
+++ b/src/GDSB.Infrastructure/Backup/VaultBackupNaming.cs
@@ -13,6 +13,12 @@ namespace GDSB.Infrastructure.Backup
 
         public static string BuildName(string vaultFileName, string suffix) => $"{Prefix}{vaultFileName}{suffix}";
 
+        // Usado só para Rolling, que agora acumula versões em vez de sobrescrever - o timestamp
+        // é o que distingue uma versão da outra. Sem ":" no horário porque é ilegal em nome de
+        // arquivo no Windows.
+        public static string BuildName(string vaultFileName, string suffix, DateTime createdAtUtc) =>
+            $"{Prefix}{vaultFileName} - {createdAtUtc:yyyy-MM-dd HH-mm-ss}{suffix}";
+
         public static bool IsBackupName(string fileName) =>
             fileName.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase)
             || fileName.EndsWith(LegacySuffix, StringComparison.OrdinalIgnoreCase)

--- a/src/GDSB.Infrastructure/ProfileFileService.cs
+++ b/src/GDSB.Infrastructure/ProfileFileService.cs
@@ -42,14 +42,14 @@ namespace GDSB.Infrastructure
 
         public void Save(string location, Profile profile, string password)
         {
-            BackupBeforeOverwrite(location, profile.Nome);
+            BackupBeforeOverwrite(location, profile.Nome, BackupRetentionPolicy.From(profile.Settings));
 
             var json = JsonSerializer.Serialize(profile);
             var fileBytes = fileCryptoServiceV2.Encrypt(json, password);
             fileSystem.WriteAllBytes(location, fileBytes);
         }
 
-        private void BackupBeforeOverwrite(string location, string vaultName)
+        private void BackupBeforeOverwrite(string location, string vaultName, BackupRetentionPolicy retention)
         {
             if (!fileSystem.Exists(location))
                 return;
@@ -63,11 +63,11 @@ namespace GDSB.Infrastructure
             if (currentBytes.Length == 0)
                 return;
 
-            // Rolling ("corrente", sempre a versão de antes do último save) ou LegacyV1 (o
+            // Rolling (acumula uma versão por save, podada pelo retention) ou LegacyV1 (o
             // original importado) - qual das duas, e se ela sobrescreve uma já existente, é regra
             // do próprio IVaultBackupStore.
             var kind = IsV2Format(currentBytes) ? VaultBackupKind.Rolling : VaultBackupKind.LegacyV1;
-            backupStore.Store(location, vaultName, currentBytes, kind);
+            backupStore.Store(location, vaultName, currentBytes, kind, retention);
         }
 
         private static bool IsV2Format(byte[] fileBytes) =>

--- a/src/GDSB.MAUI.ViewModels/ViewModels/CreateVaultViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/CreateVaultViewModel.cs
@@ -53,6 +53,10 @@ namespace GDSB.MAUI.ViewModels
 
         public static IReadOnlyList<int> AutoLockMinutesOptions { get; } = new[] { 1, 2, 5, 15 };
 
+        public static IReadOnlyList<int> BackupRetentionCountOptions { get; } = new[] { 5, 10, 20, 50 };
+
+        public static IReadOnlyList<int> BackupRetentionDaysOptions { get; } = new[] { 3, 5, 15, 30 };
+
         [ObservableProperty]
         private bool clipboardClearEnabled = true;
 
@@ -65,6 +69,15 @@ namespace GDSB.MAUI.ViewModels
         [ObservableProperty]
         private int autoLockMinutes = 2;
 
+        [ObservableProperty]
+        private BackupRetentionMode backupRetentionMode = BackupRetentionMode.Count;
+
+        [ObservableProperty]
+        private int backupRetentionCount = 10;
+
+        [ObservableProperty]
+        private int backupRetentionDays = 5;
+
         // Recebe string, não int: o CommandParameter do XAML sempre chega como string (o binding
         // não converte pro tipo do parâmetro do RelayCommand), e RelayCommand<int> lança
         // InvalidCastException ao tentar converter esse valor - o clique simplesmente não fazia
@@ -74,6 +87,18 @@ namespace GDSB.MAUI.ViewModels
 
         [RelayCommand]
         private void SelectAutoLockMinutes(string minutes) => AutoLockMinutes = int.Parse(minutes);
+
+        [RelayCommand]
+        private void SelectBackupRetentionModeCount() => BackupRetentionMode = BackupRetentionMode.Count;
+
+        [RelayCommand]
+        private void SelectBackupRetentionModeDays() => BackupRetentionMode = BackupRetentionMode.Days;
+
+        [RelayCommand]
+        private void SelectBackupRetentionCount(string count) => BackupRetentionCount = int.Parse(count);
+
+        [RelayCommand]
+        private void SelectBackupRetentionDays(string days) => BackupRetentionDays = int.Parse(days);
 
         [ObservableProperty]
         private bool isBusy;
@@ -89,6 +114,10 @@ namespace GDSB.MAUI.ViewModels
         public bool CanInteract => !IsBusy;
 
         public string CreateButtonText => IsBusy ? "Criando..." : "Criar cofre";
+
+        public bool IsBackupRetentionByCount => BackupRetentionMode == BackupRetentionMode.Count;
+
+        public bool IsBackupRetentionByDays => BackupRetentionMode == BackupRetentionMode.Days;
 #pragma warning restore S2325
 
         [RelayCommand]
@@ -143,6 +172,9 @@ namespace GDSB.MAUI.ViewModels
                         ClipboardClearSeconds = ClipboardClearSeconds,
                         AutoLockEnabled = AutoLockEnabled,
                         AutoLockMinutes = AutoLockMinutes,
+                        BackupRetentionMode = BackupRetentionMode,
+                        BackupRetentionCount = BackupRetentionCount,
+                        BackupRetentionDays = BackupRetentionDays,
                     },
                 };
                 var enteredPassword = Password;
@@ -200,5 +232,11 @@ namespace GDSB.MAUI.ViewModels
         }
 
         partial void OnErrorMessageChanged(string? value) => OnPropertyChanged(nameof(HasErrorMessage));
+
+        partial void OnBackupRetentionModeChanged(BackupRetentionMode value)
+        {
+            OnPropertyChanged(nameof(IsBackupRetentionByCount));
+            OnPropertyChanged(nameof(IsBackupRetentionByDays));
+        }
     }
 }

--- a/src/GDSB.MAUI.ViewModels/ViewModels/CreateVaultViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/CreateVaultViewModel.cs
@@ -10,7 +10,7 @@ using GDSB.MAUI.Services;
 // Precisa continuar batendo com o nome registrado em AppShell.xaml.cs.
 namespace GDSB.MAUI.ViewModels
 {
-    public partial class CreateVaultViewModel : ObservableObject
+    public partial class CreateVaultViewModel : VaultProtectionsFormViewModelBase
     {
         private const int MinPasswordLength = 8;
 
@@ -49,57 +49,6 @@ namespace GDSB.MAUI.ViewModels
         [ObservableProperty]
         private string confirmPassword = string.Empty;
 
-        public static IReadOnlyList<int> ClipboardClearSecondsOptions { get; } = new[] { 20, 45, 90 };
-
-        public static IReadOnlyList<int> AutoLockMinutesOptions { get; } = new[] { 1, 2, 5, 15 };
-
-        public static IReadOnlyList<int> BackupRetentionCountOptions { get; } = new[] { 5, 10, 20, 50 };
-
-        public static IReadOnlyList<int> BackupRetentionDaysOptions { get; } = new[] { 3, 5, 15, 30 };
-
-        [ObservableProperty]
-        private bool clipboardClearEnabled = true;
-
-        [ObservableProperty]
-        private int clipboardClearSeconds = 20;
-
-        [ObservableProperty]
-        private bool autoLockEnabled = true;
-
-        [ObservableProperty]
-        private int autoLockMinutes = 2;
-
-        [ObservableProperty]
-        private BackupRetentionMode backupRetentionMode = BackupRetentionMode.Count;
-
-        [ObservableProperty]
-        private int backupRetentionCount = 10;
-
-        [ObservableProperty]
-        private int backupRetentionDays = 5;
-
-        // Recebe string, não int: o CommandParameter do XAML sempre chega como string (o binding
-        // não converte pro tipo do parâmetro do RelayCommand), e RelayCommand<int> lança
-        // InvalidCastException ao tentar converter esse valor - o clique simplesmente não fazia
-        // nada, sem erro visível.
-        [RelayCommand]
-        private void SelectClipboardClearSeconds(string seconds) => ClipboardClearSeconds = int.Parse(seconds);
-
-        [RelayCommand]
-        private void SelectAutoLockMinutes(string minutes) => AutoLockMinutes = int.Parse(minutes);
-
-        [RelayCommand]
-        private void SelectBackupRetentionModeCount() => BackupRetentionMode = BackupRetentionMode.Count;
-
-        [RelayCommand]
-        private void SelectBackupRetentionModeDays() => BackupRetentionMode = BackupRetentionMode.Days;
-
-        [RelayCommand]
-        private void SelectBackupRetentionCount(string count) => BackupRetentionCount = int.Parse(count);
-
-        [RelayCommand]
-        private void SelectBackupRetentionDays(string days) => BackupRetentionDays = int.Parse(days);
-
         [ObservableProperty]
         private bool isBusy;
 
@@ -114,10 +63,6 @@ namespace GDSB.MAUI.ViewModels
         public bool CanInteract => !IsBusy;
 
         public string CreateButtonText => IsBusy ? "Criando..." : "Criar cofre";
-
-        public bool IsBackupRetentionByCount => BackupRetentionMode == BackupRetentionMode.Count;
-
-        public bool IsBackupRetentionByDays => BackupRetentionMode == BackupRetentionMode.Days;
 #pragma warning restore S2325
 
         [RelayCommand]
@@ -232,11 +177,5 @@ namespace GDSB.MAUI.ViewModels
         }
 
         partial void OnErrorMessageChanged(string? value) => OnPropertyChanged(nameof(HasErrorMessage));
-
-        partial void OnBackupRetentionModeChanged(BackupRetentionMode value)
-        {
-            OnPropertyChanged(nameof(IsBackupRetentionByCount));
-            OnPropertyChanged(nameof(IsBackupRetentionByDays));
-        }
     }
 }

--- a/src/GDSB.MAUI.ViewModels/ViewModels/VaultProtectionsFormViewModelBase.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/VaultProtectionsFormViewModelBase.cs
@@ -1,0 +1,80 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using GDSB.Domain.Entities;
+
+namespace GDSB.MAUI.ViewModels
+{
+    // Estado e comandos do bloco PROTEÇÕES (limpeza de área de transferência, bloqueio
+    // automático) e do bloco BACKUPS (retenção) - compartilhados entre VaultSettingsViewModel
+    // (edição de um cofre existente) e CreateVaultViewModel (criação), que espelham exatamente
+    // os mesmos campos e comandos de seleção. SaveProtectionsAsync/CreateVaultAsync continuam em
+    // cada ViewModel, porque os dois fazem coisas fundamentalmente diferentes com esses valores.
+    public abstract partial class VaultProtectionsFormViewModelBase : ObservableObject
+    {
+        public static IReadOnlyList<int> ClipboardClearSecondsOptions { get; } = new[] { 20, 45, 90 };
+
+        public static IReadOnlyList<int> AutoLockMinutesOptions { get; } = new[] { 1, 2, 5, 15 };
+
+        public static IReadOnlyList<int> BackupRetentionCountOptions { get; } = new[] { 5, 10, 20, 50 };
+
+        public static IReadOnlyList<int> BackupRetentionDaysOptions { get; } = new[] { 3, 5, 15, 30 };
+
+        [ObservableProperty]
+        private bool clipboardClearEnabled = true;
+
+        [ObservableProperty]
+        private int clipboardClearSeconds = 20;
+
+        [ObservableProperty]
+        private bool autoLockEnabled = true;
+
+        [ObservableProperty]
+        private int autoLockMinutes = 2;
+
+        [ObservableProperty]
+        private BackupRetentionMode backupRetentionMode = BackupRetentionMode.Count;
+
+        [ObservableProperty]
+        private int backupRetentionCount = 10;
+
+        [ObservableProperty]
+        private int backupRetentionDays = 5;
+
+        // S2325 ("make static") é falso positivo aqui: essas propriedades leem estado por
+        // instância (via a propriedade gerada por [ObservableProperty] acima) e não podem virar
+        // static sem quebrar o binding do XAML.
+#pragma warning disable S2325
+        public bool IsBackupRetentionByCount => BackupRetentionMode == BackupRetentionMode.Count;
+
+        public bool IsBackupRetentionByDays => BackupRetentionMode == BackupRetentionMode.Days;
+#pragma warning restore S2325
+
+        // Recebe string, não int: o CommandParameter do XAML sempre chega como string (o binding
+        // não converte pro tipo do parâmetro do RelayCommand), e RelayCommand<int> lança
+        // InvalidCastException ao tentar converter esse valor - o clique simplesmente não fazia
+        // nada, sem erro visível.
+        [RelayCommand]
+        private void SelectClipboardClearSeconds(string seconds) => ClipboardClearSeconds = int.Parse(seconds);
+
+        [RelayCommand]
+        private void SelectAutoLockMinutes(string minutes) => AutoLockMinutes = int.Parse(minutes);
+
+        [RelayCommand]
+        private void SelectBackupRetentionModeCount() => BackupRetentionMode = BackupRetentionMode.Count;
+
+        [RelayCommand]
+        private void SelectBackupRetentionModeDays() => BackupRetentionMode = BackupRetentionMode.Days;
+
+        [RelayCommand]
+        private void SelectBackupRetentionCount(string count) => BackupRetentionCount = int.Parse(count);
+
+        [RelayCommand]
+        private void SelectBackupRetentionDays(string days) => BackupRetentionDays = int.Parse(days);
+
+        partial void OnBackupRetentionModeChanged(BackupRetentionMode value)
+        {
+            OnPropertyChanged(nameof(IsBackupRetentionByCount));
+            OnPropertyChanged(nameof(IsBackupRetentionByDays));
+        }
+    }
+}

--- a/src/GDSB.MAUI.ViewModels/ViewModels/VaultSettingsViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/VaultSettingsViewModel.cs
@@ -12,7 +12,7 @@ using System.Text;
 // Precisa continuar batendo com o nome registrado em AppShell.xaml.cs.
 namespace GDSB.MAUI.ViewModels
 {
-    public partial class VaultSettingsViewModel : ObservableObject, IQueryAttributable
+    public partial class VaultSettingsViewModel : VaultProtectionsFormViewModelBase, IQueryAttributable
     {
         private const int MinPasswordLength = 8;
         private const string GenericSaveErrorMessage = "Não foi possível salvar o cofre. Tente novamente.";
@@ -63,40 +63,11 @@ namespace GDSB.MAUI.ViewModels
         /// </summary>
         public event EventHandler? SettingsSaved;
 
-        public static IReadOnlyList<int> ClipboardClearSecondsOptions { get; } = new[] { 20, 45, 90 };
-
-        public static IReadOnlyList<int> AutoLockMinutesOptions { get; } = new[] { 1, 2, 5, 15 };
-
-        public static IReadOnlyList<int> BackupRetentionCountOptions { get; } = new[] { 5, 10, 20, 50 };
-
-        public static IReadOnlyList<int> BackupRetentionDaysOptions { get; } = new[] { 3, 5, 15, 30 };
-
         [ObservableProperty]
         private string vaultName = string.Empty;
 
         [ObservableProperty]
         private string? nameErrorMessage;
-
-        [ObservableProperty]
-        private bool clipboardClearEnabled;
-
-        [ObservableProperty]
-        private int clipboardClearSeconds;
-
-        [ObservableProperty]
-        private bool autoLockEnabled;
-
-        [ObservableProperty]
-        private int autoLockMinutes;
-
-        [ObservableProperty]
-        private BackupRetentionMode backupRetentionMode;
-
-        [ObservableProperty]
-        private int backupRetentionCount;
-
-        [ObservableProperty]
-        private int backupRetentionDays;
 
         [ObservableProperty]
         private string currentPassword = string.Empty;
@@ -137,10 +108,6 @@ namespace GDSB.MAUI.ViewModels
         public bool HasErrorMessage => !string.IsNullOrEmpty(ErrorMessage);
 
         public bool CanInteract => !IsBusy;
-
-        public bool IsBackupRetentionByCount => BackupRetentionMode == BackupRetentionMode.Count;
-
-        public bool IsBackupRetentionByDays => BackupRetentionMode == BackupRetentionMode.Days;
 #pragma warning restore S2325
 
         public void ApplyQueryAttributes(IDictionary<string, object> query)
@@ -203,28 +170,6 @@ namespace GDSB.MAUI.ViewModels
                 IsBusy = false;
             }
         }
-
-        // Recebe string, não int: o CommandParameter do XAML sempre chega como string (o binding
-        // não converte pro tipo do parâmetro do RelayCommand), e RelayCommand<int> lança
-        // InvalidCastException ao tentar converter esse valor - o clique simplesmente não fazia
-        // nada, sem erro visível.
-        [RelayCommand]
-        private void SelectClipboardClearSeconds(string seconds) => ClipboardClearSeconds = int.Parse(seconds);
-
-        [RelayCommand]
-        private void SelectAutoLockMinutes(string minutes) => AutoLockMinutes = int.Parse(minutes);
-
-        [RelayCommand]
-        private void SelectBackupRetentionModeCount() => BackupRetentionMode = BackupRetentionMode.Count;
-
-        [RelayCommand]
-        private void SelectBackupRetentionModeDays() => BackupRetentionMode = BackupRetentionMode.Days;
-
-        [RelayCommand]
-        private void SelectBackupRetentionCount(string count) => BackupRetentionCount = int.Parse(count);
-
-        [RelayCommand]
-        private void SelectBackupRetentionDays(string days) => BackupRetentionDays = int.Parse(days);
 
         [RelayCommand(CanExecute = nameof(CanInteract))]
         private async Task SaveProtectionsAsync()
@@ -421,12 +366,6 @@ namespace GDSB.MAUI.ViewModels
             SaveProtectionsCommand.NotifyCanExecuteChanged();
             ChangePasswordCommand.NotifyCanExecuteChanged();
             OnPropertyChanged(nameof(CanInteract));
-        }
-
-        partial void OnBackupRetentionModeChanged(BackupRetentionMode value)
-        {
-            OnPropertyChanged(nameof(IsBackupRetentionByCount));
-            OnPropertyChanged(nameof(IsBackupRetentionByDays));
         }
 
         partial void OnNameErrorMessageChanged(string? value) => OnPropertyChanged(nameof(HasNameErrorMessage));

--- a/src/GDSB.MAUI.ViewModels/ViewModels/VaultSettingsViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/VaultSettingsViewModel.cs
@@ -67,6 +67,10 @@ namespace GDSB.MAUI.ViewModels
 
         public static IReadOnlyList<int> AutoLockMinutesOptions { get; } = new[] { 1, 2, 5, 15 };
 
+        public static IReadOnlyList<int> BackupRetentionCountOptions { get; } = new[] { 5, 10, 20, 50 };
+
+        public static IReadOnlyList<int> BackupRetentionDaysOptions { get; } = new[] { 3, 5, 15, 30 };
+
         [ObservableProperty]
         private string vaultName = string.Empty;
 
@@ -84,6 +88,15 @@ namespace GDSB.MAUI.ViewModels
 
         [ObservableProperty]
         private int autoLockMinutes;
+
+        [ObservableProperty]
+        private BackupRetentionMode backupRetentionMode;
+
+        [ObservableProperty]
+        private int backupRetentionCount;
+
+        [ObservableProperty]
+        private int backupRetentionDays;
 
         [ObservableProperty]
         private string currentPassword = string.Empty;
@@ -124,6 +137,10 @@ namespace GDSB.MAUI.ViewModels
         public bool HasErrorMessage => !string.IsNullOrEmpty(ErrorMessage);
 
         public bool CanInteract => !IsBusy;
+
+        public bool IsBackupRetentionByCount => BackupRetentionMode == BackupRetentionMode.Count;
+
+        public bool IsBackupRetentionByDays => BackupRetentionMode == BackupRetentionMode.Days;
 #pragma warning restore S2325
 
         public void ApplyQueryAttributes(IDictionary<string, object> query)
@@ -136,6 +153,9 @@ namespace GDSB.MAUI.ViewModels
                 ClipboardClearSeconds = profile.Settings.ClipboardClearSeconds;
                 AutoLockEnabled = profile.Settings.AutoLockEnabled;
                 AutoLockMinutes = profile.Settings.AutoLockMinutes;
+                BackupRetentionMode = profile.Settings.BackupRetentionMode;
+                BackupRetentionCount = profile.Settings.BackupRetentionCount;
+                BackupRetentionDays = profile.Settings.BackupRetentionDays;
             }
 
             if (query.TryGetValue("Location", out var locationValue) && locationValue is string location)
@@ -194,6 +214,18 @@ namespace GDSB.MAUI.ViewModels
         [RelayCommand]
         private void SelectAutoLockMinutes(string minutes) => AutoLockMinutes = int.Parse(minutes);
 
+        [RelayCommand]
+        private void SelectBackupRetentionModeCount() => BackupRetentionMode = BackupRetentionMode.Count;
+
+        [RelayCommand]
+        private void SelectBackupRetentionModeDays() => BackupRetentionMode = BackupRetentionMode.Days;
+
+        [RelayCommand]
+        private void SelectBackupRetentionCount(string count) => BackupRetentionCount = int.Parse(count);
+
+        [RelayCommand]
+        private void SelectBackupRetentionDays(string days) => BackupRetentionDays = int.Parse(days);
+
         [RelayCommand(CanExecute = nameof(CanInteract))]
         private async Task SaveProtectionsAsync()
         {
@@ -209,6 +241,9 @@ namespace GDSB.MAUI.ViewModels
                     ClipboardClearSeconds = ClipboardClearSeconds,
                     AutoLockEnabled = AutoLockEnabled,
                     AutoLockMinutes = AutoLockMinutes,
+                    BackupRetentionMode = BackupRetentionMode,
+                    BackupRetentionCount = BackupRetentionCount,
+                    BackupRetentionDays = BackupRetentionDays,
                 };
 
                 await Task.Run(() => _profileFileService.Save(_location, _profile, _password));
@@ -386,6 +421,12 @@ namespace GDSB.MAUI.ViewModels
             SaveProtectionsCommand.NotifyCanExecuteChanged();
             ChangePasswordCommand.NotifyCanExecuteChanged();
             OnPropertyChanged(nameof(CanInteract));
+        }
+
+        partial void OnBackupRetentionModeChanged(BackupRetentionMode value)
+        {
+            OnPropertyChanged(nameof(IsBackupRetentionByCount));
+            OnPropertyChanged(nameof(IsBackupRetentionByDays));
         }
 
         partial void OnNameErrorMessageChanged(string? value) => OnPropertyChanged(nameof(HasNameErrorMessage));

--- a/src/GDSB.MAUI/App.xaml
+++ b/src/GDSB.MAUI/App.xaml
@@ -2,6 +2,7 @@
 <Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:GDSB.MAUI"
+             xmlns:converters="clr-namespace:GDSB.MAUI.Converters"
              x:Class="GDSB.MAUI.App">
     <Application.Resources>
         <ResourceDictionary>
@@ -9,6 +10,11 @@
                 <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
                 <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
+
+            <!-- Global porque é usado por SelectableChip.IsSelected em várias telas (VaultPage,
+                 VaultSettingsPage, CreateVaultPage) - registrar por página repetiria a mesma
+                 declaração em cada uma. -->
+            <converters:EqualsConverter x:Key="EqualsConverter" />
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/GDSB.MAUI/Controls/SelectableChip.cs
+++ b/src/GDSB.MAUI/Controls/SelectableChip.cs
@@ -1,0 +1,45 @@
+using Microsoft.Maui.Graphics;
+
+namespace GDSB.MAUI.Controls
+{
+    // Botão de chip cujo destaque de "selecionado" é ligado por IsSelected, em vez de repetir
+    // Button.Triggers/DataTrigger/3 Setters em cada chip do XAML - esse bloco (~7 linhas) se
+    // repetia dezenas de vezes entre VaultPage, VaultSettingsPage e CreateVaultPage, sinalizado
+    // como duplicação pelo Sonar. ClearValue devolve o controle pro que o FilterChipStyle já
+    // define (a Style precisa de ApplyToDerivedTypes="True" pra valer aqui, já que o TargetType
+    // dela é Button) - SetDynamicResource/RemoveDynamicResource de BindableObject não servem
+    // porque são internos ao assembly do MAUI, não públicos.
+    public class SelectableChip : Button
+    {
+        public static readonly BindableProperty IsSelectedProperty = BindableProperty.Create(
+            nameof(IsSelected), typeof(bool), typeof(SelectableChip), false, propertyChanged: OnIsSelectedChanged);
+
+        public bool IsSelected
+        {
+            get => (bool)GetValue(IsSelectedProperty);
+            set => SetValue(IsSelectedProperty, value);
+        }
+
+        private static void OnIsSelectedChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var chip = (SelectableChip)bindable;
+            if ((bool)newValue)
+            {
+                chip.BackgroundColor = ResourceColor("Primary");
+                chip.BorderColor = ResourceColor("Primary");
+                chip.TextColor = ResourceColor("White");
+            }
+            else
+            {
+                chip.ClearValue(BackgroundColorProperty);
+                chip.ClearValue(BorderColorProperty);
+                chip.ClearValue(TextColorProperty);
+            }
+        }
+
+        private static Color ResourceColor(string key) =>
+            Application.Current?.Resources.TryGetValue(key, out var value) == true && value is Color color
+                ? color
+                : Colors.Transparent;
+    }
+}

--- a/src/GDSB.MAUI/Controls/SelectableChip.cs
+++ b/src/GDSB.MAUI/Controls/SelectableChip.cs
@@ -14,12 +14,19 @@ namespace GDSB.MAUI.Controls
         public static readonly BindableProperty IsSelectedProperty = BindableProperty.Create(
             nameof(IsSelected), typeof(bool), typeof(SelectableChip), false, propertyChanged: OnIsSelectedChanged);
 
+        // S2325 é falso positivo: GetValue/SetValue são métodos de instância de BindableObject -
+        // uma bindable property não existe sem instância, então isto não pode virar static.
+#pragma warning disable S2325
         public bool IsSelected
         {
             get => (bool)GetValue(IsSelectedProperty);
             set => SetValue(IsSelectedProperty, value);
         }
+#pragma warning restore S2325
 
+        // oldValue é ignorado de propósito, mas não dá pra remover: a assinatura é fixa pelo
+        // delegate BindablePropertyChangedDelegate esperado por BindableProperty.Create.
+#pragma warning disable S1172
         private static void OnIsSelectedChanged(BindableObject bindable, object oldValue, object newValue)
         {
             var chip = (SelectableChip)bindable;
@@ -36,9 +43,10 @@ namespace GDSB.MAUI.Controls
                 chip.ClearValue(TextColorProperty);
             }
         }
+#pragma warning restore S1172
 
         private static Color ResourceColor(string key) =>
-            Application.Current?.Resources.TryGetValue(key, out var value) == true && value is Color color
+            Application.Current?.Resources.TryGetValue(key, out var value) is true && value is Color color
                 ? color
                 : Colors.Transparent;
     }

--- a/src/GDSB.MAUI/Controls/SelectableChip.cs
+++ b/src/GDSB.MAUI/Controls/SelectableChip.cs
@@ -45,9 +45,13 @@ namespace GDSB.MAUI.Controls
         }
 #pragma warning restore S1172
 
-        private static Color ResourceColor(string key) =>
-            Application.Current?.Resources.TryGetValue(key, out var value) is true && value is Color color
-                ? color
-                : Colors.Transparent;
+        private static Color ResourceColor(string key)
+        {
+            var resources = Application.Current?.Resources;
+            if (resources is not null && resources.TryGetValue(key, out var value) && value is Color color)
+                return color;
+
+            return Colors.Transparent;
+        }
     }
 }

--- a/src/GDSB.MAUI/Converters/EqualsConverter.cs
+++ b/src/GDSB.MAUI/Converters/EqualsConverter.cs
@@ -1,0 +1,22 @@
+using System.Globalization;
+
+namespace GDSB.MAUI.Converters
+{
+    // Compara o valor bindado com o ConverterParameter do chip (SelectableChip.IsSelected) -
+    // sempre como string, porque o parâmetro sempre chega como string do XAML e o valor bindado
+    // pode ser int ou enum, dependendo do grupo de chips.
+    public class EqualsConverter : IValueConverter
+    {
+        // Convert/ConvertBack fazem parte da interface IValueConverter (métodos de instância) -
+        // não podem virar static sem quebrar a implementação da interface, apesar de não usarem
+        // estado desta classe.
+#pragma warning disable S2325
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+            value is not null && parameter is not null
+            && string.Equals(value.ToString(), parameter.ToString(), StringComparison.Ordinal);
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+            throw new NotSupportedException();
+#pragma warning restore S2325
+    }
+}

--- a/src/GDSB.MAUI/CreateVaultPage.xaml
+++ b/src/GDSB.MAUI/CreateVaultPage.xaml
@@ -2,6 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:behaviors="clr-namespace:GDSB.MAUI.Behaviors"
+             xmlns:controls="clr-namespace:GDSB.MAUI.Controls"
              xmlns:views="clr-namespace:GDSB.MAUI.Views"
              xmlns:converters="clr-namespace:GDSB.MAUI.Converters"
              x:Class="GDSB.MAUI.CreateVaultPage"
@@ -100,36 +101,15 @@
                                 <Label Text="Ao copiar uma senha ou usuário, o app apaga o valor da área de transferência depois do tempo escolhido."
                                        TextColor="{StaticResource TextSecondaryDark}" FontSize="12" />
                                 <HorizontalStackLayout Spacing="8" IsVisible="{Binding ClipboardClearEnabled}">
-                                    <Button Text="20s" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectClipboardClearSecondsCommand}" CommandParameter="20">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding ClipboardClearSeconds}" Value="20">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="45s" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectClipboardClearSecondsCommand}" CommandParameter="45">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding ClipboardClearSeconds}" Value="45">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="90s" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectClipboardClearSecondsCommand}" CommandParameter="90">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding ClipboardClearSeconds}" Value="90">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
+                                    <controls:SelectableChip Text="20s" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectClipboardClearSecondsCommand}" CommandParameter="20"
+                                            IsSelected="{Binding ClipboardClearSeconds, Converter={StaticResource EqualsConverter}, ConverterParameter=20}" />
+                                    <controls:SelectableChip Text="45s" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectClipboardClearSecondsCommand}" CommandParameter="45"
+                                            IsSelected="{Binding ClipboardClearSeconds, Converter={StaticResource EqualsConverter}, ConverterParameter=45}" />
+                                    <controls:SelectableChip Text="90s" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectClipboardClearSecondsCommand}" CommandParameter="90"
+                                            IsSelected="{Binding ClipboardClearSeconds, Converter={StaticResource EqualsConverter}, ConverterParameter=90}" />
                                 </HorizontalStackLayout>
                             </VerticalStackLayout>
 
@@ -148,46 +128,18 @@
                                        TextColor="{StaticResource Danger}" FontSize="12"
                                        IsVisible="{Binding AutoLockEnabled, Converter={StaticResource InvertedBoolConverter}}" />
                                 <HorizontalStackLayout Spacing="8" IsVisible="{Binding AutoLockEnabled}">
-                                    <Button Text="1 min" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="1">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding AutoLockMinutes}" Value="1">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="2 min" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="2">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding AutoLockMinutes}" Value="2">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="5 min" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="5">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding AutoLockMinutes}" Value="5">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="15 min" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="15">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding AutoLockMinutes}" Value="15">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
+                                    <controls:SelectableChip Text="1 min" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="1"
+                                            IsSelected="{Binding AutoLockMinutes, Converter={StaticResource EqualsConverter}, ConverterParameter=1}" />
+                                    <controls:SelectableChip Text="2 min" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="2"
+                                            IsSelected="{Binding AutoLockMinutes, Converter={StaticResource EqualsConverter}, ConverterParameter=2}" />
+                                    <controls:SelectableChip Text="5 min" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="5"
+                                            IsSelected="{Binding AutoLockMinutes, Converter={StaticResource EqualsConverter}, ConverterParameter=5}" />
+                                    <controls:SelectableChip Text="15 min" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="15"
+                                            IsSelected="{Binding AutoLockMinutes, Converter={StaticResource EqualsConverter}, ConverterParameter=15}" />
                                 </HorizontalStackLayout>
                             </VerticalStackLayout>
 
@@ -198,112 +150,42 @@
                                 <Label Text="Manter quantas versões"
                                        TextColor="{StaticResource TextPrimaryDark}" FontSize="14" />
                                 <HorizontalStackLayout Spacing="8">
-                                    <Button Text="Por quantidade" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionModeCountCommand}">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding IsBackupRetentionByCount}" Value="True">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="Por tempo" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionModeDaysCommand}">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding IsBackupRetentionByDays}" Value="True">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
+                                    <controls:SelectableChip Text="Por quantidade" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionModeCountCommand}"
+                                            IsSelected="{Binding IsBackupRetentionByCount}" />
+                                    <controls:SelectableChip Text="Por tempo" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionModeDaysCommand}"
+                                            IsSelected="{Binding IsBackupRetentionByDays}" />
                                 </HorizontalStackLayout>
 
                                 <HorizontalStackLayout Spacing="8" IsVisible="{Binding IsBackupRetentionByCount}">
-                                    <Button Text="5" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="5">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionCount}" Value="5">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="10" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="10">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionCount}" Value="10">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="20" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="20">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionCount}" Value="20">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="50" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="50">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionCount}" Value="50">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
+                                    <controls:SelectableChip Text="5" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="5"
+                                            IsSelected="{Binding BackupRetentionCount, Converter={StaticResource EqualsConverter}, ConverterParameter=5}" />
+                                    <controls:SelectableChip Text="10" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="10"
+                                            IsSelected="{Binding BackupRetentionCount, Converter={StaticResource EqualsConverter}, ConverterParameter=10}" />
+                                    <controls:SelectableChip Text="20" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="20"
+                                            IsSelected="{Binding BackupRetentionCount, Converter={StaticResource EqualsConverter}, ConverterParameter=20}" />
+                                    <controls:SelectableChip Text="50" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="50"
+                                            IsSelected="{Binding BackupRetentionCount, Converter={StaticResource EqualsConverter}, ConverterParameter=50}" />
                                 </HorizontalStackLayout>
 
                                 <HorizontalStackLayout Spacing="8" IsVisible="{Binding IsBackupRetentionByDays}">
-                                    <Button Text="3 dias" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="3">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionDays}" Value="3">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="5 dias" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="5">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionDays}" Value="5">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="15 dias" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="15">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionDays}" Value="15">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="30 dias" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="30">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionDays}" Value="30">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
+                                    <controls:SelectableChip Text="3 dias" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="3"
+                                            IsSelected="{Binding BackupRetentionDays, Converter={StaticResource EqualsConverter}, ConverterParameter=3}" />
+                                    <controls:SelectableChip Text="5 dias" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="5"
+                                            IsSelected="{Binding BackupRetentionDays, Converter={StaticResource EqualsConverter}, ConverterParameter=5}" />
+                                    <controls:SelectableChip Text="15 dias" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="15"
+                                            IsSelected="{Binding BackupRetentionDays, Converter={StaticResource EqualsConverter}, ConverterParameter=15}" />
+                                    <controls:SelectableChip Text="30 dias" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="30"
+                                            IsSelected="{Binding BackupRetentionDays, Converter={StaticResource EqualsConverter}, ConverterParameter=30}" />
                                 </HorizontalStackLayout>
 
                                 <Label Text="Ao passar do limite de versões, a mais antiga é apagada. A versão mais recente nunca é apagada."

--- a/src/GDSB.MAUI/CreateVaultPage.xaml
+++ b/src/GDSB.MAUI/CreateVaultPage.xaml
@@ -191,6 +191,129 @@
                                 </HorizontalStackLayout>
                             </VerticalStackLayout>
 
+                            <BoxView HeightRequest="1" Color="{StaticResource BorderDark}" />
+
+                            <VerticalStackLayout Spacing="6">
+                                <Label Text="BACKUPS" Style="{StaticResource FieldLabelStyle}" />
+                                <Label Text="Manter quantas versões"
+                                       TextColor="{StaticResource TextPrimaryDark}" FontSize="14" />
+                                <HorizontalStackLayout Spacing="8">
+                                    <Button Text="Por quantidade" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionModeCountCommand}">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding IsBackupRetentionByCount}" Value="True">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                    <Button Text="Por tempo" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionModeDaysCommand}">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding IsBackupRetentionByDays}" Value="True">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                </HorizontalStackLayout>
+
+                                <HorizontalStackLayout Spacing="8" IsVisible="{Binding IsBackupRetentionByCount}">
+                                    <Button Text="5" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="5">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionCount}" Value="5">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                    <Button Text="10" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="10">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionCount}" Value="10">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                    <Button Text="20" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="20">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionCount}" Value="20">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                    <Button Text="50" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="50">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionCount}" Value="50">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                </HorizontalStackLayout>
+
+                                <HorizontalStackLayout Spacing="8" IsVisible="{Binding IsBackupRetentionByDays}">
+                                    <Button Text="3 dias" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="3">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionDays}" Value="3">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                    <Button Text="5 dias" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="5">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionDays}" Value="5">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                    <Button Text="15 dias" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="15">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionDays}" Value="15">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                    <Button Text="30 dias" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="30">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionDays}" Value="30">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                </HorizontalStackLayout>
+
+                                <Label Text="Ao passar do limite de versões, a mais antiga é apagada. A versão mais recente nunca é apagada."
+                                       TextColor="{StaticResource TextSecondaryDark}" FontSize="12"
+                                       IsVisible="{Binding IsBackupRetentionByCount}" />
+                                <Label Text="Backups mais antigos que o limite escolhido são apagados. A versão mais recente nunca é apagada."
+                                       TextColor="{StaticResource TextSecondaryDark}" FontSize="12"
+                                       IsVisible="{Binding IsBackupRetentionByDays}" />
+                            </VerticalStackLayout>
+
                         </VerticalStackLayout>
                     </Border>
 

--- a/src/GDSB.MAUI/Resources/Styles/Styles.xaml
+++ b/src/GDSB.MAUI/Resources/Styles/Styles.xaml
@@ -455,7 +455,9 @@
         <Setter Property="BorderWidth" Value="1" />
     </Style>
 
-    <Style x:Key="FilterChipStyle" TargetType="Button">
+    <!-- ApplyToDerivedTypes: SelectableChip (GDSB.MAUI.Controls) é subclasse de Button e usa
+         essa mesma Style. -->
+    <Style x:Key="FilterChipStyle" TargetType="Button" ApplyToDerivedTypes="True">
         <Setter Property="TextColor" Value="{StaticResource TextSecondaryDark}" />
         <Setter Property="BackgroundColor" Value="Transparent" />
         <Setter Property="BorderColor" Value="{StaticResource Gray600}" />

--- a/src/GDSB.MAUI/VaultPage.xaml
+++ b/src/GDSB.MAUI/VaultPage.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:views="clr-namespace:GDSB.MAUI.Views"
              xmlns:behaviors="clr-namespace:GDSB.MAUI.Behaviors"
+             xmlns:controls="clr-namespace:GDSB.MAUI.Controls"
              x:Class="GDSB.MAUI.VaultPage"
              x:Name="ThisPage"
              BackgroundColor="{StaticResource SurfaceDark}">
@@ -145,24 +146,10 @@
                             Command="{Binding AddNewItemCommand}" />
                 </Grid>
                 <HorizontalStackLayout Spacing="8">
-                    <Button Text="Todos" Style="{StaticResource FilterChipStyle}" Command="{Binding SetFilterAllCommand}">
-                        <Button.Triggers>
-                            <DataTrigger TargetType="Button" Binding="{Binding IsAllFilterSelected}" Value="True">
-                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                            </DataTrigger>
-                        </Button.Triggers>
-                    </Button>
-                    <Button Text="Favoritos" Style="{StaticResource FilterChipStyle}" Command="{Binding SetFilterFavoritesCommand}">
-                        <Button.Triggers>
-                            <DataTrigger TargetType="Button" Binding="{Binding FilterFavoritesOnly}" Value="True">
-                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                            </DataTrigger>
-                        </Button.Triggers>
-                    </Button>
+                    <controls:SelectableChip Text="Todos" Style="{StaticResource FilterChipStyle}"
+                            Command="{Binding SetFilterAllCommand}" IsSelected="{Binding IsAllFilterSelected}" />
+                    <controls:SelectableChip Text="Favoritos" Style="{StaticResource FilterChipStyle}"
+                            Command="{Binding SetFilterFavoritesCommand}" IsSelected="{Binding FilterFavoritesOnly}" />
                 </HorizontalStackLayout>
             </VerticalStackLayout>
 
@@ -211,24 +198,10 @@
                                 Command="{Binding AddNewItemCommand}" />
                     </Grid>
                     <HorizontalStackLayout Spacing="8">
-                        <Button Text="Todos" Style="{StaticResource FilterChipStyle}" Command="{Binding SetFilterAllCommand}">
-                            <Button.Triggers>
-                                <DataTrigger TargetType="Button" Binding="{Binding IsAllFilterSelected}" Value="True">
-                                    <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                    <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                    <Setter Property="TextColor" Value="{StaticResource White}" />
-                                </DataTrigger>
-                            </Button.Triggers>
-                        </Button>
-                        <Button Text="Favoritos" Style="{StaticResource FilterChipStyle}" Command="{Binding SetFilterFavoritesCommand}">
-                            <Button.Triggers>
-                                <DataTrigger TargetType="Button" Binding="{Binding FilterFavoritesOnly}" Value="True">
-                                    <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                    <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                    <Setter Property="TextColor" Value="{StaticResource White}" />
-                                </DataTrigger>
-                            </Button.Triggers>
-                        </Button>
+                        <controls:SelectableChip Text="Todos" Style="{StaticResource FilterChipStyle}"
+                                Command="{Binding SetFilterAllCommand}" IsSelected="{Binding IsAllFilterSelected}" />
+                        <controls:SelectableChip Text="Favoritos" Style="{StaticResource FilterChipStyle}"
+                                Command="{Binding SetFilterFavoritesCommand}" IsSelected="{Binding FilterFavoritesOnly}" />
                     </HorizontalStackLayout>
                 </VerticalStackLayout>
                 <CollectionView Grid.Row="1" Margin="12,10" ItemsSource="{Binding Items}"

--- a/src/GDSB.MAUI/VaultSettingsPage.xaml
+++ b/src/GDSB.MAUI/VaultSettingsPage.xaml
@@ -2,6 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:behaviors="clr-namespace:GDSB.MAUI.Behaviors"
+             xmlns:controls="clr-namespace:GDSB.MAUI.Controls"
              xmlns:converters="clr-namespace:GDSB.MAUI.Converters"
              xmlns:views="clr-namespace:GDSB.MAUI.Views"
              x:Class="GDSB.MAUI.VaultSettingsPage"
@@ -83,36 +84,15 @@
                                             OnColor="{StaticResource Primary}" />
                                 </Grid>
                                 <HorizontalStackLayout Spacing="8" IsVisible="{Binding ClipboardClearEnabled}">
-                                    <Button Text="20s" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectClipboardClearSecondsCommand}" CommandParameter="20">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding ClipboardClearSeconds}" Value="20">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="45s" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectClipboardClearSecondsCommand}" CommandParameter="45">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding ClipboardClearSeconds}" Value="45">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="90s" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectClipboardClearSecondsCommand}" CommandParameter="90">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding ClipboardClearSeconds}" Value="90">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
+                                    <controls:SelectableChip Text="20s" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectClipboardClearSecondsCommand}" CommandParameter="20"
+                                            IsSelected="{Binding ClipboardClearSeconds, Converter={StaticResource EqualsConverter}, ConverterParameter=20}" />
+                                    <controls:SelectableChip Text="45s" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectClipboardClearSecondsCommand}" CommandParameter="45"
+                                            IsSelected="{Binding ClipboardClearSeconds, Converter={StaticResource EqualsConverter}, ConverterParameter=45}" />
+                                    <controls:SelectableChip Text="90s" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectClipboardClearSecondsCommand}" CommandParameter="90"
+                                            IsSelected="{Binding ClipboardClearSeconds, Converter={StaticResource EqualsConverter}, ConverterParameter=90}" />
                                 </HorizontalStackLayout>
                             </VerticalStackLayout>
 
@@ -129,46 +109,18 @@
                                        TextColor="{StaticResource Danger}" FontSize="12"
                                        IsVisible="{Binding AutoLockEnabled, Converter={StaticResource InvertedBoolConverter}}" />
                                 <HorizontalStackLayout Spacing="8" IsVisible="{Binding AutoLockEnabled}">
-                                    <Button Text="1 min" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="1">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding AutoLockMinutes}" Value="1">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="2 min" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="2">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding AutoLockMinutes}" Value="2">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="5 min" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="5">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding AutoLockMinutes}" Value="5">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="15 min" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="15">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding AutoLockMinutes}" Value="15">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
+                                    <controls:SelectableChip Text="1 min" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="1"
+                                            IsSelected="{Binding AutoLockMinutes, Converter={StaticResource EqualsConverter}, ConverterParameter=1}" />
+                                    <controls:SelectableChip Text="2 min" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="2"
+                                            IsSelected="{Binding AutoLockMinutes, Converter={StaticResource EqualsConverter}, ConverterParameter=2}" />
+                                    <controls:SelectableChip Text="5 min" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="5"
+                                            IsSelected="{Binding AutoLockMinutes, Converter={StaticResource EqualsConverter}, ConverterParameter=5}" />
+                                    <controls:SelectableChip Text="15 min" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="15"
+                                            IsSelected="{Binding AutoLockMinutes, Converter={StaticResource EqualsConverter}, ConverterParameter=15}" />
                                 </HorizontalStackLayout>
                             </VerticalStackLayout>
 
@@ -188,112 +140,42 @@
                                 <Label Text="Manter quantas versões"
                                        TextColor="{StaticResource TextPrimaryDark}" FontSize="14" />
                                 <HorizontalStackLayout Spacing="8">
-                                    <Button Text="Por quantidade" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionModeCountCommand}">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding IsBackupRetentionByCount}" Value="True">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="Por tempo" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionModeDaysCommand}">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding IsBackupRetentionByDays}" Value="True">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
+                                    <controls:SelectableChip Text="Por quantidade" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionModeCountCommand}"
+                                            IsSelected="{Binding IsBackupRetentionByCount}" />
+                                    <controls:SelectableChip Text="Por tempo" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionModeDaysCommand}"
+                                            IsSelected="{Binding IsBackupRetentionByDays}" />
                                 </HorizontalStackLayout>
 
                                 <HorizontalStackLayout Spacing="8" IsVisible="{Binding IsBackupRetentionByCount}">
-                                    <Button Text="5" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="5">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionCount}" Value="5">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="10" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="10">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionCount}" Value="10">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="20" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="20">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionCount}" Value="20">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="50" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="50">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionCount}" Value="50">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
+                                    <controls:SelectableChip Text="5" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="5"
+                                            IsSelected="{Binding BackupRetentionCount, Converter={StaticResource EqualsConverter}, ConverterParameter=5}" />
+                                    <controls:SelectableChip Text="10" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="10"
+                                            IsSelected="{Binding BackupRetentionCount, Converter={StaticResource EqualsConverter}, ConverterParameter=10}" />
+                                    <controls:SelectableChip Text="20" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="20"
+                                            IsSelected="{Binding BackupRetentionCount, Converter={StaticResource EqualsConverter}, ConverterParameter=20}" />
+                                    <controls:SelectableChip Text="50" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="50"
+                                            IsSelected="{Binding BackupRetentionCount, Converter={StaticResource EqualsConverter}, ConverterParameter=50}" />
                                 </HorizontalStackLayout>
 
                                 <HorizontalStackLayout Spacing="8" IsVisible="{Binding IsBackupRetentionByDays}">
-                                    <Button Text="3 dias" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="3">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionDays}" Value="3">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="5 dias" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="5">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionDays}" Value="5">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="15 dias" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="15">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionDays}" Value="15">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
-                                    <Button Text="30 dias" Style="{StaticResource FilterChipStyle}"
-                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="30">
-                                        <Button.Triggers>
-                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionDays}" Value="30">
-                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
-                                                <Setter Property="TextColor" Value="{StaticResource White}" />
-                                            </DataTrigger>
-                                        </Button.Triggers>
-                                    </Button>
+                                    <controls:SelectableChip Text="3 dias" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="3"
+                                            IsSelected="{Binding BackupRetentionDays, Converter={StaticResource EqualsConverter}, ConverterParameter=3}" />
+                                    <controls:SelectableChip Text="5 dias" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="5"
+                                            IsSelected="{Binding BackupRetentionDays, Converter={StaticResource EqualsConverter}, ConverterParameter=5}" />
+                                    <controls:SelectableChip Text="15 dias" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="15"
+                                            IsSelected="{Binding BackupRetentionDays, Converter={StaticResource EqualsConverter}, ConverterParameter=15}" />
+                                    <controls:SelectableChip Text="30 dias" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="30"
+                                            IsSelected="{Binding BackupRetentionDays, Converter={StaticResource EqualsConverter}, ConverterParameter=30}" />
                                 </HorizontalStackLayout>
 
                                 <Label Text="Ao passar do limite de versões, a mais antiga é apagada. A versão mais recente nunca é apagada."

--- a/src/GDSB.MAUI/VaultSettingsPage.xaml
+++ b/src/GDSB.MAUI/VaultSettingsPage.xaml
@@ -178,7 +178,139 @@
                         </VerticalStackLayout>
                     </Border>
 
-                    <!-- Bloco 3: trocar senha mestra -->
+                    <!-- Bloco 3: backups (fase 2) - grava junto com as proteções, sem prompt de "salvar como" -->
+                    <Border Style="{StaticResource CardBorderStyle}" Padding="22" StrokeShape="RoundRectangle 20">
+                        <VerticalStackLayout Spacing="18">
+
+                            <Label Text="BACKUPS" Style="{StaticResource FieldLabelStyle}" />
+
+                            <VerticalStackLayout Spacing="6">
+                                <Label Text="Manter quantas versões"
+                                       TextColor="{StaticResource TextPrimaryDark}" FontSize="14" />
+                                <HorizontalStackLayout Spacing="8">
+                                    <Button Text="Por quantidade" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionModeCountCommand}">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding IsBackupRetentionByCount}" Value="True">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                    <Button Text="Por tempo" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionModeDaysCommand}">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding IsBackupRetentionByDays}" Value="True">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                </HorizontalStackLayout>
+
+                                <HorizontalStackLayout Spacing="8" IsVisible="{Binding IsBackupRetentionByCount}">
+                                    <Button Text="5" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="5">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionCount}" Value="5">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                    <Button Text="10" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="10">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionCount}" Value="10">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                    <Button Text="20" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="20">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionCount}" Value="20">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                    <Button Text="50" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionCountCommand}" CommandParameter="50">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionCount}" Value="50">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                </HorizontalStackLayout>
+
+                                <HorizontalStackLayout Spacing="8" IsVisible="{Binding IsBackupRetentionByDays}">
+                                    <Button Text="3 dias" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="3">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionDays}" Value="3">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                    <Button Text="5 dias" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="5">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionDays}" Value="5">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                    <Button Text="15 dias" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="15">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionDays}" Value="15">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                    <Button Text="30 dias" Style="{StaticResource FilterChipStyle}"
+                                            Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="30">
+                                        <Button.Triggers>
+                                            <DataTrigger TargetType="Button" Binding="{Binding BackupRetentionDays}" Value="30">
+                                                <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                                                <Setter Property="TextColor" Value="{StaticResource White}" />
+                                            </DataTrigger>
+                                        </Button.Triggers>
+                                    </Button>
+                                </HorizontalStackLayout>
+
+                                <Label Text="Ao passar do limite de versões, a mais antiga é apagada. A versão mais recente nunca é apagada."
+                                       TextColor="{StaticResource TextSecondaryDark}" FontSize="12"
+                                       IsVisible="{Binding IsBackupRetentionByCount}" />
+                                <Label Text="Backups mais antigos que o limite escolhido são apagados. A versão mais recente nunca é apagada."
+                                       TextColor="{StaticResource TextSecondaryDark}" FontSize="12"
+                                       IsVisible="{Binding IsBackupRetentionByDays}" />
+                            </VerticalStackLayout>
+
+                            <Button Text="Salvar backups" Style="{StaticResource PrimaryActionButtonStyle}" HeightRequest="46"
+                                    Command="{Binding SaveProtectionsCommand}" IsEnabled="{Binding CanInteract}" />
+
+                        </VerticalStackLayout>
+                    </Border>
+
+                    <!-- Bloco 4: trocar senha mestra -->
                     <Border Style="{StaticResource CardBorderStyle}" Padding="22" StrokeShape="RoundRectangle 20">
                         <VerticalStackLayout Spacing="14">
 

--- a/tests/GDSB.Infrastructure.Tests/Backup/FileSystemVaultBackupStoreTests.cs
+++ b/tests/GDSB.Infrastructure.Tests/Backup/FileSystemVaultBackupStoreTests.cs
@@ -10,12 +10,18 @@ namespace GDSB.Infrastructure.Tests.Backup
         private const string Origin = "content://fake-vault";
         private const string VaultName = "Cofre de teste";
 
+        private static readonly BackupRetentionPolicy DefaultRetention = new(BackupRetentionMode.Count, 10, 5);
+
         private readonly string _root = Path.Combine(Path.GetTempPath(), $"gdsb-backups-{Guid.NewGuid():N}");
         private readonly FileSystemVaultBackupStore _sut;
 
+        // Relógio falso, avançado manualmente entre saves - é o que torna determinístico tanto o
+        // "timestamps distintos" (poda por quantidade) quanto a poda por dias.
+        private DateTime _now = new(2026, 9, 2, 12, 0, 0, DateTimeKind.Utc);
+
         public FileSystemVaultBackupStoreTests()
         {
-            _sut = new FileSystemVaultBackupStore(_root);
+            _sut = new FileSystemVaultBackupStore(_root, () => _now);
         }
 
         public void Dispose()
@@ -26,22 +32,98 @@ namespace GDSB.Infrastructure.Tests.Backup
 
         private static byte[] Bytes(string text) => Encoding.UTF8.GetBytes(text);
 
+        private void Tick(int seconds = 1) => _now = _now.AddSeconds(seconds);
+
         [Fact]
-        public void Store_Rolling_OverwritesPreviousBackup()
+        public void Store_Rolling_AccumulatesVersionsInsteadOfOverwriting()
         {
-            _sut.Store(Origin, VaultName, Bytes("versão 1"), VaultBackupKind.Rolling);
-            var second = _sut.Store(Origin, VaultName, Bytes("versão 2"), VaultBackupKind.Rolling);
+            var first = _sut.Store(Origin, VaultName, Bytes("versão 1"), VaultBackupKind.Rolling, DefaultRetention);
+            Tick();
+            var second = _sut.Store(Origin, VaultName, Bytes("versão 2"), VaultBackupKind.Rolling, DefaultRetention);
+
+            var backups = _sut.List();
+
+            Assert.Equal(2, backups.Count);
+            Assert.NotEqual(first.Id, second.Id);
+            Assert.Equal("versão 1", Encoding.UTF8.GetString(_sut.Read(first)));
+            Assert.Equal("versão 2", Encoding.UTF8.GetString(_sut.Read(second)));
+        }
+
+        [Fact]
+        public void Store_Rolling_SameSecondCollision_SuffixesTheFileName()
+        {
+            var first = _sut.Store(Origin, VaultName, Bytes("versão 1"), VaultBackupKind.Rolling, DefaultRetention);
+            var second = _sut.Store(Origin, VaultName, Bytes("versão 2"), VaultBackupKind.Rolling, DefaultRetention);
+
+            Assert.NotEqual(first.Id, second.Id);
+            Assert.Equal(2, _sut.List().Count);
+        }
+
+        [Fact]
+        public void Store_Rolling_CountMode_KeepsExactlyTheConfiguredNumberOfVersions()
+        {
+            var retention = new BackupRetentionPolicy(BackupRetentionMode.Count, 3, 5);
+
+            for (var i = 1; i <= 5; i++)
+            {
+                _sut.Store(Origin, VaultName, Bytes($"versão {i}"), VaultBackupKind.Rolling, retention);
+                Tick();
+            }
+
+            var backups = _sut.List();
+
+            Assert.Equal(3, backups.Count);
+            Assert.Equal(3, backups.Select(b => b.CreatedAtUtc).Distinct().Count());
+            Assert.DoesNotContain(backups, b => Encoding.UTF8.GetString(_sut.Read(b)) == "versão 1");
+            Assert.DoesNotContain(backups, b => Encoding.UTF8.GetString(_sut.Read(b)) == "versão 2");
+            Assert.Contains(backups, b => Encoding.UTF8.GetString(_sut.Read(b)) == "versão 5");
+        }
+
+        [Fact]
+        public void Store_Rolling_DaysMode_PrunesVersionsOlderThanTheLimit()
+        {
+            var retention = new BackupRetentionPolicy(BackupRetentionMode.Days, 10, 5);
+
+            _sut.Store(Origin, VaultName, Bytes("antigo"), VaultBackupKind.Rolling, retention);
+            _now = _now.AddDays(6);
+            var recent = _sut.Store(Origin, VaultName, Bytes("recente"), VaultBackupKind.Rolling, retention);
 
             var backup = Assert.Single(_sut.List());
-            Assert.Equal(second.Id, backup.Id);
-            Assert.Equal("versão 2", Encoding.UTF8.GetString(_sut.Read(backup)));
+            Assert.Equal(recent.Id, backup.Id);
+        }
+
+        [Fact]
+        public void Store_Rolling_DaysMode_StillRespectsHardCeiling()
+        {
+            var retention = new BackupRetentionPolicy(BackupRetentionMode.Days, 10, 36500);
+
+            for (var i = 0; i < BackupRetentionPolicy.HardCeiling + 5; i++)
+            {
+                _sut.Store(Origin, VaultName, Bytes($"versão {i}"), VaultBackupKind.Rolling, retention);
+                Tick();
+            }
+
+            Assert.Equal(BackupRetentionPolicy.HardCeiling, _sut.List().Count);
+        }
+
+        [Fact]
+        public void Store_Rolling_NeverPrunesTheMostRecentVersion_EvenWhenPolicyWouldDeleteEverything()
+        {
+            var retention = new BackupRetentionPolicy(BackupRetentionMode.Count, 0, 5);
+
+            _sut.Store(Origin, VaultName, Bytes("v1"), VaultBackupKind.Rolling, retention);
+            Tick();
+            var latest = _sut.Store(Origin, VaultName, Bytes("v2"), VaultBackupKind.Rolling, retention);
+
+            var backup = Assert.Single(_sut.List());
+            Assert.Equal(latest.Id, backup.Id);
         }
 
         [Fact]
         public void Store_LegacyV1_NeverOverwritesExistingBackup()
         {
-            var first = _sut.Store(Origin, VaultName, Bytes("original v1"), VaultBackupKind.LegacyV1);
-            _sut.Store(Origin, VaultName, Bytes("tentativa de sobrescrever"), VaultBackupKind.LegacyV1);
+            var first = _sut.Store(Origin, VaultName, Bytes("original v1"), VaultBackupKind.LegacyV1, DefaultRetention);
+            _sut.Store(Origin, VaultName, Bytes("tentativa de sobrescrever"), VaultBackupKind.LegacyV1, DefaultRetention);
 
             var backup = Assert.Single(_sut.List());
             Assert.Equal(first.Id, backup.Id);
@@ -49,9 +131,27 @@ namespace GDSB.Infrastructure.Tests.Backup
         }
 
         [Fact]
+        public void Store_LegacyV1_IsNeverPrunedAndDoesNotCountTowardRollingRetention()
+        {
+            var retention = new BackupRetentionPolicy(BackupRetentionMode.Count, 1, 5);
+
+            var legacy = _sut.Store(Origin, VaultName, Bytes("original v1"), VaultBackupKind.LegacyV1, retention);
+            _sut.Store(Origin, VaultName, Bytes("rolling 1"), VaultBackupKind.Rolling, retention);
+            Tick();
+            _sut.Store(Origin, VaultName, Bytes("rolling 2"), VaultBackupKind.Rolling, retention);
+
+            var backups = _sut.List();
+
+            Assert.Equal(2, backups.Count);
+            Assert.Contains(backups, b => b.Id == legacy.Id);
+            Assert.Contains(backups, b => b.Kind == VaultBackupKind.Rolling
+                && Encoding.UTF8.GetString(_sut.Read(b)) == "rolling 2");
+        }
+
+        [Fact]
         public void List_ReturnsReadableNameAndOrigin()
         {
-            _sut.Store(Origin, VaultName, Bytes("conteúdo"), VaultBackupKind.Rolling);
+            _sut.Store(Origin, VaultName, Bytes("conteúdo"), VaultBackupKind.Rolling, DefaultRetention);
 
             var backup = Assert.Single(_sut.List());
             Assert.Equal(Origin, backup.OriginLocation);
@@ -63,8 +163,8 @@ namespace GDSB.Infrastructure.Tests.Backup
         [Fact]
         public void List_ReturnsBothKindsForSameOrigin()
         {
-            _sut.Store(Origin, VaultName, Bytes("rolling"), VaultBackupKind.Rolling);
-            _sut.Store(Origin, VaultName, Bytes("legacy"), VaultBackupKind.LegacyV1);
+            _sut.Store(Origin, VaultName, Bytes("rolling"), VaultBackupKind.Rolling, DefaultRetention);
+            _sut.Store(Origin, VaultName, Bytes("legacy"), VaultBackupKind.LegacyV1, DefaultRetention);
 
             var backups = _sut.List();
 
@@ -76,8 +176,8 @@ namespace GDSB.Infrastructure.Tests.Backup
         [Fact]
         public void Delete_RemovesOnlyThatBackup()
         {
-            _sut.Store(Origin, VaultName, Bytes("rolling"), VaultBackupKind.Rolling);
-            var legacy = _sut.Store(Origin, VaultName, Bytes("legacy"), VaultBackupKind.LegacyV1);
+            _sut.Store(Origin, VaultName, Bytes("rolling"), VaultBackupKind.Rolling, DefaultRetention);
+            var legacy = _sut.Store(Origin, VaultName, Bytes("legacy"), VaultBackupKind.LegacyV1, DefaultRetention);
 
             _sut.Delete(legacy);
 
@@ -89,9 +189,9 @@ namespace GDSB.Infrastructure.Tests.Backup
         [Fact]
         public void DeleteAllFor_RemovesEveryBackupOfThatOrigin()
         {
-            _sut.Store(Origin, VaultName, Bytes("rolling"), VaultBackupKind.Rolling);
-            _sut.Store(Origin, VaultName, Bytes("legacy"), VaultBackupKind.LegacyV1);
-            _sut.Store("content://other-vault", "Outro cofre", Bytes("outro"), VaultBackupKind.Rolling);
+            _sut.Store(Origin, VaultName, Bytes("rolling"), VaultBackupKind.Rolling, DefaultRetention);
+            _sut.Store(Origin, VaultName, Bytes("legacy"), VaultBackupKind.LegacyV1, DefaultRetention);
+            _sut.Store("content://other-vault", "Outro cofre", Bytes("outro"), VaultBackupKind.Rolling, DefaultRetention);
 
             _sut.DeleteAllFor(Origin);
 

--- a/tests/GDSB.Infrastructure.Tests/ProfileFileServiceTests.cs
+++ b/tests/GDSB.Infrastructure.Tests/ProfileFileServiceTests.cs
@@ -134,7 +134,7 @@ namespace GDSB.Infrastructure.Tests
         }
 
         [Fact]
-        public void Save_OverwritingV2File_CreatesRollingBakOfPreviousVersion()
+        public void Save_OverwritingV2File_AccumulatesRollingBakOfEachPreviousVersion()
         {
             var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.GDSBX");
             try
@@ -153,9 +153,42 @@ namespace GDSB.Infrastructure.Tests
                 profile.Boxes[0].BoxName = "Netflix (editado de novo)";
                 _sut.Save(path, profile, Password);
 
-                var backupAgain = Assert.Single(_backupStore.List(), b => b.OriginLocation == path);
-                var backedUpAgain = _sut.Open(backupAgain.Id, Password);
-                Assert.Equal("Netflix (editado)", backedUpAgain.Profile.Boxes[0].BoxName);
+                // Rolling agora acumula uma versão por save (dentro do limite de retenção
+                // default, Count=10) em vez de sobrescrever a anterior.
+                var backups = _backupStore.List().Where(b => b.OriginLocation == path).ToList();
+                Assert.Equal(2, backups.Count);
+                Assert.Contains(backups, b => _sut.Open(b.Id, Password).Profile.Boxes[0].BoxName == "Netflix");
+                Assert.Contains(backups, b => _sut.Open(b.Id, Password).Profile.Boxes[0].BoxName == "Netflix (editado)");
+            }
+            finally
+            {
+                File.Delete(path);
+                _backupStore.DeleteAllFor(path);
+            }
+        }
+
+        [Fact]
+        public void Save_PrunesRollingBackupsUsingRetentionFromProfileSettings()
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.GDSBX");
+            try
+            {
+                var profile = CreateSampleProfile();
+                profile.Settings.BackupRetentionMode = BackupRetentionMode.Count;
+                profile.Settings.BackupRetentionCount = 1;
+
+                _sut.Save(path, profile, Password);
+
+                profile.Boxes[0].BoxName = "Netflix (editado)";
+                _sut.Save(path, profile, Password);
+
+                profile.Boxes[0].BoxName = "Netflix (editado de novo)";
+                _sut.Save(path, profile, Password);
+
+                var rollingBackups = _backupStore.List()
+                    .Where(b => b.OriginLocation == path && b.Kind == VaultBackupKind.Rolling)
+                    .ToList();
+                Assert.Single(rollingBackups);
             }
             finally
             {

--- a/tests/GDSB.MAUI.Tests/CreateVaultViewModelTests.cs
+++ b/tests/GDSB.MAUI.Tests/CreateVaultViewModelTests.cs
@@ -1,3 +1,4 @@
+using GDSB.Domain.Entities;
 using GDSB.MAUI.Tests.Fakes;
 using GDSB.MAUI.ViewModels;
 using Xunit;
@@ -119,6 +120,69 @@ namespace GDSB.MAUI.Tests
             sut.ViewModel.SelectAutoLockMinutesCommand.Execute("15");
 
             Assert.Equal(15, sut.ViewModel.AutoLockMinutes);
+        }
+
+        [Fact]
+        public void NewViewModel_DefaultsToCountAndTen()
+        {
+            var sut = new Sut();
+
+            Assert.Equal(BackupRetentionMode.Count, sut.ViewModel.BackupRetentionMode);
+            Assert.Equal(10, sut.ViewModel.BackupRetentionCount);
+            Assert.Equal(5, sut.ViewModel.BackupRetentionDays);
+            Assert.True(sut.ViewModel.IsBackupRetentionByCount);
+            Assert.False(sut.ViewModel.IsBackupRetentionByDays);
+        }
+
+        [Fact]
+        public void SelectBackupRetentionCountCommand_ParsesStringParameter()
+        {
+            var sut = new Sut();
+
+            sut.ViewModel.SelectBackupRetentionCountCommand.Execute("50");
+
+            Assert.Equal(50, sut.ViewModel.BackupRetentionCount);
+        }
+
+        [Fact]
+        public void SelectBackupRetentionDaysCommand_ParsesStringParameter()
+        {
+            var sut = new Sut();
+
+            sut.ViewModel.SelectBackupRetentionDaysCommand.Execute("30");
+
+            Assert.Equal(30, sut.ViewModel.BackupRetentionDays);
+        }
+
+        [Fact]
+        public void SelectBackupRetentionModeDaysCommand_SwitchesModeAndFlipsVisibilityFlags()
+        {
+            var sut = new Sut();
+
+            sut.ViewModel.SelectBackupRetentionModeDaysCommand.Execute(null);
+
+            Assert.Equal(BackupRetentionMode.Days, sut.ViewModel.BackupRetentionMode);
+            Assert.False(sut.ViewModel.IsBackupRetentionByCount);
+            Assert.True(sut.ViewModel.IsBackupRetentionByDays);
+        }
+
+        [Fact]
+        public async Task CreateVaultAsync_Success_BackupRetentionReachesSavedProfile()
+        {
+            const string sampleUnlockCode = "senha12345";
+
+            var sut = new Sut();
+            sut.ViewModel.VaultName = "Meu Cofre";
+            sut.ViewModel.Password = sampleUnlockCode;
+            sut.ViewModel.ConfirmPassword = sampleUnlockCode;
+            sut.ViewModel.SelectBackupRetentionModeDaysCommand.Execute(null);
+            sut.ViewModel.SelectBackupRetentionDaysCommand.Execute("30");
+
+            await sut.ViewModel.CreateVaultCommand.ExecuteAsync(null);
+
+            var save = Assert.Single(sut.ProfileFileService.SaveCalls);
+            Assert.Equal(BackupRetentionMode.Days, save.Profile.Settings.BackupRetentionMode);
+            Assert.Equal(30, save.Profile.Settings.BackupRetentionDays);
         }
     }
 }

--- a/tests/GDSB.MAUI.Tests/Fakes/FakeVaultBackupStore.cs
+++ b/tests/GDSB.MAUI.Tests/Fakes/FakeVaultBackupStore.cs
@@ -9,7 +9,7 @@ namespace GDSB.MAUI.Tests.Fakes
 
         public List<string> DeleteAllForCalls { get; } = new();
 
-        public VaultBackupInfo Store(string originLocation, string vaultName, byte[] previousBytes, VaultBackupKind kind)
+        public VaultBackupInfo Store(string originLocation, string vaultName, byte[] previousBytes, VaultBackupKind kind, BackupRetentionPolicy? retention = null)
         {
             var info = new VaultBackupInfo(
                 Id: $"{originLocation}::backup",

--- a/tests/GDSB.MAUI.Tests/VaultSettingsViewModelTests.cs
+++ b/tests/GDSB.MAUI.Tests/VaultSettingsViewModelTests.cs
@@ -103,12 +103,62 @@ namespace GDSB.MAUI.Tests
         }
 
         [Fact]
+        public void SelectBackupRetentionCountCommand_ParsesStringParameter()
+        {
+            var sut = new Sut();
+
+            sut.ViewModel.SelectBackupRetentionCountCommand.Execute("20");
+
+            Assert.Equal(20, sut.ViewModel.BackupRetentionCount);
+        }
+
+        [Fact]
+        public void SelectBackupRetentionDaysCommand_ParsesStringParameter()
+        {
+            var sut = new Sut();
+
+            sut.ViewModel.SelectBackupRetentionDaysCommand.Execute("15");
+
+            Assert.Equal(15, sut.ViewModel.BackupRetentionDays);
+        }
+
+        [Fact]
+        public void SelectBackupRetentionModeCommands_SwitchModeAndFlipVisibilityFlags()
+        {
+            var sut = new Sut();
+
+            sut.ViewModel.SelectBackupRetentionModeDaysCommand.Execute(null);
+            Assert.Equal(BackupRetentionMode.Days, sut.ViewModel.BackupRetentionMode);
+            Assert.False(sut.ViewModel.IsBackupRetentionByCount);
+            Assert.True(sut.ViewModel.IsBackupRetentionByDays);
+
+            sut.ViewModel.SelectBackupRetentionModeCountCommand.Execute(null);
+            Assert.Equal(BackupRetentionMode.Count, sut.ViewModel.BackupRetentionMode);
+            Assert.True(sut.ViewModel.IsBackupRetentionByCount);
+            Assert.False(sut.ViewModel.IsBackupRetentionByDays);
+        }
+
+        [Fact]
+        public void Load_OldVaultWithoutBackupRetentionKey_OpensWithCountAndDefaultOf10()
+        {
+            var sut = new Sut();
+
+            sut.Load();
+
+            Assert.Equal(BackupRetentionMode.Count, sut.ViewModel.BackupRetentionMode);
+            Assert.Equal(10, sut.ViewModel.BackupRetentionCount);
+            Assert.Equal(5, sut.ViewModel.BackupRetentionDays);
+        }
+
+        [Fact]
         public async Task SaveProtectionsAsync_SavesCurrentFileAndStartsSession_WithoutOffer()
         {
             var sut = new Sut();
             sut.Load();
             sut.ViewModel.ClipboardClearEnabled = false;
             sut.ViewModel.AutoLockMinutes = 15;
+            sut.ViewModel.SelectBackupRetentionModeDaysCommand.Execute(null);
+            sut.ViewModel.BackupRetentionDays = 15;
             var settingsSavedCount = 0;
             sut.ViewModel.SettingsSaved += (_, _) => settingsSavedCount++;
 
@@ -118,6 +168,8 @@ namespace GDSB.MAUI.Tests
             Assert.Equal(Location, save.Location);
             Assert.False(save.Profile.Settings.ClipboardClearEnabled);
             Assert.Equal(15, save.Profile.Settings.AutoLockMinutes);
+            Assert.Equal(BackupRetentionMode.Days, save.Profile.Settings.BackupRetentionMode);
+            Assert.Equal(15, save.Profile.Settings.BackupRetentionDays);
             Assert.Same(save.Profile.Settings, sut.VaultSessionService.Settings);
             Assert.False(sut.ViewModel.ShowSaveAsNewFileOffer);
             Assert.Equal(1, settingsSavedCount);


### PR DESCRIPTION
## Resumo

Fases 1 e 2 da rodada descrita em `claude-context.md` (frente "Backups versionados"), feitas
juntas neste PR a pedido do usuário, já que se complementam: a configuração nova nas telas (fase
2) depende diretamente do domínio criado na fase 1. Inclui também uma correção de duplicação de
código pedida depois pelo usuário, ao ver o Quality Gate do SonarCloud falhar.

### Fase 1 — Retenção no domínio e no store

- `BackupRetentionPolicy` (novo): `Mode` (`Count` | `Days`), `Count`, `Days`, com
  `HardCeiling = 100` e `From(VaultSettings)`.
- `VaultSettings` ganha três propriedades com default por inicializador (`Count` / 10 versões /
  5 dias) — um cofre v2 antigo sem a chave no JSON abre nesses valores.
- `IVaultBackupStore.Store` ganha o parâmetro `BackupRetentionPolicy retention`.
- `FileSystemVaultBackupStore`: backups `Rolling` passam a acumular uma versão por save (nome com
  timestamp, colisão no mesmo segundo resolvida com sufixo `(2)`, `(3)`...) em vez de sobrescrever
  o único arquivo anterior. Poda automática logo após cada `Store`: só `Rolling` conta,
  `LegacyV1` nunca é podado; teto rígido de 100 arquivos nos dois modos; a versão mais recente
  nunca é apagada; limpa entradas órfãs do `meta.json`.
- `ProfileFileService.Save` deriva a retenção de `profile.Settings` a cada save — baixar o limite
  na tela de edição já poda no save seguinte, sem método de "aplicar agora".
- Correção de Sonar (New Code): o `for(;;)` de colisão de nome virou `while (true)` com
  `attempt++` explícito, já que a saída real é o `return` interno, não a condição do laço.

### Fase 2 — Bloco BACKUPS nas telas

- `VaultSettingsViewModel`/`CreateVaultViewModel` ganham `BackupRetentionMode/Count/Days` como
  `[ObservableProperty]`, comandos de seleção (parâmetro `string`, convertido dentro — o
  `CommandParameter` do XAML sempre chega como string) e os booleanos
  `IsBackupRetentionByCount`/`ByDays` que os chips e o texto de apoio usam.
- `VaultSettingsPage.xaml`: card novo "BACKUPS" entre PROTEÇÕES e TROCAR SENHA MESTRA, com botão
  próprio "Salvar backups" ligado ao `SaveProtectionsCommand` já existente — grava direto, sem a
  oferta de "salvar como arquivo novo" (não mexe no ponto de desbloqueio).
- `CreateVaultPage.xaml`: o mesmo bloco, dentro do card PROTEÇÕES que já existe ali.
- UI: dois chips de modo (Por quantidade / Por tempo); só o conjunto do modo ativo fica visível
  (5/10/20/50 versões ou 3/5/15/30 dias); texto de apoio abaixo explicando a poda.

### Correção de duplicação de código (Quality Gate: 4.6% > 3% em New Code)

O bloco `Button.Triggers` + `DataTrigger` + 3 `Setter` (destacar um chip quando um valor bate) se
repetia ~38 vezes entre `VaultPage`, `VaultSettingsPage` e `CreateVaultPage` — a maior fonte de
duplicação. Substituído por dois componentes reutilizáveis:

- `Controls.SelectableChip`: subclasse de `Button` com a bindable `IsSelected`, que aplica o
  destaque em C# (lendo `Application.Current.Resources`) via `ClearValue`/atribuição direta —
  `BindableObject.SetDynamicResource`/`RemoveDynamicResource` são internos ao assembly do MAUI,
  não servem daqui (conferido nos metadados do assembly). `FilterChipStyle` ganhou
  `ApplyToDerivedTypes="True"` pra continuar valendo pro subtipo.
- `Converters.EqualsConverter`, registrado globalmente em `App.xaml`: compara o valor bindado com
  o `ConverterParameter` do chip.

Cada `<Button>` + `Triggers` + `DataTrigger` virou uma linha de `<controls:SelectableChip
IsSelected="{Binding X, Converter=..., ConverterParameter=N}" />`. Os dois botões de estrela de
favorito em `VaultPage` (padrão de cor diferente) ficaram fora do escopo.

Também extraída `VaultProtectionsFormViewModelBase`, com os campos e comandos do bloco
PROTEÇÕES/BACKUPS que `VaultSettingsViewModel` e `CreateVaultViewModel` duplicavam integralmente
desde a fase 2 — `SaveProtectionsAsync`/`CreateVaultAsync` continuam em cada ViewModel, já que
fazem coisas diferentes com esses valores.

## Testes

- `FileSystemVaultBackupStoreTests`, `ProfileFileServiceTests`, `VaultSettingsViewModelTests`,
  `CreateVaultViewModelTests`: cobrem a retenção (poda por quantidade/dias, teto, piso, LegacyV1
  intocado) e os comandos/estado do bloco BACKUPS nas duas telas.
- `dotnet test tests/GDSB.Infrastructure.Tests` — 27 testes, todos verdes.
- `dotnet test tests/GDSB.MAUI.Tests` — 77 testes, todos verdes.
- XAML validado como XML bem-formado (`xmllint`); API pública usada por `SelectableChip`
  conferida direto nos metadados do assembly `Microsoft.Maui.Controls`. Build Android completo
  não foi possível validar neste ambiente (sem SDK Android nem rede pro workload MAUI).

## Pronto quando (do plano)

- [x] Fase 1: as duas suítes passam; um cofre salvo 5 vezes com `Count=3` deixa exatamente 3
  arquivos com timestamps distintos no store.
- [x] Fase 2: trocar o limite na tela de edição e salvar altera o `Profile.Settings` gravado
  dentro do arquivo, e a poda seguinte respeita o valor novo; um cofre antigo sem a chave no JSON
  abre a tela com Por quantidade / 10; testes em `VaultSettingsViewModelTests` e
  `CreateVaultViewModelTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bvPZ6LDdmTi5J2cU8mSPM