### PR TITLE
Fases 3 a 7: primeiro acesso guiado, ajuda contextual e auditoria de permissões do Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ preservado como backup — nunca ao lado do cofre, ver "Backups" abaixo.
   recuperação, alcançada pela tela de desbloqueio ("Recuperar de um backup"), lista todos os
   backups e permite restaurar um deles para um arquivo novo (o cofre original nunca é sobrescrito)
   ou excluir backups, um por vez ou todos de uma vez.
+- **Histórico de backups com retenção configurável.** Cada gravação guarda uma versão nova (o nome
+  leva data e hora), em vez de sobrescrever sempre a mesma cópia. Quantas versões ficam é definido
+  **por cofre**, gravado dentro do próprio arquivo: "até N versões" ou "até N dias", com poda
+  automática ao passar do limite. A versão mais recente nunca é apagada, e os backups importados de
+  arquivos v1 nunca são podados. Há ainda um teto rígido de 100 arquivos por cofre, válido nos dois
+  modos.
+- **Primeiro acesso guiado.** Um tutorial de três slides aparece sozinho na primeira abertura e
+  continua acessível pelo link "Como funciona?", no topo da tela de desbloqueio. Ao lado das
+  funcionalidades que não se explicam sozinhas há um "?" que abre um painel no estilo do app — e
+  todo painel **mostra** o controle de que fala: uma réplica inerte do botão, campo ou chip em
+  questão, com um indicador de toque animado apontando onde tocar. Nos formulários, campo
+  obrigatório é marcado com asterisco em cor de destaque, com a legenda "* campos obrigatórios" no
+  fim do bloco; campo opcional não recebe marca nenhuma.
 - **Edição de cofre.** Uma tela própria (ícone de engrenagem no cabeçalho do cofre) permite
   renomear o cofre e trocar a senha mestra — as duas únicas mudanças que afetam o ponto de
   desbloqueio, então, depois de gravar no arquivo atual, a tela oferece salvar também num arquivo
@@ -65,7 +78,8 @@ preservado como backup — nunca ao lado do cofre, ver "Backups" abaixo.
   como alternativa.
 - Layout responsivo: lista + bottom-sheet no celular, mestre-detalhe lado a lado no tablet.
 - No Android, acesso a arquivo via Storage Access Framework, permitindo cofres sincronizados por
-  provedores como Google Drive ou OneDrive.
+  provedores como Google Drive ou OneDrive. Como o SAF dispensa permissão de armazenamento e o app
+  é offline por inteiro, o manifesto declara **uma única** permissão: `USE_BIOMETRIC`.
 
 ## Build e testes
 

--- a/claude-context.md
+++ b/claude-context.md
@@ -126,11 +126,14 @@ explicar — na ordem inversa, as mesmas telas seriam reabertas duas vezes.
 | 0 | Contexto e plano (este arquivo + artifact) | — | — | ✅ Concluída | — |
 | 1 | Retenção no domínio e no store | Backups | — | ✅ Concluída | [#19](https://github.com/betinn/GDSB.MAUI/pull/19) |
 | 2 | Bloco BACKUPS nas telas | Backups | 1 | ✅ Concluída | [#19](https://github.com/betinn/GDSB.MAUI/pull/19) |
-| 3 | Infra de ajuda e obrigatoriedade | Onboarding | — | ⬜ A fazer | — |
-| 4 | Tutorial de primeiro acesso | Onboarding | 3 | ⬜ A fazer | — |
-| 5 | Cofre novo e segredo novo | Onboarding | 2, 3 | ⬜ A fazer | — |
-| 6 | Backup e edição do cofre | Onboarding | 2, 3 | ⬜ A fazer | — |
-| 7 | Fechamento (README, contexto, testes, build) | — | todas | ⬜ A fazer | — |
+| 3 | Infra de ajuda e obrigatoriedade | Onboarding | — | ✅ Concluída | [#20](https://github.com/betinn/GDSB.MAUI/pull/20) |
+| 4 | Tutorial de primeiro acesso | Onboarding | 3 | ✅ Concluída | [#20](https://github.com/betinn/GDSB.MAUI/pull/20) |
+| 5 | Cofre novo e segredo novo | Onboarding | 2, 3 | ✅ Concluída | [#20](https://github.com/betinn/GDSB.MAUI/pull/20) |
+| 6 | Backup e edição do cofre | Onboarding | 2, 3 | ✅ Concluída | [#20](https://github.com/betinn/GDSB.MAUI/pull/20) |
+| 7 | Fechamento (README, contexto, testes, build) | — | todas | ✅ Concluída | [#20](https://github.com/betinn/GDSB.MAUI/pull/20) |
+
+**Rodada encerrada.** Todas as sete fases estão fechadas. Uma rodada nova começa por um
+`claude-context.md` novo e um artifact de plano novo, como as anteriores.
 
 Dependências:
 
@@ -143,9 +146,22 @@ Dependências:
 As fases **1** e **3** não dependem de nada e podem ser feitas em paralelo, em sessões diferentes.
 As fases 5 e 6 só abrem depois de 2 e 3, porque as duas colocam um "?" na sessão `BACKUPS`.
 
-**Exceção já usada:** as fases 1 e 2 foram implementadas e mergeadas juntas no PR #19, a pedido
-explícito do usuário ("elas se complementam"). A regra de "um PR por fase" (seção "Como
-trabalhar") continua valendo por padrão — só quebre de novo se o usuário pedir.
+**Exceções já usadas:** as fases 1 e 2 foram implementadas e mergeadas juntas no PR #19, a pedido
+explícito do usuário ("elas se complementam"); as fases 3 a 7 saíram juntas no PR #20, também a
+pedido explícito ("em vez de você fazer só a próxima fase, quero que faça todas as fases até a
+finalização da feature completa") - e por isso o PR #20 sai da branch `claude/...` designada, em
+vez de uma `fase-<N>-<nome>`. A regra de "um PR por fase" e a de nomenclatura de branch (seção
+"Como trabalhar") continuam valendo por padrão - só quebre de novo se o usuário pedir.
+
+**Auditoria de permissões do Android (PR #20).** Feita a pedido do usuário, de olho na publicação
+na Play Store. O manifesto passou a declarar **uma única** permissão, `USE_BIOMETRIC`; saíram
+`READ_EXTERNAL_STORAGE`, `WRITE_EXTERNAL_STORAGE`, `INTERNET` e `ACCESS_NETWORK_STATE`, nenhuma
+com uso no código (o acesso a arquivo é 100% Storage Access Framework e o app é offline por
+inteiro), junto com o `RequestStoragePermissions()` do `MainActivity` que as pedia na primeira
+abertura. **Regra permanente:** nada de declarar permissão "por precaução" - cada uma precisa de um
+uso demonstrável no código, senão vira justificativa a dar na Play Console. As injetadas por
+biblioteca (`USE_FINGERPRINT` da AndroidX.Biometric, `DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION` da
+AndroidX.Core) foram mantidas e conferidas nos `.aar` dos pacotes restaurados.
 
 ### Decisões já fechadas com o usuário
 
@@ -282,6 +298,16 @@ espelham os mesmos campos de PROTEÇÕES/BACKUPS) — resolvida com a classe bas
 propriedades `[ObservableProperty]`, as listas de opções `static` e os comandos `Select*`
 compartilhados. `SaveProtectionsAsync`/`CreateVaultAsync` continuam em cada ViewModel — fazem
 coisas fundamentalmente diferentes com esses valores, não são candidatos a extração.
+
+### Limitação de rede deste ambiente (Claude Code na web)
+
+A política de egress bloqueia `dl.google.com` e `builds.dotnet.microsoft.com` (403 no proxy), então
+**o Android SDK não pode ser instalado aqui e o alvo `net10.0-android` não compila** (para em
+`XA5300`). O SDK do .NET 10 vem do apt (`apt-get update && apt-get install -y dotnet-sdk-10.0`) e o
+workload MAUI restaura normalmente, então `dotnet test` e o build dos projetos `net10.0` funcionam -
+mas **a compilação do XAML só é validada pelo job `build-android` do CI**. Não tente contornar o
+bloqueio; conte com o CI e compense com verificação estática (XML bem formado, todo
+`{StaticResource}` resolvendo, ids de ajuda batendo com o catálogo) antes do push.
 
 ## Como manter este arquivo
 

--- a/claude-context.md
+++ b/claude-context.md
@@ -263,6 +263,10 @@ gerados por source generator (o `[ObservableProperty]` do CommunityToolkit.Mvvm 
   "todo id") vira um apontamento cada. É provavelmente a armadilha mais fácil de cair neste
   repositório, já que os comentários são todos em português. Escreva "cada" ou reformule; "toda",
   "todos" e "todas" não disparam, só a forma exata "todo".
+- **S1125 "Remove the unnecessary Boolean literal"**: `Application.Current?.Resources.TryGetValue(...) == true`
+  é flagado, mesmo o `== true` sendo o que destrincha o `bool?` que o acesso condicional produz. O
+  desenho que o projeto já usa e que não dispara nada está em `SelectableChip.ResourceColor`:
+  guardar `Application.Current?.Resources` numa variável e testar `resources is not null && ...`.
 - **Como ver os apontamentos sem o SonarCloud.** `sonarcloud.io` é bloqueado pela rede deste
   ambiente, mas o pacote `SonarAnalyzer.CSharp` vem do nuget.org normalmente. Um
   `Directory.Build.props` temporário na raiz com
@@ -272,6 +276,11 @@ gerados por source generator (o `[ObservableProperty]` do CommunityToolkit.Mvvm 
   montar um projeto `net10.0` de scratch que inclui os `.cs` de verdade por caminho absoluto mais
   um arquivo de stubs com os campos que o `InitializeComponent()` geraria - foi assim que a
   varredura desta rodada cobriu os code-behinds.
+  **Atenção ao limite disso:** o perfil padrão do pacote NuGet é mais estreito que o "Sonar way" do
+  SonarCloud. Nesta rodada, as três últimas issues (S2325 em `OnboardingViewModel.ShowFromStart` e
+  duas S1125 em `HelpSheetView`) **não apareceram** no analisador local, só no SonarCloud. Ou seja:
+  local limpo reduz muito o ruído, mas não substitui a leitura da aba "Issues" do PR - que, com o
+  `sonarcloud.io` bloqueado, precisa ser colada pelo usuário.
 - Bloco `catch (Exception) { }` vazio sem tratamento: preencha com um comentário de uma linha
   explicando por que ignorar é intencional (regra de "empty block"/"handle the exception").
 - `CommandParameter` de `Button`/etc. no XAML sempre chega como `string` ao `ICommand` ligado, não

--- a/claude-context.md
+++ b/claude-context.md
@@ -258,6 +258,20 @@ gerados por source generator (o `[ObservableProperty]` do CommunityToolkit.Mvvm 
   `static` sem quebrar o binding/o comportamento; a correção é suprimir com
   `#pragma warning disable S2325` / `restore S2325` em volta do trecho, com um comentário curto
   explicando o porquê (não usar `[SuppressMessage]` nem desabilitar a regra no projeto inteiro).
+- **S1135 "Complete the task associated to this 'TODO' comment"**: a regra procura a palavra
+  `TODO` isolada e **não distingue idioma** - o português "todo" (em "todo painel", "todo tópico",
+  "todo id") vira um apontamento cada. É provavelmente a armadilha mais fácil de cair neste
+  repositório, já que os comentários são todos em português. Escreva "cada" ou reformule; "toda",
+  "todos" e "todas" não disparam, só a forma exata "todo".
+- **Como ver os apontamentos sem o SonarCloud.** `sonarcloud.io` é bloqueado pela rede deste
+  ambiente, mas o pacote `SonarAnalyzer.CSharp` vem do nuget.org normalmente. Um
+  `Directory.Build.props` temporário na raiz com
+  `<PackageReference Include="SonarAnalyzer.CSharp" Version="*" PrivateAssets="all" />` faz o
+  `dotnet build` cuspir os mesmos `warning S####`, com arquivo e linha. **Apague o arquivo antes de
+  commitar.** Para o projeto `src/GDSB.MAUI`, que não compila aqui (sem Android SDK), dá para
+  montar um projeto `net10.0` de scratch que inclui os `.cs` de verdade por caminho absoluto mais
+  um arquivo de stubs com os campos que o `InitializeComponent()` geraria - foi assim que a
+  varredura desta rodada cobriu os code-behinds.
 - Bloco `catch (Exception) { }` vazio sem tratamento: preencha com um comentário de uma linha
   explicando por que ignorar é intencional (regra de "empty block"/"handle the exception").
 - `CommandParameter` de `Button`/etc. no XAML sempre chega como `string` ao `ICommand` ligado, não

--- a/src/GDSB.MAUI.ViewModels/Help/HelpRequestedMessage.cs
+++ b/src/GDSB.MAUI.ViewModels/Help/HelpRequestedMessage.cs
@@ -1,0 +1,8 @@
+namespace GDSB.MAUI.Help
+{
+    // Publicada pelo botão "?" (FieldLabelView / HelpButton) e recebida pelo HelpSheetView da
+    // página que está aparecendo, via WeakReferenceMessenger do CommunityToolkit.Mvvm. Passar pelo
+    // messenger evita duas coisas ruins: percorrer a árvore visual atrás do painel e acoplar o
+    // ContentView do "?" à página que por acaso o hospeda.
+    public sealed record HelpRequestedMessage(string TopicId);
+}

--- a/src/GDSB.MAUI.ViewModels/Help/HelpTopic.cs
+++ b/src/GDSB.MAUI.ViewModels/Help/HelpTopic.cs
@@ -1,7 +1,7 @@
 namespace GDSB.MAUI.Help
 {
     // Um tópico de ajuda não é uma lista de parágrafos: é uma lista de blocos, porque a regra
-    // desta rodada é que todo painel MOSTRE o controle de que fala, não só o descreva. Um painel
+    // desta rodada é que cada painel MOSTRE o controle de que fala, não só o descreva. Um painel
     // só de texto é considerado incompleto - HelpTopicsTests garante isso por teste, em vez de
     // depender de disciplina de quem escreve.
     public enum HelpBlockKind

--- a/src/GDSB.MAUI.ViewModels/Help/HelpTopic.cs
+++ b/src/GDSB.MAUI.ViewModels/Help/HelpTopic.cs
@@ -1,0 +1,32 @@
+namespace GDSB.MAUI.Help
+{
+    // Um tópico de ajuda não é uma lista de parágrafos: é uma lista de blocos, porque a regra
+    // desta rodada é que todo painel MOSTRE o controle de que fala, não só o descreva. Um painel
+    // só de texto é considerado incompleto - HelpTopicsTests garante isso por teste, em vez de
+    // depender de disciplina de quem escreve.
+    public enum HelpBlockKind
+    {
+        // Subtítulo. Existe porque um tópico pode cobrir uma tela inteira (o "?" único da tela de
+        // backup cobre quatro seções) e precisa se dividir.
+        Heading,
+
+        // Parágrafo em português leigo.
+        Text,
+
+        // Amostra visual: Value é uma chave declarada em HelpVisuals.Ids e Caption é a legenda
+        // curta que aparece abaixo da amostra.
+        Visual
+    }
+
+    public sealed record HelpBlock(HelpBlockKind Kind, string Value, string? Caption = null)
+    {
+        public static HelpBlock OfHeading(string text) => new(HelpBlockKind.Heading, text);
+
+        public static HelpBlock OfText(string text) => new(HelpBlockKind.Text, text);
+
+        public static HelpBlock OfVisual(string visualId, string caption) =>
+            new(HelpBlockKind.Visual, visualId, caption);
+    }
+
+    public sealed record HelpTopic(string Id, string Title, IReadOnlyList<HelpBlock> Blocks);
+}

--- a/src/GDSB.MAUI.ViewModels/Help/HelpTopics.cs
+++ b/src/GDSB.MAUI.ViewModels/Help/HelpTopics.cs
@@ -1,0 +1,258 @@
+namespace GDSB.MAUI.Help
+{
+    // Catálogo único de todo o texto de ajuda do app. Fica aqui, e não no XAML, por três motivos:
+    // a redação passa a ser revisável num arquivo só, o teste consegue cobri-la (ids existentes,
+    // sem duplicatas, todo tópico com pelo menos uma amostra visual) e a mesma explicação pode ser
+    // reaproveitada por telas diferentes - PROTEÇÕES e BACKUPS aparecem tanto na criação do cofre
+    // quanto na edição.
+    //
+    // Regra de redação: usuário final leigo. Nada de "criptografia", "hash", "instância" ou
+    // "persistir"; frases curtas, segunda pessoa, e sempre dizendo ONDE o controle está na tela.
+    //
+    // Os nomes de constante evitam de propósito as palavras "password"/"pwd"/"passphrase": a regra
+    // S2068 do Sonar flagra a declaração de qualquer campo com esses nomes e valor literal como
+    // "credencial no código", mesmo quando o valor é só um identificador. Mesmo motivo do
+    // VaultUnlockCode dos testes - ver claude-context.md.
+    public static class HelpTopics
+    {
+        public static class Ids
+        {
+            public const string MasterUnlockCode = "vault.masterUnlockCode";
+            public const string VaultName = "vault.name";
+            public const string VaultProtections = "vault.protections";
+            public const string VaultBackups = "vault.backups";
+            public const string ChangeMasterUnlockCode = "vault.changeMasterUnlockCode";
+            public const string SecretUrl = "secret.url";
+            public const string SecretStoredValue = "secret.storedValue";
+            public const string SecretFavorite = "secret.favorite";
+            public const string BackupRecovery = "backup.recovery";
+        }
+
+        public static IReadOnlyList<HelpTopic> All { get; } =
+        [
+            new HelpTopic(
+                Ids.MasterUnlockCode,
+                "A senha mestra",
+                [
+                    HelpBlock.OfText(
+                        "É a senha que abre este cofre. Ela não fica guardada em lugar nenhum: nem no app, " +
+                        "nem no seu celular, nem na internet. Por isso não existe \"esqueci minha senha\" " +
+                        "aqui - se você perder essa senha, ninguém consegue abrir o arquivo de novo, nem " +
+                        "você, nem quem fez o app."),
+                    HelpBlock.OfText(
+                        "Escolha algo que você lembre com folga e que ninguém adivinhe. O mínimo são 8 " +
+                        "caracteres, mas quanto mais longa, melhor."),
+                    HelpBlock.OfVisual(
+                        HelpVisuals.Ids.MasterUnlockCodeField,
+                        "É este campo. Toque nele e digite - as letras aparecem como pontinhos para " +
+                        "ninguém ler por cima do seu ombro."),
+                ]),
+
+            new HelpTopic(
+                Ids.VaultName,
+                "O nome do cofre",
+                [
+                    HelpBlock.OfText(
+                        "É o apelido que aparece dentro do app para você reconhecer este cofre. Trocar o " +
+                        "nome aqui não renomeia o arquivo que está salvo no seu celular ou na nuvem: o " +
+                        "arquivo continua com o nome de antes."),
+                    HelpBlock.OfText(
+                        "Por isso, depois de salvar um nome novo, o app oferece guardar também uma cópia " +
+                        "num arquivo novo. É opcional - se você recusar, está tudo certo, a mudança já foi " +
+                        "gravada no arquivo de sempre."),
+                    HelpBlock.OfVisual(
+                        HelpVisuals.Ids.SaveAsNewFileCard,
+                        "É este convite que aparece depois de salvar. Tocar em \"Salvar como novo arquivo\" " +
+                        "cria uma cópia e mantém o original intacto."),
+                ]),
+
+            new HelpTopic(
+                Ids.VaultProtections,
+                "Proteções do cofre",
+                [
+                    HelpBlock.OfHeading("Limpar a área de transferência"),
+                    HelpBlock.OfText(
+                        "Quando você copia uma senha, ela fica na memória de \"copiar e colar\" do celular e " +
+                        "qualquer outro aplicativo pode ler de lá. Com esta proteção ligada, o app apaga " +
+                        "esse valor sozinho depois do tempo que você escolher."),
+                    HelpBlock.OfHeading("Bloqueio automático"),
+                    HelpBlock.OfText(
+                        "Se você sair do app e demorar para voltar, ele fecha o cofre e pede a senha mestra " +
+                        "de novo. Serve para o caso de você deixar o celular na mesa e alguém pegar."),
+                    HelpBlock.OfVisual(
+                        HelpVisuals.Ids.ProtectionTimeChips,
+                        "Toque em um dos tempos para escolher. O que estiver colorido é o que está valendo."),
+                ]),
+
+            new HelpTopic(
+                Ids.VaultBackups,
+                "Backups automáticos",
+                [
+                    HelpBlock.OfText(
+                        "Toda vez que você salva alguma coisa, o app guarda antes uma cópia de como o cofre " +
+                        "estava. Assim, se você apagar um item sem querer, dá para voltar atrás."),
+                    HelpBlock.OfText(
+                        "Aqui você decide quantas dessas cópias ficam guardadas. \"Por quantidade\" guarda um " +
+                        "número fixo de versões. \"Por tempo\" guarda as dos últimos dias que você escolher. " +
+                        "A cópia mais recente nunca é apagada, aconteça o que acontecer."),
+                    HelpBlock.OfVisual(
+                        HelpVisuals.Ids.BackupModeChips,
+                        "Toque em \"Por quantidade\" ou \"Por tempo\" para escolher a regra. Logo abaixo " +
+                        "aparecem os valores disponíveis."),
+                ]),
+
+            new HelpTopic(
+                Ids.ChangeMasterUnlockCode,
+                "Trocar a senha mestra",
+                [
+                    HelpBlock.OfText(
+                        "Para trocar, o app pede a senha atual primeiro - é assim que ele confere que é " +
+                        "você mesmo. Depois da troca, é a senha nova que abre este cofre."),
+                    HelpBlock.OfText(
+                        "Atenção com os backups: as cópias guardadas antes da troca continuam presas à " +
+                        "senha antiga. Se um dia você precisar restaurar uma delas, é a senha antiga que " +
+                        "vai funcionar, não a nova. Por isso vale anotar a antiga em algum lugar seguro, " +
+                        "ou marcar a caixa que apaga essas cópias de uma vez."),
+                    HelpBlock.OfText(
+                        "Se você usa a digital para abrir o cofre, não precisa fazer nada: o app reconfigura " +
+                        "a biometria sozinho com a senha nova."),
+                    HelpBlock.OfVisual(
+                        HelpVisuals.Ids.DeleteOldBackupsCheck,
+                        "Marque esta caixa se você não quer guardar cópias que só abrem com a senha antiga."),
+                ]),
+
+            new HelpTopic(
+                Ids.SecretUrl,
+                "O endereço do site",
+                [
+                    HelpBlock.OfText(
+                        "É opcional, mas ajuda bastante: quando você preenche, o endereço vira um atalho no " +
+                        "cartão do item. Um toque e o site abre no navegador, sem você precisar digitar."),
+                    HelpBlock.OfText(
+                        "Pode escrever do jeito simples, como \"netflix.com\" - não precisa colocar o " +
+                        "\"https://\" na frente."),
+                    HelpBlock.OfVisual(
+                        HelpVisuals.Ids.SecretUrlLink,
+                        "Fica logo abaixo do nome do item, em rosa. Tocar nele abre o site."),
+                ]),
+
+            new HelpTopic(
+                Ids.SecretStoredValue,
+                "A senha guardada",
+                [
+                    HelpBlock.OfText(
+                        "É a senha daquele site ou aplicativo - a que você usaria para entrar. Ela fica " +
+                        "escondida atrás de pontinhos e só aparece quando você pede."),
+                    HelpBlock.OfText(
+                        "Na hora de usar, você tem duas opções: o olhinho mostra a senha na tela, e " +
+                        "\"Copiar\" manda ela direto para o \"colar\" do celular, sem precisar mostrar para " +
+                        "ninguém. Se a proteção de área de transferência estiver ligada, o app apaga o " +
+                        "valor copiado sozinho depois de alguns segundos."),
+                    HelpBlock.OfVisual(
+                        HelpVisuals.Ids.SecretValueActions,
+                        "São estes dois botões, no cartão da senha: o olhinho mostra, o \"Copiar\" copia."),
+                ]),
+
+            new HelpTopic(
+                Ids.SecretFavorite,
+                "Marcar como favorito",
+                [
+                    HelpBlock.OfText(
+                        "Favoritos sobem para o topo da lista e ganham uma estrelinha dourada. Serve para " +
+                        "os itens que você abre toda hora não se perderem no meio dos outros."),
+                    HelpBlock.OfText(
+                        "Não muda nada na segurança nem no conteúdo do item - é só uma forma de encontrar " +
+                        "mais rápido."),
+                    HelpBlock.OfVisual(
+                        HelpVisuals.Ids.FavoriteStar,
+                        "É esta estrelinha, que passa a aparecer no cartão do item na lista."),
+                ]),
+
+            new HelpTopic(
+                Ids.BackupRecovery,
+                "Recuperar um backup",
+                [
+                    HelpBlock.OfHeading("Como estas cópias aparecem aqui"),
+                    HelpBlock.OfText(
+                        "Toda vez que você salva algo no cofre, o app guarda antes uma cópia de como ele " +
+                        "estava. Essas cópias ficam numa pasta privada do aplicativo, nunca junto do seu " +
+                        "arquivo, para não bagunçar a sua pasta. Quantas ficam guardadas é o que você " +
+                        "escolheu em Editar cofre, na parte de Backups."),
+                    HelpBlock.OfVisual(
+                        HelpVisuals.Ids.BackupCard,
+                        "Cada cópia vira um cartão como este, com a data e a hora em que foi guardada."),
+
+                    HelpBlock.OfHeading("Restaurar"),
+                    HelpBlock.OfText(
+                        "Restaurar não mexe no seu cofre atual: o app cria um arquivo novo com o conteúdo " +
+                        "daquela cópia, e você escolhe depois qual dos dois quer abrir. O app vai pedir a " +
+                        "senha mestra da época daquela cópia - se ela for de antes de você trocar a senha, " +
+                        "é a senha antiga que funciona."),
+                    HelpBlock.OfVisual(
+                        HelpVisuals.Ids.RestoreButton,
+                        "É este botão, no rodapé de cada cartão."),
+
+                    HelpBlock.OfHeading("Excluir"),
+                    HelpBlock.OfText(
+                        "Apaga só aquela cópia da lista. Não dá para desfazer, e o seu cofre atual continua " +
+                        "intacto."),
+                    HelpBlock.OfVisual(
+                        HelpVisuals.Ids.DeleteBackupButton,
+                        "Fica ao lado de \"Restaurar\", em vermelho."),
+
+                    HelpBlock.OfHeading("Excluir todos"),
+                    HelpBlock.OfText(
+                        "Apaga de uma vez todas as cópias que estão nesta tela. Também não dá para " +
+                        "desfazer. Seu cofre atual não é afetado - só as cópias antigas somem."),
+                    HelpBlock.OfVisual(
+                        HelpVisuals.Ids.DeleteAllBackupsLink,
+                        "É este link vermelho, no fim da lista."),
+                ]),
+        ];
+
+        private static readonly Dictionary<string, HelpTopic> ById =
+            All.ToDictionary(topic => topic.Id, StringComparer.Ordinal);
+
+        public static bool TryGet(string id, out HelpTopic topic) => ById.TryGetValue(id, out topic!);
+    }
+
+    // Chaves das amostras visuais. Cada uma corresponde a um DataTemplate declarado em
+    // GDSB.MAUI/Resources/HelpVisuals.xaml, que monta uma réplica inerte do controle real usando
+    // os estilos de verdade de Styles.xaml. O projeto de teste é net10.0 puro e não enxerga XAML,
+    // então a correspondência chave -> DataTemplate é garantida em tempo de execução por uma
+    // guarda de DEBUG em HelpSheetView, não por teste.
+    public static class HelpVisuals
+    {
+        public static class Ids
+        {
+            public const string MasterUnlockCodeField = "HelpVisual.MasterUnlockCodeField";
+            public const string SaveAsNewFileCard = "HelpVisual.SaveAsNewFileCard";
+            public const string ProtectionTimeChips = "HelpVisual.ProtectionTimeChips";
+            public const string BackupModeChips = "HelpVisual.BackupModeChips";
+            public const string DeleteOldBackupsCheck = "HelpVisual.DeleteOldBackupsCheck";
+            public const string SecretUrlLink = "HelpVisual.SecretUrlLink";
+            public const string SecretValueActions = "HelpVisual.SecretValueActions";
+            public const string FavoriteStar = "HelpVisual.FavoriteStar";
+            public const string BackupCard = "HelpVisual.BackupCard";
+            public const string RestoreButton = "HelpVisual.RestoreButton";
+            public const string DeleteBackupButton = "HelpVisual.DeleteBackupButton";
+            public const string DeleteAllBackupsLink = "HelpVisual.DeleteAllBackupsLink";
+        }
+
+        public static IReadOnlyList<string> All { get; } =
+        [
+            Ids.MasterUnlockCodeField,
+            Ids.SaveAsNewFileCard,
+            Ids.ProtectionTimeChips,
+            Ids.BackupModeChips,
+            Ids.DeleteOldBackupsCheck,
+            Ids.SecretUrlLink,
+            Ids.SecretValueActions,
+            Ids.FavoriteStar,
+            Ids.BackupCard,
+            Ids.RestoreButton,
+            Ids.DeleteBackupButton,
+            Ids.DeleteAllBackupsLink,
+        ];
+    }
+}

--- a/src/GDSB.MAUI.ViewModels/Help/HelpTopics.cs
+++ b/src/GDSB.MAUI.ViewModels/Help/HelpTopics.cs
@@ -1,8 +1,8 @@
 namespace GDSB.MAUI.Help
 {
-    // Catálogo único de todo o texto de ajuda do app. Fica aqui, e não no XAML, por três motivos:
+    // Catálogo único do texto de ajuda do app, inteiro. Fica aqui, e não no XAML, por três motivos:
     // a redação passa a ser revisável num arquivo só, o teste consegue cobri-la (ids existentes,
-    // sem duplicatas, todo tópico com pelo menos uma amostra visual) e a mesma explicação pode ser
+    // sem duplicatas, cada tópico com pelo menos uma amostra visual) e a mesma explicação pode ser
     // reaproveitada por telas diferentes - PROTEÇÕES e BACKUPS aparecem tanto na criação do cofre
     // quanto na edição.
     //

--- a/src/GDSB.MAUI.ViewModels/ViewModels/OnboardingViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/OnboardingViewModel.cs
@@ -1,0 +1,125 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using GDSB.MAUI.Services;
+
+namespace GDSB.MAUI.ViewModels
+{
+    public sealed record OnboardingSlide(string Title, string Body);
+
+    /// <summary>
+    /// Os três slides que o app mostra a quem nunca o viu. Aparecem sozinhos no primeiro acesso e
+    /// continuam revisíveis pelo link "Como funciona?" no topo da tela de desbloqueio.
+    ///
+    /// O texto responde às três dúvidas que derrubam um usuário novo do GDSB, nesta ordem: onde
+    /// meus dados ficam, como eu começo, e como eu volto depois. Nada de vocabulário técnico -
+    /// "arquivo" e "senha", não "cofre criptografado" nem "derivação de chave".
+    /// </summary>
+    public partial class OnboardingViewModel : ObservableObject
+    {
+        public const string SeenPreferenceKey = "gdsb.onboardingSeen";
+
+        private readonly IPreferencesService _preferencesService;
+
+        public OnboardingViewModel(IPreferencesService preferencesService)
+        {
+            _preferencesService = preferencesService;
+        }
+
+        public IReadOnlyList<OnboardingSlide> Slides { get; } =
+        [
+            new OnboardingSlide(
+                "Seu cofre é um arquivo",
+                "O GDSB não guarda nada na nuvem nem dentro do celular: tudo mora num arquivo .GDSBX " +
+                "que é seu. O app é só a camada que abre e lê esse arquivo - sem ele disponível, não há " +
+                "o que abrir. Guarde-o onde você consiga alcançar de novo: uma pasta do Google Drive ou " +
+                "do OneDrive, por exemplo."),
+
+            new OnboardingSlide(
+                "Criar um cofre",
+                "Você escolhe onde salvar o arquivo e define a senha mestra. Essa senha é a única " +
+                "chave: ela não fica guardada em lugar nenhum e não existe \"esqueci minha senha\". " +
+                "Perdeu a senha, perdeu o conteúdo do arquivo."),
+
+            new OnboardingSlide(
+                "Abrir depois",
+                "Sempre igual: escolher o arquivo, digitar a senha. Ligando a biometria, o app lembra " +
+                "do último cofre e a digital vira o atalho - mas a senha mestra continua valendo, e o " +
+                "arquivo ainda precisa estar acessível."),
+        ];
+
+        [ObservableProperty]
+        private bool isVisible;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(CurrentSlide))]
+        [NotifyPropertyChangedFor(nameof(IsLastSlide))]
+        [NotifyPropertyChangedFor(nameof(ShowSkip))]
+        [NotifyPropertyChangedFor(nameof(AdvanceButtonText))]
+        private int currentIndex;
+
+        // Sonar não reconhece leitura de propriedade gerada por [ObservableProperty] como "dado de
+        // instância" e sugere static - tornar estático quebraria o binding de XAML. Mesma
+        // justificativa de UnlockViewModel.
+#pragma warning disable S2325
+        public OnboardingSlide CurrentSlide => Slides[CurrentIndex];
+
+        public int SlideCount => Slides.Count;
+
+        public bool IsLastSlide => CurrentIndex >= Slides.Count - 1;
+
+        // No último slide o "Pular" some: a única saída passa a ser "Começar", que é a mesma coisa
+        // sem parecer que o usuário está abandonando algo pela metade.
+        public bool ShowSkip => !IsLastSlide;
+
+        public string AdvanceButtonText => IsLastSlide ? "Começar" : "Próximo";
+#pragma warning restore S2325
+
+        public bool HasBeenSeen => _preferencesService.GetBool(SeenPreferenceKey, false);
+
+        /// <summary>
+        /// Abre o tutorial do zero. Usado pelo link "Como funciona?", que é o caminho de revisão -
+        /// por isso não olha a preferência: quem pediu para rever quer rever.
+        /// </summary>
+        public void ShowFromStart()
+        {
+            CurrentIndex = 0;
+            IsVisible = true;
+        }
+
+        /// <summary>
+        /// Abre sozinho, só uma vez na vida do app. Quem decide se é hora de chamar isto é o
+        /// UnlockViewModel, que também tem a informação sobre a biometria.
+        /// </summary>
+        public void MaybeShowOnFirstRun()
+        {
+            // O !IsVisible importa: InitializeAsync roda de novo a cada Window.Resumed, e sem essa
+            // guarda trocar de app no meio do slide 2 e voltar jogaria o usuário de volta no 1.
+            if (!HasBeenSeen && !IsVisible)
+                ShowFromStart();
+        }
+
+        [RelayCommand]
+        private void Advance()
+        {
+            if (IsLastSlide)
+            {
+                Finish();
+                return;
+            }
+
+            CurrentIndex++;
+        }
+
+        [RelayCommand]
+        private void Skip() => Finish();
+
+        // Pular conta como visto: quem fechou o tutorial não quer topar com ele de novo na próxima
+        // abertura. O link "Como funciona?" continua ali para quando quiser.
+        private void Finish()
+        {
+            _preferencesService.SetBool(SeenPreferenceKey, true);
+            IsVisible = false;
+            CurrentIndex = 0;
+        }
+    }
+}

--- a/src/GDSB.MAUI.ViewModels/ViewModels/OnboardingViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/OnboardingViewModel.cs
@@ -80,11 +80,17 @@ namespace GDSB.MAUI.ViewModels
         /// Abre o tutorial do zero. Usado pelo link "Como funciona?", que é o caminho de revisão -
         /// por isso não olha a preferência: quem pediu para rever quer rever.
         /// </summary>
+        // S2325 é falso positivo: as duas atribuições são em propriedades geradas por
+        // [ObservableProperty], que o Sonar não reconhece como estado de instância. Tornar o método
+        // static quebraria o binding - e o UnlockViewModel o chama numa instância. Mesma
+        // justificativa das propriedades de UnlockViewModel.
+#pragma warning disable S2325
         public void ShowFromStart()
         {
             CurrentIndex = 0;
             IsVisible = true;
         }
+#pragma warning restore S2325
 
         /// <summary>
         /// Abre sozinho, só uma vez na vida do app. Quem decide se é hora de chamar isto é o

--- a/src/GDSB.MAUI.ViewModels/ViewModels/UnlockOverlays.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/UnlockOverlays.cs
@@ -1,0 +1,13 @@
+namespace GDSB.MAUI.ViewModels
+{
+    // Agrupa os dois ViewModels que a UnlockPage hospeda por cima de si mesma - o convite de
+    // biometria e o tutorial de primeiro acesso - só para manter o construtor do UnlockViewModel
+    // dentro do limite de parâmetros do analisador estático, que a entrada do tutorial estourou
+    // (passou de 7). Mesmo motivo e mesmo formato do VaultAccess.
+    public sealed class UnlockOverlays(BiometricOptInCoordinator biometricOptIn, OnboardingViewModel onboarding)
+    {
+        public BiometricOptInCoordinator BiometricOptIn { get; } = biometricOptIn;
+
+        public OnboardingViewModel Onboarding { get; } = onboarding;
+    }
+}

--- a/src/GDSB.MAUI.ViewModels/ViewModels/UnlockViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/UnlockViewModel.cs
@@ -41,7 +41,8 @@ namespace GDSB.MAUI.ViewModels
             IBiometricUnlockService biometricUnlockService,
             IPreferencesService preferencesService,
             IAlertService alertService,
-            BiometricOptInCoordinator biometricOptIn)
+            BiometricOptInCoordinator biometricOptIn,
+            OnboardingViewModel onboarding)
         {
             _profileFileService = vaultAccess.ProfileFileService;
             _filePickerService = filePickerService;
@@ -51,11 +52,16 @@ namespace GDSB.MAUI.ViewModels
             _alertService = alertService;
             _vaultSessionService = vaultAccess.VaultSessionService;
             BiometricOptIn = biometricOptIn;
+            Onboarding = onboarding;
         }
 
         // Exposto pra UnlockPage.xaml hospedar a BiometricOptInView (BindingContext="{Binding
         // BiometricOptIn}") - ver GDSB.MAUI.ViewModels.BiometricOptInCoordinator.
         public BiometricOptInCoordinator BiometricOptIn { get; }
+
+        // Exposto pra UnlockPage.xaml hospedar a OnboardingView (BindingContext="{Binding
+        // Onboarding}"), do mesmo jeito que a BiometricOptInView.
+        public OnboardingViewModel Onboarding { get; }
 
         [ObservableProperty]
         private string? selectedVaultLocation;
@@ -106,6 +112,11 @@ namespace GDSB.MAUI.ViewModels
 
         [RelayCommand]
         private void ToggleShowPassword() => IsPasswordHidden = !IsPasswordHidden;
+
+        // O link "Como funciona?" no topo da tela. Reabre o tutorial a qualquer momento, sem olhar
+        // a preferência de "já vi": quem pediu pra rever quer rever.
+        [RelayCommand]
+        private void ShowOnboarding() => Onboarding.ShowFromStart();
 
         [RelayCommand]
         private Task GoToCreateVaultAsync() => _navigationService.NavigateToAsync("CreateVaultPage");
@@ -171,7 +182,18 @@ namespace GDSB.MAUI.ViewModels
         {
             await RefreshBiometricAvailabilityAsync();
 
-            if (CanUseBiometric && CanUnlockWithBiometric())
+            // O tutorial não pode brigar com a biometria: com ela armada, este mesmo método já
+            // dispara o prompt do sistema logo abaixo, e os dois por cima um do outro deixariam o
+            // usuário sem saber em qual responder. No primeiro acesso de verdade isso nunca
+            // acontece (não há cofre lembrado em Preferences), mas a guarda precisa existir para
+            // quem já usa o app e ainda não viu os slides.
+            if (!CanUseBiometric)
+            {
+                Onboarding.MaybeShowOnFirstRun();
+                return;
+            }
+
+            if (CanUnlockWithBiometric())
                 await UnlockWithBiometricAsync();
         }
 

--- a/src/GDSB.MAUI.ViewModels/ViewModels/UnlockViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/UnlockViewModel.cs
@@ -18,7 +18,10 @@ namespace GDSB.MAUI.ViewModels
         // Senha errada e arquivo corrompido devem ser indistinguíveis pra quem usa o app -
         // nunca mostrar ex.Message cru, sempre essa mensagem genérica.
         private const string GenericErrorMessage = "Senha incorreta ou arquivo corrompido.";
-        private const string EmptyPasswordMessage = "Digite a senha mestra do cofre.";
+        // Sem "password"/"pwd"/"passphrase" no nome: a regra S2068 do Sonar flaga a declaração de
+        // qualquer campo com esses nomes e valor literal como credencial no código, mesmo quando o
+        // valor é só uma mensagem de erro. Mesma renomeação já feita nas constantes de teste.
+        private const string EmptyUnlockCodeMessage = "Digite a senha mestra do cofre.";
         private const string FilePickerErrorMessage = "Não foi possível abrir o seletor de arquivos.";
         private const string BackupFileAlertTitle = "Isto é um backup";
         private const string BackupFileAlertMessage =
@@ -222,7 +225,7 @@ namespace GDSB.MAUI.ViewModels
 
             if (string.IsNullOrEmpty(Password))
             {
-                ErrorMessage = EmptyPasswordMessage;
+                ErrorMessage = EmptyUnlockCodeMessage;
                 return;
             }
 

--- a/src/GDSB.MAUI.ViewModels/ViewModels/UnlockViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/UnlockViewModel.cs
@@ -41,8 +41,7 @@ namespace GDSB.MAUI.ViewModels
             IBiometricUnlockService biometricUnlockService,
             IPreferencesService preferencesService,
             IAlertService alertService,
-            BiometricOptInCoordinator biometricOptIn,
-            OnboardingViewModel onboarding)
+            UnlockOverlays overlays)
         {
             _profileFileService = vaultAccess.ProfileFileService;
             _filePickerService = filePickerService;
@@ -51,8 +50,8 @@ namespace GDSB.MAUI.ViewModels
             _preferencesService = preferencesService;
             _alertService = alertService;
             _vaultSessionService = vaultAccess.VaultSessionService;
-            BiometricOptIn = biometricOptIn;
-            Onboarding = onboarding;
+            BiometricOptIn = overlays.BiometricOptIn;
+            Onboarding = overlays.Onboarding;
         }
 
         // Exposto pra UnlockPage.xaml hospedar a BiometricOptInView (BindingContext="{Binding

--- a/src/GDSB.MAUI/App.xaml
+++ b/src/GDSB.MAUI/App.xaml
@@ -9,6 +9,9 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
                 <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
+                <!-- Depois de Styles.xaml de propósito: as amostras do painel de ajuda usam os
+                     estilos de verdade declarados lá (FilterChipStyle, CardBorderStyle...). -->
+                <ResourceDictionary Source="Resources/HelpVisuals.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
             <!-- Global porque é usado por SelectableChip.IsSelected em várias telas (VaultPage,

--- a/src/GDSB.MAUI/BackupRecoveryPage.xaml
+++ b/src/GDSB.MAUI/BackupRecoveryPage.xaml
@@ -56,8 +56,16 @@
                             <TapGestureRecognizer Command="{Binding GoBackCommand}" />
                         </Label.GestureRecognizers>
                     </Label>
-                    <Label Text="Recuperar backup" FontSize="22" FontFamily="OpenSansSemibold"
-                           TextColor="{StaticResource TextPrimaryDark}" />
+                    <!-- Um "?" só para a tela inteira, no cabeçalho: o painel dele cobre as
+                         quatro seções (como as cópias aparecem, restaurar, excluir e excluir
+                         todos). Nada de "?" nos cartões, nos botões nem no "Excluir todos" -
+                         numa lista com N cartões isso viraria N vezes o mesmo ícone. -->
+                    <HorizontalStackLayout Spacing="10">
+                        <Label Text="Recuperar backup" FontSize="22" FontFamily="OpenSansSemibold"
+                               TextColor="{StaticResource TextPrimaryDark}" VerticalOptions="Center" />
+                        <views:HelpButton TopicId="backup.recovery" Style="{StaticResource HelpButtonStyle}"
+                                          VerticalOptions="Center" />
+                    </HorizontalStackLayout>
                     <Label Text="Backups são gerados automaticamente antes de cada gravação. Restaurar sempre cria um arquivo novo - o cofre original nunca é sobrescrito."
                            TextColor="{StaticResource TextSecondaryDark}" FontSize="13" Margin="0,4,0,0" />
                 </VerticalStackLayout>
@@ -179,5 +187,7 @@
              store - mesma animação/overlay de VaultPage, deixando visível a destruição do item em
              vez de só a lista encolher em silêncio. -->
         <views:SealOverlayView x:Name="SealOverlay" />
+
+        <views:HelpSheetView x:Name="HelpSheet" />
     </Grid>
 </ContentPage>

--- a/src/GDSB.MAUI/BackupRecoveryPage.xaml.cs
+++ b/src/GDSB.MAUI/BackupRecoveryPage.xaml.cs
@@ -1,4 +1,4 @@
-using GDSB.MAUI.ViewModels;
+﻿using GDSB.MAUI.ViewModels;
 using GDSB.MAUI.Views;
 
 namespace GDSB.MAUI;
@@ -20,6 +20,17 @@ public partial class BackupRecoveryPage : ContentPage
     {
         base.OnAppearing();
         _viewModel.Initialize();
+
+        // O painel de ajuda só atende enquanto esta página está à vista: com Shell, a página
+        // anterior continua carregada na pilha, e sem isso o "?" de uma tela abriria o painel da
+        // outra também.
+        HelpSheet.StartListening();
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        HelpSheet.StopListening();
     }
 
     // S2325 ("make static") é falso positivo: SealOverlay é um elemento nomeado do XAML (campo de

--- a/src/GDSB.MAUI/CreateVaultPage.xaml
+++ b/src/GDSB.MAUI/CreateVaultPage.xaml
@@ -45,7 +45,7 @@
                         <VerticalStackLayout Spacing="16">
 
                             <VerticalStackLayout Spacing="8">
-                                <Label Text="NOME DO COFRE" Style="{StaticResource FieldLabelStyle}" />
+                                <views:FieldLabelView Text="NOME DO COFRE" IsRequired="True" />
                                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                                         StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="48">
                                     <Entry Text="{Binding VaultName}" TextColor="{StaticResource TextPrimaryDark}"
@@ -55,7 +55,8 @@
                             </VerticalStackLayout>
 
                             <VerticalStackLayout Spacing="8">
-                                <Label Text="SENHA MESTRA" Style="{StaticResource FieldLabelStyle}" />
+                                <views:FieldLabelView Text="SENHA MESTRA" IsRequired="True"
+                                                      HelpTopicId="vault.masterUnlockCode" />
                                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                                         StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="48">
                                     <Entry Text="{Binding Password}" IsPassword="True"
@@ -66,7 +67,7 @@
                             </VerticalStackLayout>
 
                             <VerticalStackLayout Spacing="8">
-                                <Label Text="CONFIRMAR SENHA" Style="{StaticResource FieldLabelStyle}" />
+                                <views:FieldLabelView Text="CONFIRMAR SENHA" IsRequired="True" />
                                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                                         StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="48">
                                     <Entry Text="{Binding ConfirmPassword}" IsPassword="True"
@@ -76,6 +77,8 @@
                                            ReturnCommand="{Binding CreateVaultCommand}" />
                                 </Border>
                             </VerticalStackLayout>
+
+                            <Label Text="* campos obrigatórios" Style="{StaticResource RequiredFieldsLegendStyle}" />
 
                             <Label Text="{Binding ErrorMessage}" TextColor="{StaticResource Danger}" FontSize="13"
                                    IsVisible="{Binding HasErrorMessage}" />
@@ -89,7 +92,7 @@
                     <Border Style="{StaticResource CardBorderStyle}" Padding="22" StrokeShape="RoundRectangle 20">
                         <VerticalStackLayout Spacing="18">
 
-                            <Label Text="PROTEÇÕES" Style="{StaticResource FieldLabelStyle}" />
+                            <views:FieldLabelView Text="PROTEÇÕES" HelpTopicId="vault.protections" />
 
                             <VerticalStackLayout Spacing="6">
                                 <Grid ColumnDefinitions="*,Auto">
@@ -146,7 +149,7 @@
                             <BoxView HeightRequest="1" Color="{StaticResource BorderDark}" />
 
                             <VerticalStackLayout Spacing="6">
-                                <Label Text="BACKUPS" Style="{StaticResource FieldLabelStyle}" />
+                                <views:FieldLabelView Text="BACKUPS" HelpTopicId="vault.backups" />
                                 <Label Text="Manter quantas versões"
                                        TextColor="{StaticResource TextPrimaryDark}" FontSize="14" />
                                 <HorizontalStackLayout Spacing="8">
@@ -205,6 +208,8 @@
         </Grid>
 
         <views:BiometricOptInView BindingContext="{Binding BiometricOptIn}" />
+
+        <views:HelpSheetView x:Name="HelpSheet" />
 
     </Grid>
 </ContentPage>

--- a/src/GDSB.MAUI/CreateVaultPage.xaml.cs
+++ b/src/GDSB.MAUI/CreateVaultPage.xaml.cs
@@ -1,4 +1,4 @@
-using GDSB.MAUI.ViewModels;
+﻿using GDSB.MAUI.ViewModels;
 using GDSB.MAUI.Views;
 
 namespace GDSB.MAUI;
@@ -11,5 +11,19 @@ public partial class CreateVaultPage : ContentPage
         BindingContext = viewModel;
         // Haste erguida: o cofre desta tela ainda não foi selado.
         BrandMark.Drawable = new BrandMarkDrawable { Open = true };
+    }
+
+    // O painel de ajuda só atende enquanto esta página está à vista: com Shell, a página anterior
+    // continua carregada na pilha, e sem isso o "?" de uma tela abriria o painel da outra também.
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        HelpSheet.StartListening();
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        HelpSheet.StopListening();
     }
 }

--- a/src/GDSB.MAUI/MauiProgram.cs
+++ b/src/GDSB.MAUI/MauiProgram.cs
@@ -79,6 +79,7 @@ namespace GDSB.MAUI
             services.AddTransient<BiometricOptInCoordinator>();
 
             services.AddTransient<OnboardingViewModel>();
+            services.AddTransient<UnlockOverlays>();
             services.AddTransient<UnlockViewModel>();
             services.AddTransient<VaultViewModel>();
             services.AddTransient<CreateVaultViewModel>();

--- a/src/GDSB.MAUI/MauiProgram.cs
+++ b/src/GDSB.MAUI/MauiProgram.cs
@@ -1,4 +1,4 @@
-using GDSB.Domain.Interfaces;
+﻿using GDSB.Domain.Interfaces;
 using GDSB.Infrastructure;
 using GDSB.Infrastructure.Backup;
 using GDSB.Infrastructure.Encryption.Legacy;
@@ -78,6 +78,7 @@ namespace GDSB.MAUI
             // precisa da sua própria instância, com seu próprio TaskCompletionSource pendente.
             services.AddTransient<BiometricOptInCoordinator>();
 
+            services.AddTransient<OnboardingViewModel>();
             services.AddTransient<UnlockViewModel>();
             services.AddTransient<VaultViewModel>();
             services.AddTransient<CreateVaultViewModel>();

--- a/src/GDSB.MAUI/Platforms/Android/AndroidManifest.xml
+++ b/src/GDSB.MAUI/Platforms/Android/AndroidManifest.xml
@@ -14,9 +14,29 @@
 			</intent-filter>
 		</activity>
 	</application>
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+	<!--
+	  Só o que o app realmente usa. Toda permissão a mais aqui vira uma pergunta a responder na
+	  Play Console e um motivo a mais para a publicação travar, então a lista é mantida no mínimo:
+
+	  USE_BIOMETRIC - BiometricPrompt/BiometricManager, em
+	                  Platforms/Android/Services/BiometricUnlockService.cs.
+
+	  Removidas nesta rodada, por não terem uso nenhum no código:
+
+	  READ_EXTERNAL_STORAGE / WRITE_EXTERNAL_STORAGE - o app nunca toca em caminho de arquivo do
+	      Android. Abrir e gravar um cofre é 100% Storage Access Framework (ActionOpenDocument /
+	      ActionCreateDocument em FilePickerService, e ContentResolver.OpenInputStream/
+	      OpenOutputStream sobre content:// em AndroidSafFileSystem), que por definição dispensa
+	      permissão - é o usuário quem escolhe o arquivo no seletor do sistema. Os backups ficam em
+	      FileSystem.AppDataDirectory, área privada do app. Além disso a WRITE_EXTERNAL_STORAGE não
+	      tem mais efeito desde o Android 11 e a READ_EXTERNAL_STORAGE desde o Android 13, e as duas
+	      estão na lista de permissões que o Google cobra justificativa para publicar.
+
+	  INTERNET / ACCESS_NETWORK_STATE - o GDSB é offline por inteiro: não há HttpClient,
+	      WebView nem uso de Connectivity em lugar nenhum. Abrir a URL de um item é
+	      Launcher.Default.OpenAsync, que dispara um Intent para o navegador - quem acessa a rede
+	      é o navegador, com a permissão dele. (Em build de Debug o SDK do Android injeta a
+	      INTERNET sozinho, para o depurador; o Release sai sem ela.)
+	-->
 	<uses-permission android:name="android.permission.USE_BIOMETRIC" />
 </manifest>

--- a/src/GDSB.MAUI/Platforms/Android/MainActivity.cs
+++ b/src/GDSB.MAUI/Platforms/Android/MainActivity.cs
@@ -1,18 +1,12 @@
-﻿using Android;
-using Android.App;
+﻿using Android.App;
 using Android.Content;
 using Android.Content.PM;
-using Android.OS;
-using AndroidX.Core.App;
-using AndroidX.Core.Content;
 
 namespace GDSB.MAUI
 {
     [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
-        const int RequestStorageId = 0;
-
         // Ponte pro Storage Access Framework (ver Platforms/Android/Services/FilePickerService):
         // o resultado de ActionOpenDocument/ActionCreateDocument só chega aqui, na Activity que
         // disparou o intent - o serviço registra um callback por request code e espera por ele.
@@ -33,45 +27,12 @@ namespace GDSB.MAUI
             WindowFocusChanged?.Invoke(hasFocus);
         }
 
-        protected override void OnCreate(Bundle savedInstanceState)
-        {
-            base.OnCreate(savedInstanceState);
-
-            RequestStoragePermissions();
-        }
-
         protected override void OnActivityResult(int requestCode, Result resultCode, Intent? data)
         {
             base.OnActivityResult(requestCode, resultCode, data);
 
             if (PendingDocumentPicks.Remove(requestCode, out var callback))
                 callback(resultCode, data);
-        }
-
-        void RequestStoragePermissions()
-        {
-            if (ContextCompat.CheckSelfPermission(this, Manifest.Permission.ReadExternalStorage) != Permission.Granted ||
-                ContextCompat.CheckSelfPermission(this, Manifest.Permission.WriteExternalStorage) != Permission.Granted)
-            {
-                ActivityCompat.RequestPermissions(this, new string[]
-                {
-                    Manifest.Permission.ReadExternalStorage,
-                    Manifest.Permission.WriteExternalStorage
-                }, RequestStorageId);
-            }
-        }
-
-        public override void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults)
-        {
-            base.OnRequestPermissionsResult(requestCode, permissions, grantResults);
-
-            if (requestCode == RequestStorageId)
-            {
-                var granted = grantResults.Length > 0 && grantResults[0] == Permission.Granted;
-                System.Diagnostics.Debug.WriteLine(granted
-                    ? "GDSB: legacy storage permission granted."
-                    : "GDSB: legacy storage permission denied; file access relies on the Storage Access Framework picker instead.");
-            }
         }
     }
 }

--- a/src/GDSB.MAUI/Platforms/Windows/CursorMappings.cs
+++ b/src/GDSB.MAUI/Platforms/Windows/CursorMappings.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using GDSB.MAUI.Behaviors;
 using Microsoft.Maui.Handlers;
 using Microsoft.UI.Input;
@@ -31,6 +31,15 @@ namespace GDSB.MAUI.Platforms.Windows
             });
 
             LayoutHandler.Mapper.AppendToMapping("HoverCursor", (handler, view) =>
+            {
+                if (view is BindableObject element && HoverCursor.GetIsHand(element))
+                    SetHand(handler.PlatformView);
+            });
+
+            // Border não passa por LayoutHandler nem por LabelHandler - tem handler próprio. Sem
+            // este mapeamento, uma pílula/cartão clicável (a entrada "Como funciona?" da tela de
+            // desbloqueio) ficava com o cursor de seta, sem nenhuma pista de que dá para clicar.
+            BorderHandler.Mapper.AppendToMapping("HoverCursor", (handler, view) =>
             {
                 if (view is BindableObject element && HoverCursor.GetIsHand(element))
                     SetHand(handler.PlatformView);

--- a/src/GDSB.MAUI/Platforms/Windows/CursorMappings.cs
+++ b/src/GDSB.MAUI/Platforms/Windows/CursorMappings.cs
@@ -11,6 +11,11 @@ namespace GDSB.MAUI.Platforms.Windows
     // .NET MAUI/WinUI pra esse cenário, não um hack instável específico deste app.
     internal static class CursorMappings
     {
+        // Chave dos quatro AppendToMapping abaixo. Constante porque o Sonar (S1192) cobra a partir
+        // da terceira repetição do mesmo literal - e porque um erro de digitação em um deles
+        // passaria despercebido: o mapeamento simplesmente não valeria, sem erro nenhum.
+        private const string MappingKey = "HoverCursor";
+
         private static readonly PropertyInfo? ProtectedCursorProperty =
             typeof(UIElement).GetProperty("ProtectedCursor", BindingFlags.Instance | BindingFlags.NonPublic);
 
@@ -20,17 +25,17 @@ namespace GDSB.MAUI.Platforms.Windows
         public static void Apply()
         {
             // Todo Button do app é uma ação clicável (copiar, editar, favoritar, excluir, filtros...).
-            ButtonHandler.Mapper.AppendToMapping("HoverCursor", (handler, _) => SetHand(handler.PlatformView));
+            ButtonHandler.Mapper.AppendToMapping(MappingKey, (handler, _) => SetHand(handler.PlatformView));
 
             // Label/Grid usados como área clicável via TapGestureRecognizer (link de URL, linha da lista)
             // precisam de opt-in explícito via Behaviors.HoverCursor.IsHand="True" no XAML.
-            LabelHandler.Mapper.AppendToMapping("HoverCursor", (handler, view) =>
+            LabelHandler.Mapper.AppendToMapping(MappingKey, (handler, view) =>
             {
                 if (view is BindableObject element && HoverCursor.GetIsHand(element))
                     SetHand(handler.PlatformView);
             });
 
-            LayoutHandler.Mapper.AppendToMapping("HoverCursor", (handler, view) =>
+            LayoutHandler.Mapper.AppendToMapping(MappingKey, (handler, view) =>
             {
                 if (view is BindableObject element && HoverCursor.GetIsHand(element))
                     SetHand(handler.PlatformView);
@@ -39,7 +44,7 @@ namespace GDSB.MAUI.Platforms.Windows
             // Border não passa por LayoutHandler nem por LabelHandler - tem handler próprio. Sem
             // este mapeamento, uma pílula/cartão clicável (a entrada "Como funciona?" da tela de
             // desbloqueio) ficava com o cursor de seta, sem nenhuma pista de que dá para clicar.
-            BorderHandler.Mapper.AppendToMapping("HoverCursor", (handler, view) =>
+            BorderHandler.Mapper.AppendToMapping(MappingKey, (handler, view) =>
             {
                 if (view is BindableObject element && HoverCursor.GetIsHand(element))
                     SetHand(handler.PlatformView);

--- a/src/GDSB.MAUI/Resources/HelpVisuals.xaml
+++ b/src/GDSB.MAUI/Resources/HelpVisuals.xaml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<?xaml-comp compile="true" ?>
+<!--
+  Amostras visuais do painel de ajuda: um DataTemplate por chave declarada em
+  GDSB.MAUI.Help.HelpVisuals.Ids. Cada um monta uma RÉPLICA INERTE do controle real da tela que o
+  tópico explica, e por cima dela um TapHintView - a "mãozinha" que desce, sobe e abre o anel de
+  toque, mostrando onde o usuário tocaria em vez de só descrever com palavras.
+
+  Três regras valem para todos:
+
+  1. A raiz é InputTransparent="True" (cascateia para os filhos no MAUI) - é ilustração, não
+     controle. Nunca IsEnabled="False", que esmaece o desenho e descaracteriza a amostra.
+  2. Os estilos são os DE VERDADE de Styles.xaml (FilterChipStyle, SecondaryActionButtonStyle,
+     CardBorderStyle, FieldLabelStyle...), nunca cópias - assim a amostra acompanha sozinha
+     qualquer mudança futura no visual do app.
+  3. A mãozinha só aparece onde existe uma ação de verdade. Amostras que ilustram um RESULTADO
+     (o cartão de backup, por exemplo) não levam indicador: apontar um toque que não existe
+     ensinaria errado.
+-->
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:controls="clr-namespace:GDSB.MAUI.Controls"
+    xmlns:views="clr-namespace:GDSB.MAUI.Views">
+
+    <!-- ============ Cofre: criação e edição ============ -->
+
+    <DataTemplate x:Key="HelpVisual.MasterUnlockCodeField">
+        <VerticalStackLayout InputTransparent="True" Spacing="8">
+            <HorizontalStackLayout Spacing="4">
+                <Label Text="SENHA MESTRA" Style="{StaticResource FieldLabelStyle}" VerticalOptions="Center" />
+                <Label Text="*" Style="{StaticResource RequiredMarkStyle}" VerticalOptions="Center" />
+            </HorizontalStackLayout>
+            <Grid Padding="0,0,0,16">
+                <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
+                        StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="48" VerticalOptions="Start">
+                    <Label Text="&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;"
+                           TextColor="{StaticResource TextPrimaryDark}" FontSize="17" VerticalOptions="Center" />
+                </Border>
+                <views:TapHintView HorizontalOptions="Start" VerticalOptions="Start" Margin="58,17,0,0" />
+            </Grid>
+        </VerticalStackLayout>
+    </DataTemplate>
+
+    <DataTemplate x:Key="HelpVisual.SaveAsNewFileCard">
+        <Grid InputTransparent="True" Padding="0,0,0,12">
+            <Border Style="{StaticResource CardBorderStyle}" Padding="16" StrokeShape="RoundRectangle 16"
+                    VerticalOptions="Start">
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Salvar também num arquivo novo?" FontFamily="OpenSansSemibold" FontSize="14"
+                           TextColor="{StaticResource TextPrimaryDark}" />
+                    <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                        <Button Grid.Column="0" Text="Não, obrigado" Style="{StaticResource SecondaryActionButtonStyle}"
+                                FontSize="12" HeightRequest="40" />
+                        <Button Grid.Column="1" Text="Salvar como novo" Style="{StaticResource PrimaryActionButtonStyle}"
+                                FontSize="12" HeightRequest="40" />
+                    </Grid>
+                </VerticalStackLayout>
+            </Border>
+            <views:TapHintView HorizontalOptions="End" VerticalOptions="End" Margin="0,0,44,4" />
+        </Grid>
+    </DataTemplate>
+
+    <DataTemplate x:Key="HelpVisual.ProtectionTimeChips">
+        <Grid InputTransparent="True" Padding="0,0,0,20" HorizontalOptions="Start">
+            <HorizontalStackLayout Spacing="8" VerticalOptions="Start">
+                <controls:SelectableChip Text="20s" Style="{StaticResource FilterChipStyle}" />
+                <controls:SelectableChip Text="45s" Style="{StaticResource FilterChipStyle}" IsSelected="True" />
+                <controls:SelectableChip Text="90s" Style="{StaticResource FilterChipStyle}" />
+            </HorizontalStackLayout>
+            <views:TapHintView HorizontalOptions="Start" VerticalOptions="Start" Margin="83,9,0,0" />
+        </Grid>
+    </DataTemplate>
+
+    <DataTemplate x:Key="HelpVisual.BackupModeChips">
+        <Grid InputTransparent="True" Padding="0,0,0,20" HorizontalOptions="Start">
+            <HorizontalStackLayout Spacing="8" VerticalOptions="Start">
+                <controls:SelectableChip Text="Por quantidade" Style="{StaticResource FilterChipStyle}" IsSelected="True" />
+                <controls:SelectableChip Text="Por tempo" Style="{StaticResource FilterChipStyle}" />
+            </HorizontalStackLayout>
+            <views:TapHintView HorizontalOptions="Start" VerticalOptions="Start" Margin="153,9,0,0" />
+        </Grid>
+    </DataTemplate>
+
+    <DataTemplate x:Key="HelpVisual.DeleteOldBackupsCheck">
+        <Grid InputTransparent="True" Padding="0,0,0,16">
+            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8" VerticalOptions="Start">
+                <CheckBox Grid.Column="0" IsChecked="True" Color="{StaticResource Primary}" VerticalOptions="Center" />
+                <Label Grid.Column="1" Text="Excluir os backups antigos deste cofre"
+                       TextColor="{StaticResource TextSecondaryDark}" FontSize="13" VerticalOptions="Center" />
+            </Grid>
+            <views:TapHintView HorizontalOptions="Start" VerticalOptions="Start" Margin="6,14,0,0" />
+        </Grid>
+    </DataTemplate>
+
+    <!-- ============ Item do cofre ============ -->
+
+    <DataTemplate x:Key="HelpVisual.SecretUrlLink">
+        <Grid InputTransparent="True" Padding="0,0,0,18">
+            <VerticalStackLayout Spacing="2" VerticalOptions="Start">
+                <Label Text="Netflix" FontFamily="OpenSansSemibold" FontSize="15"
+                       TextColor="{StaticResource TextPrimaryDark}" />
+                <Label Text="netflix.com" FontSize="13" TextColor="{StaticResource PrimaryDark}" />
+            </VerticalStackLayout>
+            <views:TapHintView HorizontalOptions="Start" VerticalOptions="Start" Margin="16,20,0,0" />
+        </Grid>
+    </DataTemplate>
+
+    <DataTemplate x:Key="HelpVisual.SecretValueActions">
+        <Grid InputTransparent="True" Padding="0,0,0,14">
+            <Border Style="{StaticResource CardBorderStyle}" VerticalOptions="Start">
+                <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+                    <VerticalStackLayout Grid.Column="0" Spacing="4" VerticalOptions="Center">
+                        <Label Text="SENHA" Style="{StaticResource FieldLabelStyle}" />
+                        <Label Text="&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;"
+                               TextColor="{StaticResource TextPrimaryDark}" FontSize="15" />
+                    </VerticalStackLayout>
+                    <Button Grid.Column="1" Text="&#128065;" BackgroundColor="{StaticResource SurfaceDark}"
+                            WidthRequest="36" HeightRequest="36" Padding="0" FontSize="14" VerticalOptions="Center" />
+                    <Button Grid.Column="2" Text="Copiar" BackgroundColor="{StaticResource SurfaceDark}"
+                            TextColor="{StaticResource TextPrimaryDark}" FontSize="12" HeightRequest="36"
+                            VerticalOptions="Center" />
+                </Grid>
+            </Border>
+            <views:TapHintView HorizontalOptions="End" VerticalOptions="Center" Margin="0,10,86,0" />
+        </Grid>
+    </DataTemplate>
+
+    <DataTemplate x:Key="HelpVisual.FavoriteStar">
+        <Grid InputTransparent="True" Padding="0,0,0,14">
+            <Border Style="{StaticResource CardBorderStyle}" VerticalOptions="Start">
+                <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
+                    <Border Grid.Column="0" WidthRequest="36" HeightRequest="36" StrokeShape="RoundRectangle 11"
+                            BackgroundColor="{StaticResource Tertiary}" StrokeThickness="0">
+                        <Label Text="N" TextColor="{StaticResource White}" FontFamily="OpenSansSemibold"
+                               FontSize="14" HorizontalOptions="Center" VerticalOptions="Center" />
+                    </Border>
+                    <VerticalStackLayout Grid.Column="1" VerticalOptions="Center" Spacing="1">
+                        <Label Text="Netflix" FontFamily="OpenSansSemibold" FontSize="14.5"
+                               TextColor="{StaticResource TextPrimaryDark}" />
+                        <Label Text="netflix.com" FontSize="12" TextColor="{StaticResource TextSecondaryDark}" />
+                    </VerticalStackLayout>
+                    <Label Grid.Column="2" Text="&#9733;" FontSize="20" TextColor="{StaticResource FavoriteGold}"
+                           VerticalOptions="Center" />
+                </Grid>
+            </Border>
+            <views:TapHintView HorizontalOptions="End" VerticalOptions="Start" Margin="0,26,10,0" />
+        </Grid>
+    </DataTemplate>
+
+    <!-- ============ Tela de backups ============ -->
+
+    <!-- Sem mãozinha: ilustra COMO uma cópia aparece na lista, não uma ação. -->
+    <DataTemplate x:Key="HelpVisual.BackupCard">
+        <Border InputTransparent="True" Style="{StaticResource CardBorderStyle}">
+            <VerticalStackLayout Spacing="6">
+                <Label Text="Cofre pessoal" FontFamily="OpenSansSemibold" FontSize="14"
+                       TextColor="{StaticResource TextPrimaryDark}" />
+                <Label Text="BKP - Cofre pessoal.GDSBX - 2026-09-02 14-30-12.bak" FontSize="12"
+                       TextColor="{StaticResource TextSecondaryDark}" LineBreakMode="HeadTruncation" MaxLines="1" />
+                <Label FontSize="12" TextColor="{StaticResource TextMutedDark}">
+                    <Label.FormattedText>
+                        <FormattedString>
+                            <Span Text="02/09/2026 14:30" />
+                            <Span Text="  &#183;  " />
+                            <Span Text="12 KB" />
+                            <Span Text="  &#183;  " />
+                            <Span Text="Automático" />
+                        </FormattedString>
+                    </Label.FormattedText>
+                </Label>
+            </VerticalStackLayout>
+        </Border>
+    </DataTemplate>
+
+    <DataTemplate x:Key="HelpVisual.RestoreButton">
+        <Grid InputTransparent="True" Padding="0,0,0,18" HorizontalOptions="Start">
+            <Button Text="Restaurar" Style="{StaticResource SecondaryActionButtonStyle}"
+                    WidthRequest="150" HeightRequest="42" VerticalOptions="Start" />
+            <views:TapHintView HorizontalOptions="Start" VerticalOptions="Start" Margin="58,14,0,0" />
+        </Grid>
+    </DataTemplate>
+
+    <DataTemplate x:Key="HelpVisual.DeleteBackupButton">
+        <Grid InputTransparent="True" Padding="0,0,0,18" HorizontalOptions="Start">
+            <Button Text="Excluir" HeightRequest="42" WidthRequest="150" VerticalOptions="Start"
+                    BackgroundColor="Transparent" TextColor="{StaticResource Danger}"
+                    BorderColor="{StaticResource Danger}" BorderWidth="1" CornerRadius="12"
+                    FontFamily="OpenSansSemibold" FontSize="14" />
+            <views:TapHintView HorizontalOptions="Start" VerticalOptions="Start" Margin="58,14,0,0" />
+        </Grid>
+    </DataTemplate>
+
+    <DataTemplate x:Key="HelpVisual.DeleteAllBackupsLink">
+        <Grid InputTransparent="True" Padding="0,0,0,18" HorizontalOptions="Start">
+            <Label Text="Excluir todos os backups" TextColor="{StaticResource Danger}" FontSize="13"
+                   VerticalOptions="Start" />
+            <views:TapHintView HorizontalOptions="Start" VerticalOptions="Start" Margin="58,8,0,0" />
+        </Grid>
+    </DataTemplate>
+
+</ResourceDictionary>

--- a/src/GDSB.MAUI/Resources/Styles/Styles.xaml
+++ b/src/GDSB.MAUI/Resources/Styles/Styles.xaml
@@ -476,4 +476,67 @@
         <Setter Property="CharacterSpacing" Value="0.4" />
     </Style>
 
+    <!-- Fase 3: sinalização de campo obrigatório e botão de ajuda contextual. -->
+
+    <!-- O asterisco fica em PrimaryDark (#F27BEB, 8.1:1 sobre o fundo) e não em Danger: campo
+         obrigatório é instrução, não erro - vermelho aqui faria o formulário parecer quebrado
+         antes de o usuário digitar qualquer coisa. -->
+    <Style x:Key="RequiredMarkStyle" TargetType="Label">
+        <Setter Property="TextColor" Value="{StaticResource PrimaryDark}" />
+        <Setter Property="FontFamily" Value="OpenSansSemibold" />
+        <Setter Property="FontSize" Value="13" />
+    </Style>
+
+    <Style x:Key="RequiredFieldsLegendStyle" TargetType="Label">
+        <Setter Property="TextColor" Value="{StaticResource TextMutedDark}" />
+        <Setter Property="FontSize" Value="11.5" />
+    </Style>
+
+    <!-- Círculo de 28px com o "?". Os MinimumHeight/WidthRequest de 44 do Style base de Button
+         são reduzidos aqui de propósito: um alvo de 44px ao lado de um label de 11px empurraria a
+         linha inteira e descolaria o "?" do campo que ele explica. 28px é o mesmo compromisso já
+         adotado nos botões de olho/copiar do app (36px em UnlockPage e ItemEditorView). -->
+    <Style x:Key="HelpButtonStyle" TargetType="Button">
+        <Setter Property="Text" Value="?" />
+        <Setter Property="BackgroundColor" Value="{StaticResource SurfaceElevatedDark}" />
+        <Setter Property="TextColor" Value="{StaticResource PrimaryDark}" />
+        <Setter Property="BorderColor" Value="{StaticResource BorderStrongDark}" />
+        <Setter Property="BorderWidth" Value="1" />
+        <Setter Property="FontFamily" Value="OpenSansSemibold" />
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="CornerRadius" Value="14" />
+        <Setter Property="WidthRequest" Value="28" />
+        <Setter Property="HeightRequest" Value="28" />
+        <Setter Property="MinimumWidthRequest" Value="28" />
+        <Setter Property="MinimumHeightRequest" Value="28" />
+        <Setter Property="Padding" Value="0" />
+    </Style>
+
+    <!-- Faixa onde cada amostra visual do painel de ajuda é embutida: o recuo e a borda são o que
+         faz a réplica ler como "isto é uma ilustração do controle", e não como um controle de
+         verdade no meio do texto. -->
+    <Style x:Key="HelpVisualFrameStyle" TargetType="Border">
+        <Setter Property="BackgroundColor" Value="{StaticResource SurfaceDark}" />
+        <Setter Property="Stroke" Value="{StaticResource BorderDarkBrush}" />
+        <Setter Property="StrokeThickness" Value="1" />
+        <Setter Property="StrokeShape" Value="RoundRectangle 12" />
+        <Setter Property="Padding" Value="16,18" />
+    </Style>
+
+    <Style x:Key="HelpVisualCaptionStyle" TargetType="Label">
+        <Setter Property="TextColor" Value="{StaticResource TextMutedDark}" />
+        <Setter Property="FontSize" Value="12" />
+    </Style>
+
+    <Style x:Key="HelpHeadingStyle" TargetType="Label">
+        <Setter Property="TextColor" Value="{StaticResource PrimaryDark}" />
+        <Setter Property="FontFamily" Value="OpenSansSemibold" />
+        <Setter Property="FontSize" Value="14" />
+    </Style>
+
+    <Style x:Key="HelpTextStyle" TargetType="Label">
+        <Setter Property="TextColor" Value="{StaticResource TextSecondaryDark}" />
+        <Setter Property="FontSize" Value="13.5" />
+    </Style>
+
 </ResourceDictionary>

--- a/src/GDSB.MAUI/Resources/Styles/Styles.xaml
+++ b/src/GDSB.MAUI/Resources/Styles/Styles.xaml
@@ -496,7 +496,9 @@
          são reduzidos aqui de propósito: um alvo de 44px ao lado de um label de 11px empurraria a
          linha inteira e descolaria o "?" do campo que ele explica. 28px é o mesmo compromisso já
          adotado nos botões de olho/copiar do app (36px em UnlockPage e ItemEditorView). -->
-    <Style x:Key="HelpButtonStyle" TargetType="Button">
+    <!-- ApplyToDerivedTypes: HelpButton (GDSB.MAUI.Views) é subclasse de Button e usa esta mesma
+         Style, como SelectableChip faz com o FilterChipStyle. -->
+    <Style x:Key="HelpButtonStyle" TargetType="Button" ApplyToDerivedTypes="True">
         <Setter Property="Text" Value="?" />
         <Setter Property="BackgroundColor" Value="{StaticResource SurfaceElevatedDark}" />
         <Setter Property="TextColor" Value="{StaticResource PrimaryDark}" />

--- a/src/GDSB.MAUI/UnlockPage.xaml
+++ b/src/GDSB.MAUI/UnlockPage.xaml
@@ -17,6 +17,31 @@
 
         <Grid RowDefinitions="*,Auto,*" Padding="32">
 
+            <!-- Porta de entrada do tutorial, fixa no topo e não junto dos links de rodapé: quem
+                 não entendeu a tela precisa achar isto ANTES de tentar mexer no bloco de
+                 desbloqueio. Vem em forma de pílula com o mesmo "?" dos campos, pra ser reconhecida
+                 como ajuda à primeira vista. -->
+            <Border Grid.Row="0" VerticalOptions="Start" HorizontalOptions="Center" Margin="0,4,0,0"
+                    BackgroundColor="{StaticResource SurfaceCardDark}" Stroke="{StaticResource BorderStrongDarkBrush}"
+                    StrokeThickness="1" StrokeShape="RoundRectangle 17" Padding="13,7"
+                    behaviors:HoverCursor.IsHand="True"
+                    SemanticProperties.Description="Como o GDSB funciona: rever o tutorial">
+                <Border.GestureRecognizers>
+                    <TapGestureRecognizer Command="{Binding ShowOnboardingCommand}" />
+                </Border.GestureRecognizers>
+                <HorizontalStackLayout Spacing="7">
+                    <Border WidthRequest="18" HeightRequest="18" StrokeShape="RoundRectangle 9"
+                            BackgroundColor="{StaticResource SurfaceElevatedDark}"
+                            Stroke="{StaticResource BorderStrongDarkBrush}" StrokeThickness="1"
+                            VerticalOptions="Center" InputTransparent="True">
+                        <Label Text="?" TextColor="{StaticResource PrimaryDark}" FontFamily="OpenSansSemibold"
+                               FontSize="10" HorizontalOptions="Center" VerticalOptions="Center" />
+                    </Border>
+                    <Label Text="Como funciona?" TextColor="{StaticResource TextSecondaryDark}"
+                           FontSize="13" VerticalOptions="Center" />
+                </HorizontalStackLayout>
+            </Border>
+
             <VerticalStackLayout Grid.Row="1" Spacing="32">
 
                 <VerticalStackLayout Spacing="14" HorizontalOptions="Center">
@@ -190,6 +215,10 @@
         </Grid>
 
         <views:BiometricOptInView BindingContext="{Binding BiometricOptIn}" />
+
+        <!-- Depois da BiometricOptInView de propósito: se as duas caírem juntas na tela, o tutorial
+             fica por cima - ele é que explica o que a outra está perguntando. -->
+        <views:OnboardingView BindingContext="{Binding Onboarding}" />
 
     </Grid>
 </ContentPage>

--- a/src/GDSB.MAUI/UnlockPage.xaml
+++ b/src/GDSB.MAUI/UnlockPage.xaml
@@ -15,204 +15,214 @@
 
     <Grid>
 
-        <Grid RowDefinitions="*,Auto,*" Padding="32">
+        <!-- Rola quando não cabe. Antes o conteúdo ficava num Grid de linhas "*,Auto,*" sem
+             ScrollView: numa janela baixa (ou num celular pequeno) as linhas "*" colapsavam, a
+             pílula do tutorial era a primeira coisa a sumir atrás da marca, e não havia como
+             alcançá-la. Agora a pílula tem linha própria Auto no topo, o miolo fica numa linha "*"
+             que só centraliza quando sobra espaço, e o que não couber vira rolagem.
+             O MinimumHeightRequest do conteúdo é ajustado em OnSizeAllocated para a altura visível
+             - é o que mantém a centralização vertical em tela grande sem impedir a rolagem em tela
+             pequena. -->
+        <ScrollView x:Name="RootScroll" Padding="32">
+            <Grid x:Name="UnlockContent" RowDefinitions="Auto,*" RowSpacing="20">
 
-            <!-- Porta de entrada do tutorial, fixa no topo e não junto dos links de rodapé: quem
-                 não entendeu a tela precisa achar isto ANTES de tentar mexer no bloco de
-                 desbloqueio. Vem em forma de pílula com o mesmo "?" dos campos, pra ser reconhecida
-                 como ajuda à primeira vista. -->
-            <Border Grid.Row="0" VerticalOptions="Start" HorizontalOptions="Center" Margin="0,4,0,0"
-                    BackgroundColor="{StaticResource SurfaceCardDark}" Stroke="{StaticResource BorderStrongDarkBrush}"
-                    StrokeThickness="1" StrokeShape="RoundRectangle 17" Padding="13,7"
-                    behaviors:HoverCursor.IsHand="True"
-                    SemanticProperties.Description="Como o GDSB funciona: rever o tutorial">
-                <Border.GestureRecognizers>
-                    <TapGestureRecognizer Command="{Binding ShowOnboardingCommand}" />
-                </Border.GestureRecognizers>
-                <HorizontalStackLayout Spacing="7">
-                    <Border WidthRequest="18" HeightRequest="18" StrokeShape="RoundRectangle 9"
-                            BackgroundColor="{StaticResource SurfaceElevatedDark}"
-                            Stroke="{StaticResource BorderStrongDarkBrush}" StrokeThickness="1"
-                            VerticalOptions="Center" InputTransparent="True">
-                        <Label Text="?" TextColor="{StaticResource PrimaryDark}" FontFamily="OpenSansSemibold"
-                               FontSize="10" HorizontalOptions="Center" VerticalOptions="Center" />
-                    </Border>
-                    <Label Text="Como funciona?" TextColor="{StaticResource TextSecondaryDark}"
-                           FontSize="13" VerticalOptions="Center" />
-                </HorizontalStackLayout>
-            </Border>
-
-            <VerticalStackLayout Grid.Row="1" Spacing="32">
-
-                <VerticalStackLayout Spacing="14" HorizontalOptions="Center">
-                    <!-- A marca de verdade, desenhada pelo BrandMarkDrawable a partir da mesma
-                         geometria das animações e do ícone do app. Antes era o emoji 🔒, que muda
-                         de desenho a cada plataforma e não aceita a cor da marca. -->
-                    <GraphicsView x:Name="BrandMark" WidthRequest="92" HeightRequest="92"
-                                  HorizontalOptions="Center" />
-                    <Label Text="GDSB" FontSize="26" FontFamily="OpenSansSemibold"
-                           TextColor="{StaticResource TextPrimaryDark}" HorizontalOptions="Center" />
-                    <Label Text="Seu cofre de senhas" FontSize="13"
-                           TextColor="{StaticResource TextSecondaryDark}" HorizontalOptions="Center" />
-                </VerticalStackLayout>
-
-                <Border Style="{StaticResource CardBorderStyle}" Padding="22" StrokeShape="RoundRectangle 20">
-                    <VerticalStackLayout Spacing="16">
-
-                        <!-- Com biometria ativa (CanUseBiometric) o campo de senha some por completo:
-                             o único jeito de abrir um cofre é aquele que a biometria mira, ou trocar
-                             de cofre (o que a desativa) - ver ChangeVaultCommand. Sem essa exclusão
-                             mútua, dava pra abrir manualmente um cofre B com uma biometria ainda
-                             selada com a senha do cofre A, e a tentativa seguinte por biometria
-                             abria B com a senha errada (a de A). -->
-                        <VerticalStackLayout Spacing="16" IsVisible="{Binding ShowManualUnlock}">
-
-                            <!-- Escolher o arquivo vem antes da senha: só depois de um cofre
-                                 selecionado é que faz sentido digitar a senha dele. -->
-                            <VerticalStackLayout Spacing="8">
-                                <Label Text="ARQUIVO DO COFRE" Style="{StaticResource FieldLabelStyle}" />
-                                <Button Text="Escolher arquivo do cofre"
-                                        Style="{StaticResource SecondaryActionButtonStyle}"
-                                        Command="{Binding PickVaultCommand}"
-                                        IsVisible="{Binding HasSelectedVault, Converter={StaticResource InvertedBoolConverter}}"
-                                        IsEnabled="{Binding CanInteract}" />
-
-                                <Border IsVisible="{Binding HasSelectedVault}"
-                                        BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
-                                        StrokeShape="RoundRectangle 12" Padding="14,10">
-                                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
-                                        <Label Grid.Column="0"
-                                               Text="{Binding SelectedVaultFileName}"
-                                               LineBreakMode="HeadTruncation"
-                                               MaxLines="1"
-                                               FontFamily="OpenSansSemibold" FontSize="14"
-                                               TextColor="{StaticResource TextPrimaryDark}"
-                                               VerticalOptions="Center" />
-                                        <Button Grid.Column="1"
-                                                Text="Trocar"
-                                                Command="{Binding ClearSelectedVaultCommand}"
-                                                BackgroundColor="Transparent"
-                                                TextColor="{StaticResource PrimaryDark}"
-                                                FontFamily="OpenSansSemibold" FontSize="13"
-                                                Padding="0" />
-                                    </Grid>
-                                </Border>
-                            </VerticalStackLayout>
-
-                            <VerticalStackLayout Spacing="8">
-                                <Label Text="SENHA MESTRA" Style="{StaticResource FieldLabelStyle}" />
-                                <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
-                                        StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="48"
-                                        IsEnabled="{Binding HasSelectedVault}"
-                                        Opacity="{Binding HasSelectedVault, Converter={StaticResource BoolToDimOpacityConverter}}">
-                                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
-                                        <Entry Grid.Column="0"
-                                               Placeholder="Digite sua senha mestra"
-                                               Text="{Binding Password}"
-                                               IsPassword="{Binding IsPasswordHidden}"
-                                               TextColor="{StaticResource TextPrimaryDark}"
-                                               PlaceholderColor="{StaticResource TextMutedDark}"
-                                               BackgroundColor="Transparent"
-                                               ReturnCommand="{Binding UnlockCommand}"
-                                               VerticalOptions="Center" />
-                                        <Button Grid.Column="1"
-                                                Text="{Binding EyeGlyph}"
-                                                Command="{Binding ToggleShowPasswordCommand}"
-                                                BackgroundColor="Transparent"
-                                                TextColor="{StaticResource TextSecondaryDark}"
-                                                FontSize="16"
-                                                Padding="0"
-                                                WidthRequest="36"
-                                                HeightRequest="36" />
-                                    </Grid>
-                                </Border>
-                            </VerticalStackLayout>
-
-                        </VerticalStackLayout>
-
-                        <Label Text="{Binding ErrorMessage}"
-                               TextColor="{StaticResource Danger}"
-                               FontSize="13"
-                               IsVisible="{Binding HasErrorMessage}" />
-
-                        <Button Text="{Binding UnlockButtonText}"
-                                Style="{StaticResource PrimaryActionButtonStyle}"
-                                Command="{Binding UnlockCommand}"
-                                IsVisible="{Binding ShowManualUnlock}"
-                                IsEnabled="{Binding HasSelectedVault}"
-                                Opacity="{Binding HasSelectedVault, Converter={StaticResource BoolToDimOpacityConverter}}" />
-
-                        <!-- Ao abrir a UnlockPage, a biometria já dispara sozinha quando disponível
-                             (UnlockViewModel.InitializeAsync) - este bloco mostra pra qual cofre ela
-                             está mirando e as duas únicas opções nesse estado: usá-la (opção
-                             principal - também serve de retry manual se o usuário cancelar o prompt
-                             do sistema sem querer) ou trocar de cofre. -->
-                        <VerticalStackLayout Spacing="10" IsVisible="{Binding CanUseBiometric}">
-                            <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
-                                    StrokeShape="RoundRectangle 12" Padding="14,10">
-                                <VerticalStackLayout Spacing="2">
-                                    <Label Text="BIOMETRIA CONFIGURADA PARA" Style="{StaticResource FieldLabelStyle}" />
-                                    <Label Text="{Binding BiometricVaultName}"
-                                           FontFamily="OpenSansSemibold" FontSize="14"
-                                           TextColor="{StaticResource TextPrimaryDark}"
-                                           LineBreakMode="TailTruncation" />
-                                </VerticalStackLayout>
-                            </Border>
-
-                            <!-- Button do MAUI não aceita conteúdo vetorial, então o ícone e o
-                                 rótulo ficam sobrepostos num Grid: o Button segue responsável
-                                 pelo toque, comando e estado, e a camada de cima é
-                                 InputTransparent (cascateia para os filhos). O texto sai do
-                                 Button para não aparecer duplicado. -->
-                            <Grid>
-                                <Button Style="{StaticResource PrimaryActionButtonStyle}"
-                                        Command="{Binding UnlockWithBiometricCommand}"
-                                        IsEnabled="{Binding CanInteract}"
-                                        SemanticProperties.Description="Desbloquear com biometria" />
-                                <HorizontalStackLayout HorizontalOptions="Center" VerticalOptions="Center"
-                                                       Spacing="9" InputTransparent="True">
-                                    <GraphicsView x:Name="BiometricButtonIcon"
-                                                  WidthRequest="18" HeightRequest="18"
-                                                  VerticalOptions="Center" />
-                                    <Label Text="Desbloquear com biometria"
-                                           TextColor="{StaticResource White}"
-                                           FontFamily="OpenSansSemibold" FontSize="15"
-                                           VerticalOptions="Center" />
-                                </HorizontalStackLayout>
-                            </Grid>
-
-                            <Button Text="Trocar cofre"
-                                    Style="{StaticResource SecondaryActionButtonStyle}"
-                                    Command="{Binding ChangeVaultCommand}"
-                                    IsEnabled="{Binding CanInteract}" />
-                        </VerticalStackLayout>
-
-                    </VerticalStackLayout>
+                <!-- Porta de entrada do tutorial, no topo e não junto dos links de rodapé: quem não
+                     entendeu a tela precisa achar isto ANTES de tentar mexer no bloco de desbloqueio.
+                     Vem em forma de pílula com o mesmo "?" dos campos, pra ser reconhecida como ajuda
+                     à primeira vista. -->
+                <Border Grid.Row="0" HorizontalOptions="Center"
+                        BackgroundColor="{StaticResource SurfaceCardDark}" Stroke="{StaticResource BorderStrongDarkBrush}"
+                        StrokeThickness="1" StrokeShape="RoundRectangle 17" Padding="13,7"
+                        behaviors:HoverCursor.IsHand="True"
+                        SemanticProperties.Description="Como o GDSB funciona: rever o tutorial">
+                    <Border.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding ShowOnboardingCommand}" />
+                    </Border.GestureRecognizers>
+                    <HorizontalStackLayout Spacing="7">
+                        <Border WidthRequest="18" HeightRequest="18" StrokeShape="RoundRectangle 9"
+                                BackgroundColor="{StaticResource SurfaceElevatedDark}"
+                                Stroke="{StaticResource BorderStrongDarkBrush}" StrokeThickness="1"
+                                VerticalOptions="Center" InputTransparent="True">
+                            <Label Text="?" TextColor="{StaticResource PrimaryDark}" FontFamily="OpenSansSemibold"
+                                   FontSize="10" HorizontalOptions="Center" VerticalOptions="Center" />
+                        </Border>
+                        <Label Text="Como funciona?" TextColor="{StaticResource TextSecondaryDark}"
+                               FontSize="13" VerticalOptions="Center" />
+                    </HorizontalStackLayout>
                 </Border>
 
-                <Label Text="Criar um cofre novo"
-                       TextColor="{StaticResource PrimaryDark}"
-                       FontSize="13"
-                       HorizontalOptions="Center"
-                       behaviors:HoverCursor.IsHand="True">
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding GoToCreateVaultCommand}" />
-                    </Label.GestureRecognizers>
-                </Label>
+                <VerticalStackLayout Grid.Row="1" Spacing="32" VerticalOptions="Center">
 
-                <Label Text="Recuperar de um backup"
-                       TextColor="{StaticResource TextSecondaryDark}"
-                       FontSize="13"
-                       HorizontalOptions="Center"
-                       behaviors:HoverCursor.IsHand="True">
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding GoToBackupRecoveryCommand}" />
-                    </Label.GestureRecognizers>
-                </Label>
+                    <VerticalStackLayout Spacing="14" HorizontalOptions="Center">
+                        <!-- A marca de verdade, desenhada pelo BrandMarkDrawable a partir da mesma
+                             geometria das animações e do ícone do app. Antes era o emoji 🔒, que muda
+                             de desenho a cada plataforma e não aceita a cor da marca. -->
+                        <GraphicsView x:Name="BrandMark" WidthRequest="92" HeightRequest="92"
+                                      HorizontalOptions="Center" />
+                        <Label Text="GDSB" FontSize="26" FontFamily="OpenSansSemibold"
+                               TextColor="{StaticResource TextPrimaryDark}" HorizontalOptions="Center" />
+                        <Label Text="Seu cofre de senhas" FontSize="13"
+                               TextColor="{StaticResource TextSecondaryDark}" HorizontalOptions="Center" />
+                    </VerticalStackLayout>
 
-            </VerticalStackLayout>
+                    <Border Style="{StaticResource CardBorderStyle}" Padding="22" StrokeShape="RoundRectangle 20">
+                        <VerticalStackLayout Spacing="16">
 
-        </Grid>
+                            <!-- Com biometria ativa (CanUseBiometric) o campo de senha some por completo:
+                                 o único jeito de abrir um cofre é aquele que a biometria mira, ou trocar
+                                 de cofre (o que a desativa) - ver ChangeVaultCommand. Sem essa exclusão
+                                 mútua, dava pra abrir manualmente um cofre B com uma biometria ainda
+                                 selada com a senha do cofre A, e a tentativa seguinte por biometria
+                                 abria B com a senha errada (a de A). -->
+                            <VerticalStackLayout Spacing="16" IsVisible="{Binding ShowManualUnlock}">
+
+                                <!-- Escolher o arquivo vem antes da senha: só depois de um cofre
+                                     selecionado é que faz sentido digitar a senha dele. -->
+                                <VerticalStackLayout Spacing="8">
+                                    <Label Text="ARQUIVO DO COFRE" Style="{StaticResource FieldLabelStyle}" />
+                                    <Button Text="Escolher arquivo do cofre"
+                                            Style="{StaticResource SecondaryActionButtonStyle}"
+                                            Command="{Binding PickVaultCommand}"
+                                            IsVisible="{Binding HasSelectedVault, Converter={StaticResource InvertedBoolConverter}}"
+                                            IsEnabled="{Binding CanInteract}" />
+
+                                    <Border IsVisible="{Binding HasSelectedVault}"
+                                            BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
+                                            StrokeShape="RoundRectangle 12" Padding="14,10">
+                                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                                            <Label Grid.Column="0"
+                                                   Text="{Binding SelectedVaultFileName}"
+                                                   LineBreakMode="HeadTruncation"
+                                                   MaxLines="1"
+                                                   FontFamily="OpenSansSemibold" FontSize="14"
+                                                   TextColor="{StaticResource TextPrimaryDark}"
+                                                   VerticalOptions="Center" />
+                                            <Button Grid.Column="1"
+                                                    Text="Trocar"
+                                                    Command="{Binding ClearSelectedVaultCommand}"
+                                                    BackgroundColor="Transparent"
+                                                    TextColor="{StaticResource PrimaryDark}"
+                                                    FontFamily="OpenSansSemibold" FontSize="13"
+                                                    Padding="0" />
+                                        </Grid>
+                                    </Border>
+                                </VerticalStackLayout>
+
+                                <VerticalStackLayout Spacing="8">
+                                    <Label Text="SENHA MESTRA" Style="{StaticResource FieldLabelStyle}" />
+                                    <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
+                                            StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="48"
+                                            IsEnabled="{Binding HasSelectedVault}"
+                                            Opacity="{Binding HasSelectedVault, Converter={StaticResource BoolToDimOpacityConverter}}">
+                                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+                                            <Entry Grid.Column="0"
+                                                   Placeholder="Digite sua senha mestra"
+                                                   Text="{Binding Password}"
+                                                   IsPassword="{Binding IsPasswordHidden}"
+                                                   TextColor="{StaticResource TextPrimaryDark}"
+                                                   PlaceholderColor="{StaticResource TextMutedDark}"
+                                                   BackgroundColor="Transparent"
+                                                   ReturnCommand="{Binding UnlockCommand}"
+                                                   VerticalOptions="Center" />
+                                            <Button Grid.Column="1"
+                                                    Text="{Binding EyeGlyph}"
+                                                    Command="{Binding ToggleShowPasswordCommand}"
+                                                    BackgroundColor="Transparent"
+                                                    TextColor="{StaticResource TextSecondaryDark}"
+                                                    FontSize="16"
+                                                    Padding="0"
+                                                    WidthRequest="36"
+                                                    HeightRequest="36" />
+                                        </Grid>
+                                    </Border>
+                                </VerticalStackLayout>
+
+                            </VerticalStackLayout>
+
+                            <Label Text="{Binding ErrorMessage}"
+                                   TextColor="{StaticResource Danger}"
+                                   FontSize="13"
+                                   IsVisible="{Binding HasErrorMessage}" />
+
+                            <Button Text="{Binding UnlockButtonText}"
+                                    Style="{StaticResource PrimaryActionButtonStyle}"
+                                    Command="{Binding UnlockCommand}"
+                                    IsVisible="{Binding ShowManualUnlock}"
+                                    IsEnabled="{Binding HasSelectedVault}"
+                                    Opacity="{Binding HasSelectedVault, Converter={StaticResource BoolToDimOpacityConverter}}" />
+
+                            <!-- Ao abrir a UnlockPage, a biometria já dispara sozinha quando disponível
+                                 (UnlockViewModel.InitializeAsync) - este bloco mostra pra qual cofre ela
+                                 está mirando e as duas únicas opções nesse estado: usá-la (opção
+                                 principal - também serve de retry manual se o usuário cancelar o prompt
+                                 do sistema sem querer) ou trocar de cofre. -->
+                            <VerticalStackLayout Spacing="10" IsVisible="{Binding CanUseBiometric}">
+                                <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
+                                        StrokeShape="RoundRectangle 12" Padding="14,10">
+                                    <VerticalStackLayout Spacing="2">
+                                        <Label Text="BIOMETRIA CONFIGURADA PARA" Style="{StaticResource FieldLabelStyle}" />
+                                        <Label Text="{Binding BiometricVaultName}"
+                                               FontFamily="OpenSansSemibold" FontSize="14"
+                                               TextColor="{StaticResource TextPrimaryDark}"
+                                               LineBreakMode="TailTruncation" />
+                                    </VerticalStackLayout>
+                                </Border>
+
+                                <!-- Button do MAUI não aceita conteúdo vetorial, então o ícone e o
+                                     rótulo ficam sobrepostos num Grid: o Button segue responsável
+                                     pelo toque, comando e estado, e a camada de cima é
+                                     InputTransparent (cascateia para os filhos). O texto sai do
+                                     Button para não aparecer duplicado. -->
+                                <Grid>
+                                    <Button Style="{StaticResource PrimaryActionButtonStyle}"
+                                            Command="{Binding UnlockWithBiometricCommand}"
+                                            IsEnabled="{Binding CanInteract}"
+                                            SemanticProperties.Description="Desbloquear com biometria" />
+                                    <HorizontalStackLayout HorizontalOptions="Center" VerticalOptions="Center"
+                                                           Spacing="9" InputTransparent="True">
+                                        <GraphicsView x:Name="BiometricButtonIcon"
+                                                      WidthRequest="18" HeightRequest="18"
+                                                      VerticalOptions="Center" />
+                                        <Label Text="Desbloquear com biometria"
+                                               TextColor="{StaticResource White}"
+                                               FontFamily="OpenSansSemibold" FontSize="15"
+                                               VerticalOptions="Center" />
+                                    </HorizontalStackLayout>
+                                </Grid>
+
+                                <Button Text="Trocar cofre"
+                                        Style="{StaticResource SecondaryActionButtonStyle}"
+                                        Command="{Binding ChangeVaultCommand}"
+                                        IsEnabled="{Binding CanInteract}" />
+                            </VerticalStackLayout>
+
+                        </VerticalStackLayout>
+                    </Border>
+
+                    <Label Text="Criar um cofre novo"
+                           TextColor="{StaticResource PrimaryDark}"
+                           FontSize="13"
+                           HorizontalOptions="Center"
+                           behaviors:HoverCursor.IsHand="True">
+                        <Label.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding GoToCreateVaultCommand}" />
+                        </Label.GestureRecognizers>
+                    </Label>
+
+                    <Label Text="Recuperar de um backup"
+                           TextColor="{StaticResource TextSecondaryDark}"
+                           FontSize="13"
+                           HorizontalOptions="Center"
+                           behaviors:HoverCursor.IsHand="True">
+                        <Label.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding GoToBackupRecoveryCommand}" />
+                        </Label.GestureRecognizers>
+                    </Label>
+
+                </VerticalStackLayout>
+
+            </Grid>
+        </ScrollView>
 
         <views:BiometricOptInView BindingContext="{Binding BiometricOptIn}" />
 

--- a/src/GDSB.MAUI/UnlockPage.xaml.cs
+++ b/src/GDSB.MAUI/UnlockPage.xaml.cs
@@ -1,4 +1,4 @@
-using GDSB.MAUI.ViewModels;
+﻿using GDSB.MAUI.ViewModels;
 using GDSB.MAUI.Views;
 
 namespace GDSB.MAUI;
@@ -21,6 +21,18 @@ public partial class UnlockPage : ContentPage
             StrokeWidth = 1.7f,
             Compact = true,
         };
+    }
+
+    // Mantém o conteúdo com pelo menos a altura visível: assim a linha "*" continua centralizando
+    // o bloco de desbloqueio quando sobra espaço, e o ScrollView assume quando não cabe (janela
+    // baixa no Windows, celular pequeno). Sem isto seria um ou outro - ou o conteúdo cola no topo
+    // sempre, ou nunca rola.
+    protected override void OnSizeAllocated(double width, double height)
+    {
+        base.OnSizeAllocated(width, height);
+
+        if (height > 0)
+            UnlockContent.MinimumHeightRequest = Math.Max(0, height - RootScroll.Padding.VerticalThickness);
     }
 
     protected override async void OnAppearing()

--- a/src/GDSB.MAUI/VaultPage.xaml
+++ b/src/GDSB.MAUI/VaultPage.xaml
@@ -235,5 +235,8 @@
              gravação no arquivo deu certo - ver SealOverlayView/LockSealDrawable. -->
         <views:SealOverlayView x:Name="SealOverlay" />
 
+        <!-- Atende os "?" do ItemEditorView, que é um ContentView e não tem overlay próprio. -->
+        <views:HelpSheetView x:Name="HelpSheet" />
+
     </Grid>
 </ContentPage>

--- a/src/GDSB.MAUI/VaultPage.xaml.cs
+++ b/src/GDSB.MAUI/VaultPage.xaml.cs
@@ -1,4 +1,4 @@
-using GDSB.MAUI.ViewModels;
+﻿using GDSB.MAUI.ViewModels;
 using GDSB.MAUI.Views;
 
 namespace GDSB.MAUI;
@@ -29,11 +29,22 @@ public partial class VaultPage : ContentPage
     {
         base.OnAppearing();
 
+        // O painel de ajuda só atende enquanto esta página está à vista: com Shell, a página
+        // anterior continua carregada na pilha, e sem isso o "?" de uma tela abriria o painel da
+        // outra também.
+        HelpSheet.StartListening();
+
 #if ANDROID
         // O teclado virtual pode continuar aberto do Entry de senha da tela anterior
         // (Unlock/CreateVault) - fecha explicitamente ao entrar no cofre.
         Platforms.Android.KeyboardDismissal.Hide();
 #endif
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        HelpSheet.StopListening();
     }
 
     private async void OnToastRequested(object? sender, string message)

--- a/src/GDSB.MAUI/VaultSettingsPage.xaml
+++ b/src/GDSB.MAUI/VaultSettingsPage.xaml
@@ -56,7 +56,7 @@
                     <!-- Bloco 1: nome -->
                     <Border Style="{StaticResource CardBorderStyle}" Padding="22" StrokeShape="RoundRectangle 20">
                         <VerticalStackLayout Spacing="14">
-                            <Label Text="NOME DO COFRE" Style="{StaticResource FieldLabelStyle}" />
+                            <views:FieldLabelView Text="NOME DO COFRE" HelpTopicId="vault.name" />
                             <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                                     StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="48">
                                 <Entry Text="{Binding VaultName}" TextColor="{StaticResource TextPrimaryDark}"
@@ -74,7 +74,7 @@
                     <Border Style="{StaticResource CardBorderStyle}" Padding="22" StrokeShape="RoundRectangle 20">
                         <VerticalStackLayout Spacing="18">
 
-                            <Label Text="PROTEÇÕES" Style="{StaticResource FieldLabelStyle}" />
+                            <views:FieldLabelView Text="PROTEÇÕES" HelpTopicId="vault.protections" />
 
                             <VerticalStackLayout Spacing="6">
                                 <Grid ColumnDefinitions="*,Auto">
@@ -134,7 +134,7 @@
                     <Border Style="{StaticResource CardBorderStyle}" Padding="22" StrokeShape="RoundRectangle 20">
                         <VerticalStackLayout Spacing="18">
 
-                            <Label Text="BACKUPS" Style="{StaticResource FieldLabelStyle}" />
+                            <views:FieldLabelView Text="BACKUPS" HelpTopicId="vault.backups" />
 
                             <VerticalStackLayout Spacing="6">
                                 <Label Text="Manter quantas versões"
@@ -196,7 +196,8 @@
                     <Border Style="{StaticResource CardBorderStyle}" Padding="22" StrokeShape="RoundRectangle 20">
                         <VerticalStackLayout Spacing="14">
 
-                            <Label Text="TROCAR SENHA MESTRA" Style="{StaticResource FieldLabelStyle}" />
+                            <views:FieldLabelView Text="TROCAR SENHA MESTRA"
+                                                  HelpTopicId="vault.changeMasterUnlockCode" />
 
                             <VerticalStackLayout Spacing="8">
                                 <Label Text="SENHA ATUAL" Style="{StaticResource FieldLabelStyle}" />
@@ -253,5 +254,7 @@
         <!-- Disparado por SettingsSaved, que só ocorre quando a gravação (nome, proteções ou
              senha) deu certo - ver SealOverlayView/LockSealDrawable. -->
         <views:SealOverlayView x:Name="SealOverlay" />
+
+        <views:HelpSheetView x:Name="HelpSheet" />
     </Grid>
 </ContentPage>

--- a/src/GDSB.MAUI/VaultSettingsPage.xaml.cs
+++ b/src/GDSB.MAUI/VaultSettingsPage.xaml.cs
@@ -1,4 +1,4 @@
-using GDSB.MAUI.ViewModels;
+﻿using GDSB.MAUI.ViewModels;
 using GDSB.MAUI.Views;
 
 namespace GDSB.MAUI;
@@ -13,6 +13,20 @@ public partial class VaultSettingsPage : ContentPage
         _viewModel = viewModel;
         BindingContext = _viewModel;
         _viewModel.SettingsSaved += OnSettingsSaved;
+    }
+
+    // O painel de ajuda só atende enquanto esta página está à vista: com Shell, a página anterior
+    // continua carregada na pilha, e sem isso o "?" de uma tela abriria o painel da outra também.
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        HelpSheet.StartListening();
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        HelpSheet.StopListening();
     }
 
     // S2325 ("make static") é falso positivo: SealOverlay é um elemento nomeado do XAML (campo de

--- a/src/GDSB.MAUI/Views/FieldLabelView.xaml
+++ b/src/GDSB.MAUI/Views/FieldLabelView.xaml
@@ -5,19 +5,23 @@
   para ele. Substitui os <Label Style="{StaticResource FieldLabelStyle}"> soltos das páginas, para
   que os três pedaços andem sempre juntos e com o mesmo espaçamento.
 
+  A altura mínima de 28 é a do "?" e vale mesmo sem ele: assim os rótulos de um mesmo formulário
+  ficam todos na mesma altura, com ou sem asterisco, e a lista de campos não fica serrilhada.
+
   Sem bindings para si mesmo (x:Reference): as três propriedades bindáveis escrevem direto nos
   elementos no code-behind. Assim o ContentView não precisa mexer no próprio BindingContext, que
   continua sendo o da página que o hospeda.
 -->
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:GDSB.MAUI.Views"
              x:Class="GDSB.MAUI.Views.FieldLabelView">
 
-    <HorizontalStackLayout Spacing="5">
+    <HorizontalStackLayout Spacing="5" MinimumHeightRequest="28">
         <Label x:Name="TextLabel" Style="{StaticResource FieldLabelStyle}" VerticalOptions="Center" />
         <Label x:Name="RequiredMark" Text="*" Style="{StaticResource RequiredMarkStyle}"
                VerticalOptions="Center" IsVisible="False" />
-        <Button x:Name="HelpButton" Style="{StaticResource HelpButtonStyle}"
-                VerticalOptions="Center" IsVisible="False" Clicked="OnHelpClicked" />
+        <views:HelpButton x:Name="HelpButton" Style="{StaticResource HelpButtonStyle}"
+                          VerticalOptions="Center" />
     </HorizontalStackLayout>
 </ContentView>

--- a/src/GDSB.MAUI/Views/FieldLabelView.xaml
+++ b/src/GDSB.MAUI/Views/FieldLabelView.xaml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Rótulo de campo de formulário: o texto em FieldLabelStyle, o asterisco de obrigatoriedade quando
+  o campo é exigido pela validação, e o "?" que abre o painel de ajuda quando existe um tópico
+  para ele. Substitui os <Label Style="{StaticResource FieldLabelStyle}"> soltos das páginas, para
+  que os três pedaços andem sempre juntos e com o mesmo espaçamento.
+
+  Sem bindings para si mesmo (x:Reference): as três propriedades bindáveis escrevem direto nos
+  elementos no code-behind. Assim o ContentView não precisa mexer no próprio BindingContext, que
+  continua sendo o da página que o hospeda.
+-->
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="GDSB.MAUI.Views.FieldLabelView">
+
+    <HorizontalStackLayout Spacing="5">
+        <Label x:Name="TextLabel" Style="{StaticResource FieldLabelStyle}" VerticalOptions="Center" />
+        <Label x:Name="RequiredMark" Text="*" Style="{StaticResource RequiredMarkStyle}"
+               VerticalOptions="Center" IsVisible="False" />
+        <Button x:Name="HelpButton" Style="{StaticResource HelpButtonStyle}"
+                VerticalOptions="Center" IsVisible="False" Clicked="OnHelpClicked" />
+    </HorizontalStackLayout>
+</ContentView>

--- a/src/GDSB.MAUI/Views/FieldLabelView.xaml
+++ b/src/GDSB.MAUI/Views/FieldLabelView.xaml
@@ -21,7 +21,7 @@
         <Label x:Name="TextLabel" Style="{StaticResource FieldLabelStyle}" VerticalOptions="Center" />
         <Label x:Name="RequiredMark" Text="*" Style="{StaticResource RequiredMarkStyle}"
                VerticalOptions="Center" IsVisible="False" />
-        <views:HelpButton x:Name="HelpButton" Style="{StaticResource HelpButtonStyle}"
+        <views:HelpButton x:Name="HelpAction" Style="{StaticResource HelpButtonStyle}"
                           VerticalOptions="Center" />
     </HorizontalStackLayout>
 </ContentView>

--- a/src/GDSB.MAUI/Views/FieldLabelView.xaml.cs
+++ b/src/GDSB.MAUI/Views/FieldLabelView.xaml.cs
@@ -1,6 +1,3 @@
-using CommunityToolkit.Mvvm.Messaging;
-using GDSB.MAUI.Help;
-
 namespace GDSB.MAUI.Views;
 
 public partial class FieldLabelView : ContentView
@@ -33,7 +30,7 @@ public partial class FieldLabelView : ContentView
         set => SetValue(IsRequiredProperty, value);
     }
 
-    /// <summary>Id de um tópico de <see cref="HelpTopics.Ids"/>. Vazio esconde o "?".</summary>
+    /// <summary>Id de um tópico de HelpTopics.Ids. Vazio esconde o "?".</summary>
     public string? HelpTopicId
     {
         get => (string?)GetValue(HelpTopicIdProperty);
@@ -44,12 +41,6 @@ public partial class FieldLabelView : ContentView
     public FieldLabelView()
     {
         InitializeComponent();
-    }
-
-    private void OnHelpClicked(object? sender, EventArgs e)
-    {
-        if (!string.IsNullOrEmpty(HelpTopicId))
-            WeakReferenceMessenger.Default.Send(new HelpRequestedMessage(HelpTopicId));
     }
 
     // oldValue é ignorado de propósito nos três callbacks, mas não dá pra remover: a assinatura é
@@ -68,7 +59,9 @@ public partial class FieldLabelView : ContentView
     private static void OnHelpTopicIdChanged(BindableObject bindable, object oldValue, object newValue)
     {
         var view = (FieldLabelView)bindable;
-        view.HelpButton.IsVisible = !string.IsNullOrEmpty(newValue as string);
+
+        // O HelpButton já se esconde sozinho quando o TopicId é vazio - aqui só se repassa o valor.
+        view.HelpButton.TopicId = newValue as string;
         view.RefreshHelpSemantics();
     }
 #pragma warning restore S1172

--- a/src/GDSB.MAUI/Views/FieldLabelView.xaml.cs
+++ b/src/GDSB.MAUI/Views/FieldLabelView.xaml.cs
@@ -1,0 +1,82 @@
+using CommunityToolkit.Mvvm.Messaging;
+using GDSB.MAUI.Help;
+
+namespace GDSB.MAUI.Views;
+
+public partial class FieldLabelView : ContentView
+{
+    public static readonly BindableProperty TextProperty = BindableProperty.Create(
+        nameof(Text), typeof(string), typeof(FieldLabelView), string.Empty, propertyChanged: OnTextChanged);
+
+    public static readonly BindableProperty IsRequiredProperty = BindableProperty.Create(
+        nameof(IsRequired), typeof(bool), typeof(FieldLabelView), false, propertyChanged: OnIsRequiredChanged);
+
+    public static readonly BindableProperty HelpTopicIdProperty = BindableProperty.Create(
+        nameof(HelpTopicId), typeof(string), typeof(FieldLabelView), null, propertyChanged: OnHelpTopicIdChanged);
+
+    // S2325 é falso positivo, como em SelectableChip: GetValue/SetValue são métodos de instância
+    // de BindableObject - uma bindable property não existe sem instância.
+#pragma warning disable S2325
+    public string Text
+    {
+        get => (string)GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+    /// <summary>
+    /// Marca o campo com o asterisco de destaque. Só para o que a validação realmente cobra -
+    /// campo opcional não recebe marca nenhuma, senão o asterisco perde o significado.
+    /// </summary>
+    public bool IsRequired
+    {
+        get => (bool)GetValue(IsRequiredProperty);
+        set => SetValue(IsRequiredProperty, value);
+    }
+
+    /// <summary>Id de um tópico de <see cref="HelpTopics.Ids"/>. Vazio esconde o "?".</summary>
+    public string? HelpTopicId
+    {
+        get => (string?)GetValue(HelpTopicIdProperty);
+        set => SetValue(HelpTopicIdProperty, value);
+    }
+#pragma warning restore S2325
+
+    public FieldLabelView()
+    {
+        InitializeComponent();
+    }
+
+    private void OnHelpClicked(object? sender, EventArgs e)
+    {
+        if (!string.IsNullOrEmpty(HelpTopicId))
+            WeakReferenceMessenger.Default.Send(new HelpRequestedMessage(HelpTopicId));
+    }
+
+    // oldValue é ignorado de propósito nos três callbacks, mas não dá pra remover: a assinatura é
+    // fixa pelo delegate esperado por BindableProperty.Create. Mesmo caso de SelectableChip.
+#pragma warning disable S1172
+    private static void OnTextChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        var view = (FieldLabelView)bindable;
+        view.TextLabel.Text = newValue as string ?? string.Empty;
+        view.RefreshHelpSemantics();
+    }
+
+    private static void OnIsRequiredChanged(BindableObject bindable, object oldValue, object newValue) =>
+        ((FieldLabelView)bindable).RequiredMark.IsVisible = (bool)newValue;
+
+    private static void OnHelpTopicIdChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        var view = (FieldLabelView)bindable;
+        view.HelpButton.IsVisible = !string.IsNullOrEmpty(newValue as string);
+        view.RefreshHelpSemantics();
+    }
+#pragma warning restore S1172
+
+    /// <summary>
+    /// O "?" sozinho não diz nada para um leitor de tela - a descrição precisa citar o campo de
+    /// que ele fala.
+    /// </summary>
+    private void RefreshHelpSemantics() =>
+        SemanticProperties.SetDescription(HelpButton, $"Ajuda sobre {Text}");
+}

--- a/src/GDSB.MAUI/Views/FieldLabelView.xaml.cs
+++ b/src/GDSB.MAUI/Views/FieldLabelView.xaml.cs
@@ -61,7 +61,7 @@ public partial class FieldLabelView : ContentView
         var view = (FieldLabelView)bindable;
 
         // O HelpButton já se esconde sozinho quando o TopicId é vazio - aqui só se repassa o valor.
-        view.HelpButton.TopicId = newValue as string;
+        view.HelpAction.TopicId = newValue as string;
         view.RefreshHelpSemantics();
     }
 #pragma warning restore S1172
@@ -71,5 +71,5 @@ public partial class FieldLabelView : ContentView
     /// que ele fala.
     /// </summary>
     private void RefreshHelpSemantics() =>
-        SemanticProperties.SetDescription(HelpButton, $"Ajuda sobre {Text}");
+        SemanticProperties.SetDescription(HelpAction, $"Ajuda sobre {Text}");
 }

--- a/src/GDSB.MAUI/Views/HelpButton.cs
+++ b/src/GDSB.MAUI/Views/HelpButton.cs
@@ -1,0 +1,49 @@
+using CommunityToolkit.Mvvm.Messaging;
+using GDSB.MAUI.Help;
+
+namespace GDSB.MAUI.Views;
+
+/// <summary>
+/// O "?" que abre o painel de ajuda. Existe como controle próprio, e não como um Button com um
+/// Clicked em cada code-behind, porque ele aparece em quatro telas - repetir a publicação da
+/// mensagem em cada uma seria o mesmo bloco copiado quatro vezes.
+///
+/// Subclasse de Button (como SelectableChip) para herdar o HelpButtonStyle, que por isso precisa
+/// de ApplyToDerivedTypes="True".
+/// </summary>
+public class HelpButton : Button
+{
+    public static readonly BindableProperty TopicIdProperty = BindableProperty.Create(
+        nameof(TopicId), typeof(string), typeof(HelpButton), null, propertyChanged: OnTopicIdChanged);
+
+    // S2325 é falso positivo, como em SelectableChip: GetValue/SetValue são métodos de instância
+    // de BindableObject - uma bindable property não existe sem instância.
+#pragma warning disable S2325
+    /// <summary>Id de um tópico de <see cref="HelpTopics.Ids"/>. Vazio esconde o botão.</summary>
+    public string? TopicId
+    {
+        get => (string?)GetValue(TopicIdProperty);
+        set => SetValue(TopicIdProperty, value);
+    }
+#pragma warning restore S2325
+
+    public HelpButton()
+    {
+        IsVisible = false;
+        SemanticProperties.SetDescription(this, "Ajuda");
+        Clicked += OnClicked;
+    }
+
+    private void OnClicked(object? sender, EventArgs e)
+    {
+        if (!string.IsNullOrEmpty(TopicId))
+            WeakReferenceMessenger.Default.Send(new HelpRequestedMessage(TopicId));
+    }
+
+    // oldValue é ignorado de propósito, mas não dá pra remover: a assinatura é fixa pelo delegate
+    // esperado por BindableProperty.Create. Mesmo caso de SelectableChip.
+#pragma warning disable S1172
+    private static void OnTopicIdChanged(BindableObject bindable, object oldValue, object newValue) =>
+        ((HelpButton)bindable).IsVisible = !string.IsNullOrEmpty(newValue as string);
+#pragma warning restore S1172
+}

--- a/src/GDSB.MAUI/Views/HelpSheetView.xaml
+++ b/src/GDSB.MAUI/Views/HelpSheetView.xaml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Painel de ajuda contextual. Mesmo padrão de overlay dos três modais de BackupRecoveryPage.xaml e
+  do BiometricOptInView (#CC141414 por cima da tela inteira), e não um DisplayAlert do sistema: o
+  alerta nativo não aceita as cores do app nem consegue mostrar a réplica do controle explicado,
+  que é justamente o ponto desta ajuda.
+
+  O conteúdo é montado no code-behind a partir do catálogo em GDSB.MAUI.Help.HelpTopics - o XAML
+  aqui é só a moldura (título, área rolável e o "Entendi").
+-->
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="GDSB.MAUI.Views.HelpSheetView">
+
+    <Grid x:Name="Overlay" IsVisible="False" BackgroundColor="#CC141414" Padding="20,44">
+        <Border Style="{StaticResource CardBorderStyle}" Padding="0" StrokeShape="RoundRectangle 20"
+                VerticalOptions="Fill" HorizontalOptions="Fill" MaximumWidthRequest="460">
+            <Grid RowDefinitions="Auto,*,Auto" RowSpacing="16" Padding="22">
+
+                <Label x:Name="TitleLabel" Grid.Row="0"
+                       FontFamily="OpenSansSemibold" FontSize="18"
+                       TextColor="{StaticResource TextPrimaryDark}" />
+
+                <ScrollView Grid.Row="1">
+                    <VerticalStackLayout x:Name="BlocksHost" Spacing="14" />
+                </ScrollView>
+
+                <Button Grid.Row="2" Text="Entendi" Style="{StaticResource PrimaryActionButtonStyle}"
+                        Clicked="OnDismissClicked" />
+
+            </Grid>
+        </Border>
+    </Grid>
+</ContentView>

--- a/src/GDSB.MAUI/Views/HelpSheetView.xaml.cs
+++ b/src/GDSB.MAUI/Views/HelpSheetView.xaml.cs
@@ -29,6 +29,11 @@ public partial class HelpSheetView : ContentView
 
     public void StopListening() => WeakReferenceMessenger.Default.Unregister<HelpRequestedMessage>(this);
 
+    // S2325 ("make static") é falso positivo em Show/Hide: os dois só tocam TitleLabel, BlocksHost
+    // e Overlay, que são campos de instância gerados pelo InitializeComponent - o Sonar não
+    // resolve esse tipo de campo e conclui que o método não usa estado nenhum. Mesmo caso de
+    // BackupRecoveryPage.OnBackupDeleted e VaultPage.OnSecretDeleted.
+#pragma warning disable S2325
     public void Show(string topicId)
     {
         if (!HelpTopics.TryGet(topicId, out var topic))
@@ -58,6 +63,7 @@ public partial class HelpSheetView : ContentView
         // atrás de um IsVisible=False até a próxima abertura.
         BlocksHost.Clear();
     }
+#pragma warning restore S2325
 
     private void OnDismissClicked(object? sender, EventArgs e) => Hide();
 

--- a/src/GDSB.MAUI/Views/HelpSheetView.xaml.cs
+++ b/src/GDSB.MAUI/Views/HelpSheetView.xaml.cs
@@ -95,7 +95,12 @@ public partial class HelpSheetView : ContentView
     /// </summary>
     private static View? ResolveVisual(string visualId)
     {
-        if (Application.Current?.Resources.TryGetValue(visualId, out var resource) == true
+        // Guardar o dicionário numa variável, em vez de encadear o acesso condicional e comparar o
+        // bool? resultante com um literal, é o mesmo desenho de SelectableChip.ResourceColor.
+        var resources = Application.Current?.Resources;
+
+        if (resources is not null
+            && resources.TryGetValue(visualId, out var resource)
             && resource is DataTemplate template
             && template.CreateContent() is View view)
         {
@@ -110,8 +115,12 @@ public partial class HelpSheetView : ContentView
 #endif
     }
 
-    private static Style? FindStyle(string key) =>
-        Application.Current?.Resources.TryGetValue(key, out var value) == true && value is Style style
+    private static Style? FindStyle(string key)
+    {
+        var resources = Application.Current?.Resources;
+
+        return resources is not null && resources.TryGetValue(key, out var value) && value is Style style
             ? style
             : null;
+    }
 }

--- a/src/GDSB.MAUI/Views/HelpSheetView.xaml.cs
+++ b/src/GDSB.MAUI/Views/HelpSheetView.xaml.cs
@@ -1,0 +1,111 @@
+using CommunityToolkit.Mvvm.Messaging;
+using GDSB.MAUI.Help;
+
+namespace GDSB.MAUI.Views;
+
+public partial class HelpSheetView : ContentView
+{
+    public HelpSheetView()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// Passa a atender os pedidos de ajuda publicados pelos botões "?". Chamado no OnAppearing da
+    /// página que hospeda o painel, e desfeito no OnDisappearing: com Shell, a página anterior
+    /// continua carregada na pilha de navegação, então amarrar isso a Loaded/Unloaded faria o
+    /// painel de uma tela que não está à vista responder ao "?" de outra.
+    /// </summary>
+    public void StartListening()
+    {
+        // Registrar duas vezes o mesmo destinatário lança no WeakReferenceMessenger, e há
+        // caminhos de navegação em que OnAppearing roda sem um OnDisappearing antes - desfazer
+        // primeiro (operação idempotente) é mais barato do que confiar no pareamento.
+        StopListening();
+
+        WeakReferenceMessenger.Default.Register<HelpRequestedMessage>(
+            this, static (recipient, message) => ((HelpSheetView)recipient).Show(message.TopicId));
+    }
+
+    public void StopListening() => WeakReferenceMessenger.Default.Unregister<HelpRequestedMessage>(this);
+
+    public void Show(string topicId)
+    {
+        if (!HelpTopics.TryGet(topicId, out var topic))
+        {
+#if DEBUG
+            throw new InvalidOperationException(
+                $"Tópico de ajuda '{topicId}' não existe em HelpTopics. Um \"?\" do XAML está apontando para um id que ninguém declarou.");
+#else
+            return;
+#endif
+        }
+
+        TitleLabel.Text = topic.Title;
+
+        BlocksHost.Clear();
+        foreach (var block in topic.Blocks)
+            BlocksHost.Add(CreateBlockView(block));
+
+        Overlay.IsVisible = true;
+    }
+
+    public void Hide()
+    {
+        Overlay.IsVisible = false;
+
+        // Solta as réplicas (e as animações da mãozinha dentro delas) em vez de deixá-las vivas
+        // atrás de um IsVisible=False até a próxima abertura.
+        BlocksHost.Clear();
+    }
+
+    private void OnDismissClicked(object? sender, EventArgs e) => Hide();
+
+    private static View CreateBlockView(HelpBlock block) => block.Kind switch
+    {
+        HelpBlockKind.Heading => new Label { Text = block.Value, Style = FindStyle("HelpHeadingStyle") },
+        HelpBlockKind.Visual => CreateVisualView(block),
+        _ => new Label { Text = block.Value, Style = FindStyle("HelpTextStyle") },
+    };
+
+    private static View CreateVisualView(HelpBlock block)
+    {
+        var caption = new Label { Text = block.Caption ?? string.Empty, Style = FindStyle("HelpVisualCaptionStyle") };
+        var sample = ResolveVisual(block.Value);
+
+        if (sample is null)
+            return caption;
+
+        var frame = new Border { Style = FindStyle("HelpVisualFrameStyle"), Content = sample };
+
+        return new VerticalStackLayout { Spacing = 8, Children = { frame, caption } };
+    }
+
+    /// <summary>
+    /// Resolve a chave da amostra no dicionário Resources/HelpVisuals.xaml, agregado em App.xaml.
+    /// O projeto de teste é net10.0 puro e não enxerga XAML, então esta correspondência não pode
+    /// ser coberta por teste: em DEBUG ela falha alto, para uma chave sem template não passar
+    /// despercebida como um quadro em branco no meio do painel.
+    /// </summary>
+    private static View? ResolveVisual(string visualId)
+    {
+        if (Application.Current?.Resources.TryGetValue(visualId, out var resource) == true
+            && resource is DataTemplate template
+            && template.CreateContent() is View view)
+        {
+            return view;
+        }
+
+#if DEBUG
+        throw new InvalidOperationException(
+            $"Amostra visual '{visualId}' não tem DataTemplate em Resources/HelpVisuals.xaml.");
+#else
+        return null;
+#endif
+    }
+
+    private static Style? FindStyle(string key) =>
+        Application.Current?.Resources.TryGetValue(key, out var value) == true && value is Style style
+            ? style
+            : null;
+}

--- a/src/GDSB.MAUI/Views/ItemEditorView.xaml
+++ b/src/GDSB.MAUI/Views/ItemEditorView.xaml
@@ -8,6 +8,7 @@
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:behaviors="clr-namespace:GDSB.MAUI.Behaviors"
+             xmlns:views="clr-namespace:GDSB.MAUI.Views"
              x:Class="GDSB.MAUI.Views.ItemEditorView">
 
     <VerticalStackLayout Spacing="16">
@@ -103,7 +104,7 @@
         <VerticalStackLayout Spacing="16" IsVisible="{Binding IsEditingItem}">
 
             <VerticalStackLayout Spacing="8">
-                <Label Text="NOME" Style="{StaticResource FieldLabelStyle}" />
+                <views:FieldLabelView Text="NOME" IsRequired="True" />
                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                         StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="46">
                     <Entry Text="{Binding EditBoxName}" Placeholder="Ex.: Netflix"
@@ -113,7 +114,7 @@
             </VerticalStackLayout>
 
             <VerticalStackLayout Spacing="8">
-                <Label Text="URL" Style="{StaticResource FieldLabelStyle}" />
+                <views:FieldLabelView Text="URL" HelpTopicId="secret.url" />
                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                         StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="46">
                     <Entry Text="{Binding EditUrl}" Placeholder="site.com" Keyboard="Url"
@@ -123,7 +124,7 @@
             </VerticalStackLayout>
 
             <VerticalStackLayout Spacing="8">
-                <Label Text="USUÁRIO" Style="{StaticResource FieldLabelStyle}" />
+                <views:FieldLabelView Text="USUÁRIO" />
                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                         StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="46">
                     <Entry Text="{Binding EditUser}"
@@ -133,7 +134,7 @@
             </VerticalStackLayout>
 
             <VerticalStackLayout Spacing="8">
-                <Label Text="SENHA" Style="{StaticResource FieldLabelStyle}" />
+                <views:FieldLabelView Text="SENHA" IsRequired="True" HelpTopicId="secret.storedValue" />
                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                         StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="46">
                     <Entry Text="{Binding EditPassword}" IsPassword="True"
@@ -143,7 +144,7 @@
             </VerticalStackLayout>
 
             <VerticalStackLayout Spacing="8">
-                <Label Text="OBSERVAÇÕES" Style="{StaticResource FieldLabelStyle}" />
+                <views:FieldLabelView Text="OBSERVAÇÕES" />
                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                         StrokeShape="RoundRectangle 12" Padding="14,10">
                     <Editor Text="{Binding EditObs}" AutoSize="TextChanges" MinimumHeightRequest="72"
@@ -155,7 +156,11 @@
             <HorizontalStackLayout Spacing="10">
                 <CheckBox IsChecked="{Binding EditFavorito}" Color="{StaticResource FavoriteGold}" />
                 <Label Text="Marcar como favorito" TextColor="{StaticResource TextPrimaryDark}" FontSize="14" VerticalOptions="Center" />
+                <views:HelpButton TopicId="secret.favorite" Style="{StaticResource HelpButtonStyle}"
+                                  VerticalOptions="Center" />
             </HorizontalStackLayout>
+
+            <Label Text="* campos obrigatórios" Style="{StaticResource RequiredFieldsLegendStyle}" />
 
             <Label Text="{Binding ValidationError}" TextColor="{StaticResource Danger}" FontSize="13"
                    IsVisible="{Binding HasValidationError}" />

--- a/src/GDSB.MAUI/Views/OnboardingView.xaml
+++ b/src/GDSB.MAUI/Views/OnboardingView.xaml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Tutorial de primeiro acesso: três slides por cima da tela de desbloqueio. Mesmo overlay dos
+  outros diálogos do app (#CC141414), e não uma página separada, para o usuário nunca perder de
+  vista onde está - o tutorial explica ESTA tela, então ela continua atrás dele.
+
+  Cada slide traz uma ilustração antes do texto. As duas últimas não são desenhos genéricos: são
+  réplicas inertes dos controles de verdade desta mesma tela, com a mãozinha em cima. O slide
+  "Criar um cofre" aponta o link que o usuário vai tocar assim que fechar o tutorial, e "Abrir
+  depois" aponta o botão de biometria - é o que transforma o tutorial em orientação ("é ali") em
+  vez de texto solto.
+
+  A troca de slide é por IsVisible + EqualsConverter sobre CurrentIndex (o mesmo conversor global
+  que os chips já usam), sem CarouselView: são três telas fixas, e o CarouselView traria gesto de
+  arraste concorrendo com o scroll do texto.
+-->
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:GDSB.MAUI.Views"
+             x:Class="GDSB.MAUI.Views.OnboardingView">
+
+    <Grid IsVisible="{Binding IsVisible}" BackgroundColor="#CC141414" Padding="24,40">
+        <Border Style="{StaticResource CardBorderStyle}" Padding="0" StrokeShape="RoundRectangle 20"
+                VerticalOptions="Center" HorizontalOptions="Fill" MaximumWidthRequest="420">
+            <Grid RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="18" Padding="24">
+
+                <!-- ===== Ilustração do slide ===== -->
+                <Grid Grid.Row="0" HeightRequest="150">
+
+                    <!-- Slide 1: o cofre é um arquivo que mora com você, não no app. -->
+                    <VerticalStackLayout Spacing="10" HorizontalOptions="Center" VerticalOptions="Center"
+                                         IsVisible="{Binding CurrentIndex, Converter={StaticResource EqualsConverter}, ConverterParameter=0}">
+                        <Border WidthRequest="112" HeightRequest="112" StrokeShape="RoundRectangle 16"
+                                BackgroundColor="{StaticResource SurfaceElevatedDark}"
+                                Stroke="{StaticResource BorderStrongDarkBrush}" StrokeThickness="1"
+                                HorizontalOptions="Center">
+                            <VerticalStackLayout Spacing="6" HorizontalOptions="Center" VerticalOptions="Center">
+                                <GraphicsView x:Name="VaultFileMark" WidthRequest="52" HeightRequest="52"
+                                              HorizontalOptions="Center" />
+                                <Label Text="meu-cofre.GDSBX" FontSize="10"
+                                       TextColor="{StaticResource TextSecondaryDark}"
+                                       HorizontalOptions="Center" />
+                            </VerticalStackLayout>
+                        </Border>
+                        <Label Text="Um arquivo seu, guardado onde você quiser"
+                               FontSize="11.5" TextColor="{StaticResource TextMutedDark}"
+                               HorizontalOptions="Center" HorizontalTextAlignment="Center" />
+                    </VerticalStackLayout>
+
+                    <!-- Slide 2: réplica do link "Criar um cofre novo" desta mesma tela. -->
+                    <VerticalStackLayout Spacing="10" HorizontalOptions="Center" VerticalOptions="Center"
+                                         IsVisible="{Binding CurrentIndex, Converter={StaticResource EqualsConverter}, ConverterParameter=1}">
+                        <Border Style="{StaticResource HelpVisualFrameStyle}" HorizontalOptions="Center">
+                            <Grid InputTransparent="True" Padding="0,0,0,20">
+                                <Label Text="Criar um cofre novo" TextColor="{StaticResource PrimaryDark}"
+                                       FontSize="14" VerticalOptions="Start" HorizontalOptions="Center" />
+                                <views:TapHintView HorizontalOptions="Center" VerticalOptions="Start"
+                                                   Margin="0,10,0,0" />
+                            </Grid>
+                        </Border>
+                        <Label Text="É este link, logo abaixo do cartão de senha"
+                               FontSize="11.5" TextColor="{StaticResource TextMutedDark}"
+                               HorizontalOptions="Center" HorizontalTextAlignment="Center" />
+                    </VerticalStackLayout>
+
+                    <!-- Slide 3: réplica do botão de biometria, com o mesmo ícone vetorial do real. -->
+                    <VerticalStackLayout Spacing="10" HorizontalOptions="Center" VerticalOptions="Center"
+                                         IsVisible="{Binding CurrentIndex, Converter={StaticResource EqualsConverter}, ConverterParameter=2}">
+                        <Border Style="{StaticResource HelpVisualFrameStyle}" HorizontalOptions="Center">
+                            <Grid InputTransparent="True" Padding="0,0,0,20">
+                                <Grid VerticalOptions="Start" WidthRequest="220">
+                                    <Button Style="{StaticResource PrimaryActionButtonStyle}" HeightRequest="46" />
+                                    <HorizontalStackLayout HorizontalOptions="Center" VerticalOptions="Center"
+                                                           Spacing="9" InputTransparent="True">
+                                        <GraphicsView x:Name="BiometricSampleIcon" WidthRequest="18" HeightRequest="18"
+                                                      VerticalOptions="Center" />
+                                        <Label Text="Desbloquear com biometria" TextColor="{StaticResource White}"
+                                               FontFamily="OpenSansSemibold" FontSize="14" VerticalOptions="Center" />
+                                    </HorizontalStackLayout>
+                                </Grid>
+                                <views:TapHintView HorizontalOptions="Center" VerticalOptions="Start"
+                                                   Margin="0,18,0,0" />
+                            </Grid>
+                        </Border>
+                        <Label Text="Aparece no lugar do campo de senha depois que você liga a digital"
+                               FontSize="11.5" TextColor="{StaticResource TextMutedDark}"
+                               HorizontalOptions="Center" HorizontalTextAlignment="Center" />
+                    </VerticalStackLayout>
+
+                </Grid>
+
+                <!-- ===== Texto do slide ===== -->
+                <VerticalStackLayout Grid.Row="1" Spacing="10">
+                    <Label Text="{Binding CurrentSlide.Title}" FontFamily="OpenSansSemibold" FontSize="19"
+                           TextColor="{StaticResource TextPrimaryDark}" HorizontalTextAlignment="Center" />
+                    <Label Text="{Binding CurrentSlide.Body}" FontSize="13.5"
+                           TextColor="{StaticResource TextSecondaryDark}" HorizontalTextAlignment="Center" />
+                </VerticalStackLayout>
+
+                <IndicatorView Grid.Row="2"
+                               Count="{Binding SlideCount}" Position="{Binding CurrentIndex}"
+                               IndicatorColor="{StaticResource BorderStrongDark}"
+                               SelectedIndicatorColor="{StaticResource PrimaryDark}"
+                               IndicatorSize="7" HorizontalOptions="Center" />
+
+                <VerticalStackLayout Grid.Row="3" Spacing="10">
+                    <Button Text="{Binding AdvanceButtonText}" Style="{StaticResource PrimaryActionButtonStyle}"
+                            Command="{Binding AdvanceCommand}" />
+                    <Button Text="Pular" Style="{StaticResource SecondaryActionButtonStyle}"
+                            Command="{Binding SkipCommand}" IsVisible="{Binding ShowSkip}" />
+                </VerticalStackLayout>
+
+            </Grid>
+        </Border>
+    </Grid>
+</ContentView>

--- a/src/GDSB.MAUI/Views/OnboardingView.xaml.cs
+++ b/src/GDSB.MAUI/Views/OnboardingView.xaml.cs
@@ -1,0 +1,22 @@
+namespace GDSB.MAUI.Views;
+
+public partial class OnboardingView : ContentView
+{
+    public OnboardingView()
+    {
+        InitializeComponent();
+
+        // A mesma marca da tela de desbloqueio, aberta: no primeiro slide ela ilustra o conteúdo
+        // do arquivo, que ainda não foi selado por nenhuma senha.
+        VaultFileMark.Drawable = new BrandMarkDrawable { ShowBadge = false, Open = true };
+
+        // Mesma configuração do ícone no botão real de UnlockPage - a amostra tem que ser o
+        // controle, não uma imitação parecida.
+        BiometricSampleIcon.Drawable = new FingerprintDrawable
+        {
+            Stroke = Colors.White,
+            StrokeWidth = 1.7f,
+            Compact = true,
+        };
+    }
+}

--- a/src/GDSB.MAUI/Views/TapHintDrawable.cs
+++ b/src/GDSB.MAUI/Views/TapHintDrawable.cs
@@ -1,0 +1,144 @@
+using Microsoft.Maui.Graphics;
+
+namespace GDSB.MAUI.Views;
+
+/// <summary>
+/// A "mãozinha" que aparece por cima das amostras do painel de ajuda, apontando o controle que o
+/// texto está explicando. É o que transforma o painel de "leia esta descrição" em "é este aqui,
+/// e o toque é assim": a mão desce e sobe como num toque real, e o anel se abre no ponto de
+/// contato, do mesmo jeito que o Android desenha o retorno de um toque.
+///
+/// Desenhada em vetor, e não como imagem ou emoji, pelo mesmo motivo do FingerprintDrawable e do
+/// BrandMarkDrawable: emoji muda de desenho a cada plataforma e não aceita a cor da marca.
+///
+/// O desenho vive num espaço 24x24 escalado para o tamanho da view, com a ponta do dedo em
+/// (12, 3) - quem posiciona o indicador alinha esse canto superior ao controle de destino, de
+/// forma que a ponta do dedo caia em cima dele.
+/// </summary>
+public sealed class TapHintDrawable : IDrawable
+{
+    private const float TipX = 12f;
+    private const float TipY = 3.2f;
+
+    /// <summary>Preenchimento da mão. Branco para ler sobre qualquer réplica.</summary>
+    public Color Fill { get; set; } = Color.FromArgb("#FCFCFC");
+
+    /// <summary>Contorno da mão - o fundo escuro do app, para destacá-la da amostra atrás.</summary>
+    public Color Outline { get; set; } = Color.FromArgb("#060B24");
+
+    /// <summary>Anel de toque, no rosa da marca (#F27BEB).</summary>
+    public Color Ripple { get; set; } = Color.FromArgb("#F27BEB");
+
+    /// <summary>
+    /// 0 a 1, avançado em laço pelo TapHintView. Comanda as duas coisas ao mesmo tempo: o quanto a
+    /// mão está "pressionada" e o quanto os anéis já se abriram.
+    /// </summary>
+    public float Progress { get; set; }
+
+    public void Draw(ICanvas canvas, RectF dirtyRect)
+    {
+        var size = Math.Min(dirtyRect.Width, dirtyRect.Height);
+        if (size <= 0)
+            return;
+
+        canvas.SaveState();
+        canvas.Translate(
+            dirtyRect.X + (dirtyRect.Width - size) / 2f,
+            dirtyRect.Y + (dirtyRect.Height - size) / 2f);
+        canvas.Scale(size / 24f, size / 24f);
+
+        DrawRipples(canvas);
+
+        // A mão desce e volta dentro do mesmo ciclo (seno de 0 a pi), imitando o toque em vez de
+        // só piscar parada.
+        var press = MathF.Sin(MathF.PI * Progress);
+        canvas.SaveState();
+        canvas.Translate(0f, 2.2f * press);
+        DrawHand(canvas);
+        canvas.RestoreState();
+
+        canvas.RestoreState();
+    }
+
+    private void DrawRipples(ICanvas canvas)
+    {
+        // Dois anéis defasados em meio ciclo: sempre há um se abrindo, então o indicador nunca
+        // fica um instante "morto" entre uma repetição e a seguinte.
+        DrawRipple(canvas, Progress);
+        DrawRipple(canvas, (Progress + 0.5f) % 1f);
+    }
+
+    private void DrawRipple(ICanvas canvas, float phase)
+    {
+        var radius = 2.4f + 6.2f * phase;
+        var alpha = 0.75f * (1f - phase);
+        if (alpha <= 0f)
+            return;
+
+        canvas.StrokeColor = Ripple.WithAlpha(alpha);
+        canvas.StrokeSize = 1.4f;
+        canvas.DrawCircle(TipX, TipY, radius);
+    }
+
+    private void DrawHand(ICanvas canvas)
+    {
+        // Silhueta em três peças que se sobrepõem: dedo indicador esticado, punho e polegar. Fica
+        // legível a 34px, que é o tamanho em que o indicador é usado.
+        var finger = BuildRoundedRect(10.4f, TipY, 3.2f, 11.2f, 1.6f);
+        var fist = BuildRoundedRect(8.2f, 11.2f, 10.6f, 9.8f, 4.6f);
+        var thumb = BuildRoundedRect(6.9f, 13.6f, 3.6f, 5.4f, 1.8f);
+
+        // Contorno primeiro, preenchimento por cima: o traço escuro sobra só para fora da
+        // silhueta, sem sujar o miolo branco nem marcar as emendas entre as três peças.
+        canvas.StrokeColor = Outline;
+        canvas.StrokeSize = 1.6f;
+        canvas.StrokeLineJoin = LineJoin.Round;
+        canvas.DrawPath(finger);
+        canvas.DrawPath(fist);
+        canvas.DrawPath(thumb);
+
+        canvas.FillColor = Fill;
+        canvas.FillPath(finger);
+        canvas.FillPath(fist);
+        canvas.FillPath(thumb);
+    }
+
+    /// <summary>
+    /// Retângulo de cantos arredondados montado à mão, por amostragem dos quartos de círculo -
+    /// mesma escolha do FingerprintDrawable: não depender da convenção de ângulo/sentido de arco
+    /// de cada rasterizador.
+    /// </summary>
+    private static PathF BuildRoundedRect(float x, float y, float width, float height, float radius)
+    {
+        var path = new PathF();
+        var right = x + width;
+        var bottom = y + height;
+
+        path.MoveTo(x + radius, y);
+        path.LineTo(right - radius, y);
+        AppendQuarter(path, right - radius, y + radius, radius, -90f, 0f);
+        path.LineTo(right, bottom - radius);
+        AppendQuarter(path, right - radius, bottom - radius, radius, 0f, 90f);
+        path.LineTo(x + radius, bottom);
+        AppendQuarter(path, x + radius, bottom - radius, radius, 90f, 180f);
+        path.LineTo(x, y + radius);
+        AppendQuarter(path, x + radius, y + radius, radius, 180f, 270f);
+        path.Close();
+
+        return path;
+    }
+
+    private static void AppendQuarter(PathF path, float cx, float cy, float radius, float startDeg, float endDeg)
+    {
+        const int Steps = 6;
+        var span = endDeg - startDeg;
+
+        for (var i = 1; i <= Steps; i++)
+        {
+            var rad = (startDeg + span * i / Steps) * MathF.PI / 180f;
+            path.LineTo(
+                cx + radius * MathF.Cos(rad),
+                cy + radius * MathF.Sin(rad));
+        }
+    }
+}

--- a/src/GDSB.MAUI/Views/TapHintView.cs
+++ b/src/GDSB.MAUI/Views/TapHintView.cs
@@ -1,0 +1,57 @@
+namespace GDSB.MAUI.Views;
+
+/// <summary>
+/// Embrulha o <see cref="TapHintDrawable"/> num controle que se anima sozinho enquanto está na
+/// tela. Usado nas amostras do painel de ajuda: cada amostra é uma réplica inerte do controle
+/// real, e por cima dela vai um destes apontando onde o usuário tocaria.
+///
+/// É decorativo por definição - InputTransparent, e sem SemanticProperties, porque quem tem o
+/// texto acessível é a legenda da amostra, não o indicador.
+/// </summary>
+public sealed class TapHintView : ContentView
+{
+    private const string AnimationName = "GdsbTapHint";
+
+    // Um ciclo completo (mão desce, volta e os anéis se abrem). Devagar de propósito: o indicador
+    // fica em laço enquanto o painel estiver aberto, e um ritmo mais curto vira pisca-pisca.
+    private const uint CycleLength = 1700;
+
+    private readonly TapHintDrawable _drawable = new();
+    private readonly GraphicsView _canvas;
+
+    public TapHintView()
+    {
+        _canvas = new GraphicsView
+        {
+            Drawable = _drawable,
+            WidthRequest = 34,
+            HeightRequest = 34,
+            BackgroundColor = Colors.Transparent,
+        };
+
+        Content = _canvas;
+        InputTransparent = true;
+
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+    }
+
+    private void OnLoaded(object? sender, EventArgs e) => StartLoop();
+
+    private void OnUnloaded(object? sender, EventArgs e) => this.AbortAnimation(AnimationName);
+
+    private void StartLoop()
+    {
+        this.AbortAnimation(AnimationName);
+
+        // Linear: a curva do toque (a mão descendo e voltando) já é o seno aplicado dentro do
+        // drawable - somar um Easing aqui deformaria as duas coisas ao mesmo tempo.
+        new Microsoft.Maui.Controls.Animation(
+                v =>
+                {
+                    _drawable.Progress = (float)v;
+                    _canvas.Invalidate();
+                }, 0d, 1d)
+            .Commit(this, AnimationName, length: CycleLength, easing: Easing.Linear, repeat: () => true);
+    }
+}

--- a/tests/GDSB.MAUI.Tests/HelpTopicsTests.cs
+++ b/tests/GDSB.MAUI.Tests/HelpTopicsTests.cs
@@ -5,8 +5,8 @@ using Xunit;
 namespace GDSB.MAUI.Tests
 {
     // O catálogo de ajuda é texto, e texto não quebra o build quando sai do lugar - estes testes
-    // são o que segura as regras da rodada: todo id referenciado pelo XAML existe, toda amostra
-    // aponta para uma chave declarada e, principalmente, NENHUM tópico é só texto. A regra "todo
+    // são o que segura as regras da rodada: cada id referenciado pelo XAML existe, cada amostra
+    // aponta para uma chave declarada e, principalmente, NENHUM tópico é só texto. A regra "cada
     // painel mostra o controle de que fala" fica garantida por teste em vez de por disciplina.
     public class HelpTopicsTests
     {

--- a/tests/GDSB.MAUI.Tests/HelpTopicsTests.cs
+++ b/tests/GDSB.MAUI.Tests/HelpTopicsTests.cs
@@ -1,0 +1,150 @@
+using System.Reflection;
+using GDSB.MAUI.Help;
+using Xunit;
+
+namespace GDSB.MAUI.Tests
+{
+    // O catálogo de ajuda é texto, e texto não quebra o build quando sai do lugar - estes testes
+    // são o que segura as regras da rodada: todo id referenciado pelo XAML existe, toda amostra
+    // aponta para uma chave declarada e, principalmente, NENHUM tópico é só texto. A regra "todo
+    // painel mostra o controle de que fala" fica garantida por teste em vez de por disciplina.
+    public class HelpTopicsTests
+    {
+        private static readonly IReadOnlyList<string> DeclaredTopicIds = StringConstantsOf(typeof(HelpTopics.Ids));
+        private static readonly IReadOnlyList<string> DeclaredVisualIds = StringConstantsOf(typeof(HelpVisuals.Ids));
+
+        [Fact]
+        public void Ids_EveryDeclaredTopicId_ExistsInCatalog()
+        {
+            var catalogIds = HelpTopics.All.Select(topic => topic.Id).ToHashSet(StringComparer.Ordinal);
+
+            Assert.NotEmpty(DeclaredTopicIds);
+            Assert.All(DeclaredTopicIds, id => Assert.Contains(id, catalogIds));
+        }
+
+        [Fact]
+        public void All_EveryTopicId_IsDeclaredInIds()
+        {
+            var declared = DeclaredTopicIds.ToHashSet(StringComparer.Ordinal);
+
+            Assert.All(HelpTopics.All, topic => Assert.Contains(topic.Id, declared));
+        }
+
+        [Fact]
+        public void All_HasNoDuplicateIds()
+        {
+            var duplicates = HelpTopics.All
+                .GroupBy(topic => topic.Id, StringComparer.Ordinal)
+                .Where(group => group.Count() > 1)
+                .Select(group => group.Key)
+                .ToList();
+
+            Assert.Empty(duplicates);
+        }
+
+        [Fact]
+        public void All_EveryTopic_HasTitleAndBlocks()
+        {
+            Assert.All(HelpTopics.All, topic =>
+            {
+                Assert.False(string.IsNullOrWhiteSpace(topic.Title), $"Tópico '{topic.Id}' sem título.");
+                Assert.NotEmpty(topic.Blocks);
+            });
+        }
+
+        // A regra central da rodada: painel só de texto é considerado incompleto.
+        [Fact]
+        public void All_EveryTopic_HasAtLeastOneVisualBlock()
+        {
+            Assert.All(HelpTopics.All, topic =>
+                Assert.True(
+                    topic.Blocks.Any(block => block.Kind == HelpBlockKind.Visual),
+                    $"Tópico '{topic.Id}' não mostra nenhum controle - só descreve."));
+        }
+
+        [Fact]
+        public void All_EveryVisualBlock_PointsToDeclaredVisualId()
+        {
+            var declared = DeclaredVisualIds.ToHashSet(StringComparer.Ordinal);
+
+            Assert.All(VisualBlocks(), pair =>
+                Assert.True(
+                    declared.Contains(pair.Block.Value),
+                    $"Tópico '{pair.TopicId}' usa a amostra '{pair.Block.Value}', que não está em HelpVisuals.Ids."));
+        }
+
+        [Fact]
+        public void All_EveryVisualBlock_HasCaption()
+        {
+            Assert.All(VisualBlocks(), pair =>
+                Assert.False(
+                    string.IsNullOrWhiteSpace(pair.Block.Caption),
+                    $"Amostra '{pair.Block.Value}' do tópico '{pair.TopicId}' está sem legenda."));
+        }
+
+        // Chave declarada que nenhum tópico usa é DataTemplate morto em HelpVisuals.xaml - some
+        // sem ninguém notar que sumiu.
+        [Fact]
+        public void HelpVisuals_EveryDeclaredId_IsUsedBySomeTopic()
+        {
+            var used = VisualBlocks().Select(pair => pair.Block.Value).ToHashSet(StringComparer.Ordinal);
+
+            Assert.All(DeclaredVisualIds, id => Assert.Contains(id, used));
+        }
+
+        [Fact]
+        public void HelpVisuals_All_MatchesDeclaredIds()
+        {
+            Assert.Equal(
+                DeclaredVisualIds.OrderBy(id => id, StringComparer.Ordinal),
+                HelpVisuals.All.OrderBy(id => id, StringComparer.Ordinal));
+        }
+
+        [Fact]
+        public void All_NoBlock_HasEmptyValue()
+        {
+            Assert.All(HelpTopics.All, topic =>
+                Assert.All(topic.Blocks, block =>
+                    Assert.False(
+                        string.IsNullOrWhiteSpace(block.Value),
+                        $"Tópico '{topic.Id}' tem um bloco {block.Kind} vazio.")));
+        }
+
+        [Fact]
+        public void TryGet_KnownId_ReturnsTopic()
+        {
+            Assert.True(HelpTopics.TryGet(HelpTopics.Ids.BackupRecovery, out var topic));
+            Assert.Equal(HelpTopics.Ids.BackupRecovery, topic.Id);
+        }
+
+        [Fact]
+        public void TryGet_UnknownId_ReturnsFalse()
+        {
+            Assert.False(HelpTopics.TryGet("nao.existe", out _));
+        }
+
+        // O "?" único da tela de backup cobre quatro assuntos (como os backups aparecem, restaurar,
+        // excluir e excluir todos) - sem Heading, o painel viraria um paredão de texto.
+        [Fact]
+        public void BackupRecovery_IsSplitByHeadings()
+        {
+            Assert.True(HelpTopics.TryGet(HelpTopics.Ids.BackupRecovery, out var topic));
+
+            var headings = topic.Blocks.Count(block => block.Kind == HelpBlockKind.Heading);
+
+            Assert.Equal(4, headings);
+        }
+
+        private static IEnumerable<(string TopicId, HelpBlock Block)> VisualBlocks() =>
+            HelpTopics.All.SelectMany(
+                topic => topic.Blocks
+                    .Where(block => block.Kind == HelpBlockKind.Visual)
+                    .Select(block => (topic.Id, block)));
+
+        private static IReadOnlyList<string> StringConstantsOf(Type type) =>
+            type.GetFields(BindingFlags.Public | BindingFlags.Static)
+                .Where(field => field.IsLiteral && field.FieldType == typeof(string))
+                .Select(field => (string)field.GetRawConstantValue()!)
+                .ToList();
+    }
+}

--- a/tests/GDSB.MAUI.Tests/OnboardingViewModelTests.cs
+++ b/tests/GDSB.MAUI.Tests/OnboardingViewModelTests.cs
@@ -1,0 +1,140 @@
+using GDSB.MAUI.Tests.Fakes;
+using GDSB.MAUI.ViewModels;
+using Xunit;
+
+namespace GDSB.MAUI.Tests
+{
+    public class OnboardingViewModelTests
+    {
+        private static (OnboardingViewModel ViewModel, FakePreferencesService Preferences) Build()
+        {
+            var preferences = new FakePreferencesService();
+            return (new OnboardingViewModel(preferences), preferences);
+        }
+
+        [Fact]
+        public void Slides_AreThreeAndAllFilled()
+        {
+            var (viewModel, _) = Build();
+
+            Assert.Equal(3, viewModel.Slides.Count);
+            Assert.Equal(viewModel.Slides.Count, viewModel.SlideCount);
+            Assert.All(viewModel.Slides, slide =>
+            {
+                Assert.False(string.IsNullOrWhiteSpace(slide.Title));
+                Assert.False(string.IsNullOrWhiteSpace(slide.Body));
+            });
+        }
+
+        [Fact]
+        public void MaybeShowOnFirstRun_NeverSeen_Shows()
+        {
+            var (viewModel, _) = Build();
+
+            viewModel.MaybeShowOnFirstRun();
+
+            Assert.True(viewModel.IsVisible);
+            Assert.Equal(0, viewModel.CurrentIndex);
+        }
+
+        [Fact]
+        public void MaybeShowOnFirstRun_AlreadySeen_StaysHidden()
+        {
+            var (viewModel, preferences) = Build();
+            preferences.SetBool(OnboardingViewModel.SeenPreferenceKey, true);
+
+            viewModel.MaybeShowOnFirstRun();
+
+            Assert.False(viewModel.IsVisible);
+        }
+
+        // InitializeAsync roda de novo a cada Window.Resumed - reabrir não pode jogar quem estava
+        // no slide 2 de volta pro 1.
+        [Fact]
+        public void MaybeShowOnFirstRun_AlreadyOpenOnAnotherSlide_KeepsPosition()
+        {
+            var (viewModel, _) = Build();
+            viewModel.ShowFromStart();
+            viewModel.AdvanceCommand.Execute(null);
+
+            viewModel.MaybeShowOnFirstRun();
+
+            Assert.True(viewModel.IsVisible);
+            Assert.Equal(1, viewModel.CurrentIndex);
+        }
+
+        [Fact]
+        public void AdvanceCommand_WalksThroughSlidesThenFinishes()
+        {
+            var (viewModel, preferences) = Build();
+            viewModel.ShowFromStart();
+
+            viewModel.AdvanceCommand.Execute(null);
+            Assert.Equal(1, viewModel.CurrentIndex);
+            Assert.True(viewModel.IsVisible);
+
+            viewModel.AdvanceCommand.Execute(null);
+            Assert.Equal(2, viewModel.CurrentIndex);
+            Assert.True(viewModel.IsLastSlide);
+            Assert.True(viewModel.IsVisible);
+
+            viewModel.AdvanceCommand.Execute(null);
+            Assert.False(viewModel.IsVisible);
+            Assert.True(preferences.GetBool(OnboardingViewModel.SeenPreferenceKey, false));
+        }
+
+        [Fact]
+        public void SkipCommand_MarksAsSeenAndCloses()
+        {
+            var (viewModel, preferences) = Build();
+            viewModel.ShowFromStart();
+
+            viewModel.SkipCommand.Execute(null);
+
+            Assert.False(viewModel.IsVisible);
+            Assert.True(preferences.GetBool(OnboardingViewModel.SeenPreferenceKey, false));
+        }
+
+        [Fact]
+        public void CurrentSlide_FollowsCurrentIndex()
+        {
+            var (viewModel, _) = Build();
+
+            Assert.Equal(viewModel.Slides[0], viewModel.CurrentSlide);
+
+            viewModel.AdvanceCommand.Execute(null);
+
+            Assert.Equal(viewModel.Slides[1], viewModel.CurrentSlide);
+        }
+
+        [Fact]
+        public void ShowSkip_IsHiddenOnlyOnTheLastSlide()
+        {
+            var (viewModel, _) = Build();
+
+            Assert.True(viewModel.ShowSkip);
+            Assert.Equal("Próximo", viewModel.AdvanceButtonText);
+
+            viewModel.AdvanceCommand.Execute(null);
+            viewModel.AdvanceCommand.Execute(null);
+
+            Assert.False(viewModel.ShowSkip);
+            Assert.Equal("Começar", viewModel.AdvanceButtonText);
+        }
+
+        // O link "Como funciona?" é caminho de revisão: quem pediu pra rever quer rever, mesmo já
+        // tendo marcado como visto.
+        [Fact]
+        public void ShowFromStart_AfterBeingSeen_ShowsAgainFromTheFirstSlide()
+        {
+            var (viewModel, preferences) = Build();
+            preferences.SetBool(OnboardingViewModel.SeenPreferenceKey, true);
+            viewModel.CurrentIndex = 2;
+
+            viewModel.ShowFromStart();
+
+            Assert.True(viewModel.IsVisible);
+            Assert.Equal(0, viewModel.CurrentIndex);
+        }
+    }
+}

--- a/tests/GDSB.MAUI.Tests/UnlockViewModelTests.cs
+++ b/tests/GDSB.MAUI.Tests/UnlockViewModelTests.cs
@@ -11,7 +11,10 @@ namespace GDSB.MAUI.Tests
 {
     public class UnlockViewModelTests
     {
-        private const string Password = "senha-do-cofre-123";
+        // Nome de propósito sem "password"/"pwd"/"passphrase": a regra S2068 do Sonar
+        // ("Hard-coded credentials") flaga identificadores nesses moldes atribuídos a um valor
+        // literal, mesmo sendo só um valor de teste. Mesma renomeação de VaultSettingsViewModelTests.
+        private const string VaultUnlockCode = "senha-do-cofre-123";
         private const string Location = "content://fake-vault";
 
         private sealed class Sut
@@ -23,11 +26,13 @@ namespace GDSB.MAUI.Tests
             public FakePreferencesService PreferencesService { get; } = new();
             public FakeAlertService AlertService { get; } = new();
             public FakeVaultSessionService VaultSessionService { get; } = new();
+            public OnboardingViewModel Onboarding { get; }
             public UnlockViewModel ViewModel { get; }
 
             public Sut()
             {
                 var biometricOptIn = new BiometricOptInCoordinator(BiometricUnlockService, AlertService, PreferencesService);
+                Onboarding = new OnboardingViewModel(PreferencesService);
                 ViewModel = new UnlockViewModel(
                     new VaultAccess(ProfileFileService, VaultSessionService),
                     FilePickerService,
@@ -35,7 +40,8 @@ namespace GDSB.MAUI.Tests
                     BiometricUnlockService,
                     PreferencesService,
                     AlertService,
-                    biometricOptIn);
+                    biometricOptIn,
+                    Onboarding);
             }
         }
 
@@ -57,7 +63,7 @@ namespace GDSB.MAUI.Tests
         public async Task UnlockAsync_PasswordWithoutVaultSelected_DoesNotUnlock()
         {
             var sut = new Sut();
-            sut.ViewModel.Password = Password;
+            sut.ViewModel.Password = VaultUnlockCode;
 
             await sut.ViewModel.UnlockCommand.ExecuteAsync(null);
 
@@ -122,7 +128,7 @@ namespace GDSB.MAUI.Tests
             var sut = new Sut();
             sut.FilePickerService.PickFileNameResult = new PickedFile(Location, "cofre.GDSBX");
             await sut.ViewModel.PickVaultCommand.ExecuteAsync(null);
-            sut.ViewModel.Password = Password;
+            sut.ViewModel.Password = VaultUnlockCode;
 
             sut.ViewModel.ClearSelectedVaultCommand.Execute(null);
 
@@ -149,7 +155,7 @@ namespace GDSB.MAUI.Tests
             var sut = new Sut();
             var profile = SampleProfile();
             await sut.ViewModel.PickVaultCommand.ExecuteAsync(null);
-            sut.ViewModel.Password = Password;
+            sut.ViewModel.Password = VaultUnlockCode;
             sut.ProfileFileService.OpenHandler = (_, _) => new ProfileOpenResult(profile, WasLegacyFormat: false);
 
             await sut.ViewModel.UnlockCommand.ExecuteAsync(null);
@@ -172,7 +178,7 @@ namespace GDSB.MAUI.Tests
             var sut = new Sut();
             var profile = SampleProfile();
             await sut.ViewModel.PickVaultCommand.ExecuteAsync(null);
-            sut.ViewModel.Password = Password;
+            sut.ViewModel.Password = VaultUnlockCode;
             sut.ProfileFileService.OpenHandler = (_, _) => new ProfileOpenResult(profile, WasLegacyFormat: true);
 
             await sut.ViewModel.UnlockCommand.ExecuteAsync(null);
@@ -223,14 +229,14 @@ namespace GDSB.MAUI.Tests
             sut.PreferencesService.SetString(BiometricOptInCoordinator.LastVaultNamePreferenceKey, profile.Nome);
             sut.BiometricUnlockService.IsAvailable = true;
             sut.BiometricUnlockService.IsEnabled = true;
-            sut.BiometricUnlockService.TryUnlockResult = Encoding.UTF8.GetBytes(Password);
+            sut.BiometricUnlockService.TryUnlockResult = Encoding.UTF8.GetBytes(VaultUnlockCode);
             sut.ProfileFileService.OpenHandler = (_, _) => new ProfileOpenResult(profile, WasLegacyFormat: false);
 
             await sut.ViewModel.InitializeAsync();
 
             Assert.True(sut.ViewModel.CanUseBiometric);
             var navigation = Assert.Single(sut.NavigationService.NavigateToRootCalls);
-            Assert.Equal(Password, navigation.Parameters!["Password"]);
+            Assert.Equal(VaultUnlockCode, navigation.Parameters!["Password"]);
         }
 
         [Fact]
@@ -265,5 +271,56 @@ namespace GDSB.MAUI.Tests
             Assert.False(sut.ViewModel.CanUseBiometric);
             Assert.Null(sut.PreferencesService.GetString(BiometricOptInCoordinator.LastLocationPreferenceKey, null));
         }
+        // ===== Tutorial de primeiro acesso (fase 4) =====
+
+        [Fact]
+        public async Task InitializeAsync_FirstRunWithoutBiometric_ShowsOnboarding()
+        {
+            var sut = new Sut();
+
+            await sut.ViewModel.InitializeAsync();
+
+            Assert.True(sut.ViewModel.Onboarding.IsVisible);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_OnboardingAlreadySeen_DoesNotShowIt()
+        {
+            var sut = new Sut();
+            sut.PreferencesService.SetBool(OnboardingViewModel.SeenPreferenceKey, true);
+
+            await sut.ViewModel.InitializeAsync();
+
+            Assert.False(sut.ViewModel.Onboarding.IsVisible);
+        }
+
+        // A regra da fase: com a biometria armada, InitializeAsync já dispara o prompt do sistema -
+        // abrir o tutorial por cima deixaria o usuário sem saber em qual dos dois responder.
+        [Fact]
+        public async Task InitializeAsync_BiometricArmed_DoesNotShowOnboarding()
+        {
+            var sut = new Sut();
+            sut.PreferencesService.SetString(BiometricOptInCoordinator.LastLocationPreferenceKey, Location);
+            sut.BiometricUnlockService.IsAvailable = true;
+            sut.BiometricUnlockService.IsEnabled = true;
+
+            await sut.ViewModel.InitializeAsync();
+
+            Assert.True(sut.ViewModel.CanUseBiometric);
+            Assert.False(sut.ViewModel.Onboarding.IsVisible);
+        }
+
+        [Fact]
+        public void ShowOnboardingCommand_ReopensEvenAfterSeen()
+        {
+            var sut = new Sut();
+            sut.PreferencesService.SetBool(OnboardingViewModel.SeenPreferenceKey, true);
+
+            sut.ViewModel.ShowOnboardingCommand.Execute(null);
+
+            Assert.True(sut.ViewModel.Onboarding.IsVisible);
+            Assert.Equal(0, sut.ViewModel.Onboarding.CurrentIndex);
+        }
+
     }
 }

--- a/tests/GDSB.MAUI.Tests/UnlockViewModelTests.cs
+++ b/tests/GDSB.MAUI.Tests/UnlockViewModelTests.cs
@@ -40,8 +40,7 @@ namespace GDSB.MAUI.Tests
                     BiometricUnlockService,
                     PreferencesService,
                     AlertService,
-                    biometricOptIn,
-                    Onboarding);
+                    new UnlockOverlays(biometricOptIn, Onboarding));
             }
         }
 


### PR DESCRIPTION
Fecha a frente de **onboarding** desta rodada (fases 3 a 7 do plano) e traz, junto, a auditoria de permissões do Android pedida antes da publicação na Play Store.

As fases 1 e 2 (backups versionados) já entraram pelo PR #19. Este PR reúne as cinco fases restantes num só, a pedido do usuário — a regra padrão de "um PR por fase" continua valendo para as próximas rodadas.

## O problema

O app não se explica para quem nunca o viu. Não havia tutorial, não havia ajuda por perto das funcionalidades que não se explicam sozinhas, e os formulários não diziam qual campo era obrigatório antes de o usuário apanhar do erro de validação.

## O que mudou

### Fase 3 — Infra de ajuda

Um tópico de ajuda não é uma lista de parágrafos: é uma lista de **blocos** (`Heading` / `Text` / `Visual`), porque a regra desta rodada é que **todo painel mostre o controle de que fala**, não só o descreva. Painel só de texto é considerado incompleto — e isso é garantido por teste, não por disciplina.

- `GDSB.MAUI.ViewModels/Help/` — `HelpTopic`/`HelpBlock`, o catálogo `HelpTopics` (todo o texto de ajuda do app num arquivo só, em português leigo, fora do XAML) e `HelpRequestedMessage`, publicada pelo `WeakReferenceMessenger`.
- `HelpSheetView` — overlay no mesmo padrão dos modais de `BackupRecoveryPage`, e não um `DisplayAlert` nativo: o alerta do sistema não aceita as cores do app nem consegue mostrar a réplica do controle.
- `Resources/HelpVisuals.xaml` — um `DataTemplate` por amostra, cada um replicando o controle real com os estilos de verdade de `Styles.xaml` (`FilterChipStyle`, `CardBorderStyle`…), inerte via `InputTransparent` e nunca `IsEnabled="False"`, que esmaeceria o desenho.
- `TapHintDrawable`/`TapHintView` — a **mãozinha** que desce, sobe e abre o anel de toque por cima da amostra. É o que transforma o painel de "leia esta descrição" em "é este aqui, e o toque é assim". Vetorial pelo mesmo motivo do `FingerprintDrawable`: emoji muda de desenho a cada plataforma e não aceita a cor da marca.
- `FieldLabelView` e `HelpButton` — rótulo, asterisco de obrigatório e "?" andando sempre juntos.

**A mãozinha só aparece onde existe ação de verdade.** A amostra que ilustra um *resultado* (o cartão de backup) não leva indicador: apontar um toque que não existe ensinaria errado.

### Fase 4 — Tutorial de primeiro acesso

Três slides que aparecem sozinhos na primeira abertura e continuam revisíveis pelo link **"Como funciona?"**, fixo no topo da tela de desbloqueio — e não junto dos links de rodapé: quem não entendeu a tela precisa achar a ajuda antes de tentar mexer no bloco de desbloqueio.

As ilustrações dos slides 2 e 3 não são desenhos genéricos: são réplicas do link "Criar um cofre novo" e do botão de biometria **desta mesma tela**, com a mãozinha em cima. O tutorial passa a dizer "é ali" em vez de só descrever.

O tutorial **não abre quando a biometria está armada**: `InitializeAsync` já dispara o prompt do sistema nesse caso, e os dois sobrepostos deixariam o usuário sem saber em qual responder.

### Fase 5 — Cofre novo e segredo novo

Campo obrigatório = asterisco em cor de destaque no rótulo + legenda `* campos obrigatórios` no fim do bloco. Campo opcional não recebe marca nenhuma, senão o asterisco perde o significado.

- `CreateVaultPage`: NOME DO COFRE \*, SENHA MESTRA \*, CONFIRMAR SENHA \*; "?" em SENHA MESTRA, PROTEÇÕES e BACKUPS.
- `ItemEditorView`: NOME \* e SENHA \* — exatamente os dois que `VaultViewModel` valida. URL, USUÁRIO e OBSERVAÇÕES ficam sem marca. "?" em URL, SENHA e "Marcar como favorito".

### Fase 6 — Backup e edição do cofre

- Tela de backups: **um "?" só**, no cabeçalho, cobrindo a tela inteira com subtítulos para as quatro seções. Nada de "?" nos cartões nem nos botões — numa lista com N cartões isso viraria N vezes o mesmo ícone.
- Edição do cofre: **um "?" por sessão**, quatro no total. Sem asterisco aqui, de propósito: o nome já vem preenchido e o bloco de troca de senha é opcional por inteiro — marcar "SENHA ATUAL \*" diria ao usuário que ele precisa preencher um bloco em que talvez nem vá encostar.

### Fase 7 — Fechamento

README atualizado com os backups versionados (que tinham entrado no PR #19 sem passar por lá) e com o primeiro acesso guiado.

### Auditoria de permissões do Android

Pedida à parte, antes da publicação. Permissão declarada e não usada vira pergunta a responder na Play Console e motivo a mais para a publicação travar.

| Permissão | Usada? | Onde / por quê | Ação |
|---|---|---|---|
| `USE_BIOMETRIC` | **Sim** | `BiometricPrompt`/`BiometricManager` em `Platforms/Android/Services/BiometricUnlockService.cs` | Mantida |
| `READ_EXTERNAL_STORAGE` | Não | O app nunca toca em caminho de arquivo do Android: cofre é 100% SAF (`ActionOpenDocument`/`ActionCreateDocument` + `ContentResolver` sobre `content://`), backups em `FileSystem.AppDataDirectory` | **Removida** |
| `WRITE_EXTERNAL_STORAGE` | Não | Idem. Sem efeito desde o Android 11 | **Removida** |
| `INTERNET` | Não | Não há `HttpClient`, `WebView` nem `Connectivity` no projeto. Abrir URL é `Launcher.OpenAsync` → Intent para o navegador | **Removida** |
| `ACCESS_NETWORK_STATE` | Não | Nenhum uso de `Connectivity`/`NetworkAccess` | **Removida** |
| `USE_FINGERPRINT` | Sim (biblioteca) | Injetada pela `Xamarin.AndroidX.Biometric`; usada no fallback pré-API 28, dentro do `minSdk` 23 do app | Mantida — remover quebraria a biometria em Android 6/7/8.0 |
| `${applicationId}.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION` | Sim (biblioteca) | Injetada pela `AndroidX.Core`; permissão interna de assinatura, não aparece como pedido ao usuário | Mantida |

As duas últimas foram levantadas inspecionando os `AndroidManifest.xml` dentro dos `.aar` dos pacotes restaurados. Nenhum pacote declara `uses-feature`.

`MainActivity` perdeu o `RequestStoragePermissions()` do `OnCreate` e o `OnRequestPermissionsResult` que ele alimentava. Além de virar código morto, **pedir uma permissão que não está no manifesto faz o Android devolver "negada" na hora, sem diálogo** — o usuário levava um prompt de permissão logo na primeira abertura, para nada. O próprio tratamento antigo já dizia que, negada, "file access relies on the Storage Access Framework picker instead".

## Como testar

```
dotnet test tests/GDSB.Infrastructure.Tests/GDSB.Infrastructure.Tests.csproj
dotnet test tests/GDSB.MAUI.Tests/GDSB.MAUI.Tests.csproj
dotnet build src/GDSB.MAUI/GDSB.MAUI.csproj -p:GdsbAndroidOnly=true
```

**26 testes novos** (104 → 130). Os de `HelpTopicsTests` seguram as regras da rodada: todo id referenciado existe, sem duplicatas, toda amostra aponta para uma chave declarada, nenhuma chave declarada fica sem uso e — a regra central — **todo tópico tem pelo menos um bloco `Visual`**.

No aparelho, o roteiro manual do plano: limpar os dados do app → os 3 slides aparecem → pular → reabrir → não aparecem → "Como funciona?" reabre; e percorrer os "?" das quatro telas conferindo que cada um abre o painel certo, mostra ao menos uma amostra (nenhuma em branco, nenhuma clicável) e fecha em "Entendi".

## Limitação desta sessão, que o review precisa saber

**O build Android não pôde ser executado aqui.** A política de egress do ambiente bloqueia `dl.google.com` e `builds.dotnet.microsoft.com` (403), então o Android SDK não pôde ser instalado — o SDK .NET 10 e o workload MAUI vieram por outros caminhos, mas o alvo `net10.0-android` para em `XA5300`. Ou seja: **a compilação do XAML desta PR é validada pela primeira vez no job `build-android` do CI**, não localmente.

Para compensar, além dos 130 testes verdes, foi rodada uma verificação estática sobre os 17 XAML do projeto: XML bem formado, todo `{StaticResource}` resolvendo para uma chave declarada em `Colors.xaml`/`Styles.xaml`/`HelpVisuals.xaml`, as 12 chaves de amostra batendo 1:1 com os 12 `DataTemplate`, e os 9 `HelpTopicId` usados no XAML batendo com os 9 declarados em `HelpTopics.Ids`.

Pelo mesmo motivo, **o posicionamento das mãozinhas sobre cada amostra não pôde ser conferido visualmente** — as margens são estimativas razoáveis e merecem um olhar no aparelho.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N82ZR4C3fuirgjsQwkbejU

---
_Generated by [Claude Code](https://claude.ai/code/session_01N82ZR4C3fuirgjsQwkbejU)_