### PR TITLE
Fases 2 a 5: migração mecânica completa para o app multilíngue (pt-BR/en-US)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ preservado como backup — nunca ao lado do cofre, ver "Backups" abaixo.
 - **Desbloqueio:** escolher o arquivo do cofre vem antes da senha mestra — o campo de senha só
   habilita depois de um arquivo selecionado. Não se aplica ao modo com biometria ligada, onde o
   bloco manual inteiro dá lugar a um único botão mirando o último cofre aberto.
+- **Idioma configurável.** Um dropdown na tela inicial troca entre português do Brasil (padrão) e
+  inglês na hora, sem reiniciar o app — a escolha é gravada em `Preferences` e vale para toda a
+  interface, incluindo os painéis de ajuda e o tutorial de primeiro acesso. Datas e números seguem
+  o idioma; nomes de arquivo (cofre e backup) continuam sempre no mesmo formato, para um backup
+  gravado num idioma continuar sendo reconhecido depois de trocar para outro.
 - **Backups.** Antes de cada gravação, a versão anterior do cofre é salva automaticamente num
   diretório próprio do app (`vault-backups`, dentro de `FileSystem.AppDataDirectory`) — nunca mais
   ao lado do arquivo original, nem no Windows, o que evita que o backup apareça sincronizado junto

--- a/claude-context.md
+++ b/claude-context.md
@@ -132,7 +132,7 @@ está lendo a tela, não propriedade do arquivo.
 |---|------|------------|--------|-----|
 | 0 | Contexto e plano (este arquivo + artifact) | — | ✅ Concluída | — |
 | 1 | Infra de idioma + seleção na home | — | ✅ Concluída | [#23](https://github.com/betinn/GDSB.MAUI/pull/23) |
-| 2 | Migração do XAML restante | 1 | ⬜ A fazer | — |
+| 2 | Migração do XAML restante | 1 | ✅ Código pronto (aguarda PR combinado com 3-5) | — |
 | 3 | Migração dos ViewModels | 1 | ⬜ A fazer | — |
 | 4 | Ajuda (`HelpTopics`) e tutorial | 1 | ⬜ A fazer | — |
 | 5 | Fechamento (revisão do inglês, README, contexto, build) | 2, 3, 4 | ⬜ A fazer | — |

--- a/claude-context.md
+++ b/claude-context.md
@@ -132,10 +132,10 @@ está lendo a tela, não propriedade do arquivo.
 |---|------|------------|--------|-----|
 | 0 | Contexto e plano (este arquivo + artifact) | — | ✅ Concluída | — |
 | 1 | Infra de idioma + seleção na home | — | ✅ Concluída | [#23](https://github.com/betinn/GDSB.MAUI/pull/23) |
-| 2 | Migração do XAML restante | 1 | ✅ Código pronto (aguarda PR combinado com 3-5) | — |
-| 3 | Migração dos ViewModels | 1 | ⬜ A fazer | — |
-| 4 | Ajuda (`HelpTopics`) e tutorial | 1 | ⬜ A fazer | — |
-| 5 | Fechamento (revisão do inglês, README, contexto, build) | 2, 3, 4 | ⬜ A fazer | — |
+| 2 | Migração do XAML restante | 1 | ✅ Concluída | PR B (fases 2-5) |
+| 3 | Migração dos ViewModels | 1 | ✅ Concluída | PR B (fases 2-5) |
+| 4 | Ajuda (`HelpTopics`) e tutorial | 1 | ✅ Concluída | PR B (fases 2-5) |
+| 5 | Fechamento (revisão do inglês, README, contexto, build) | 2, 3, 4 | ✅ Concluída | PR B (fases 2-5) |
 
 Dependências:
 

--- a/claude-context.md
+++ b/claude-context.md
@@ -132,10 +132,10 @@ está lendo a tela, não propriedade do arquivo.
 |---|------|------------|--------|-----|
 | 0 | Contexto e plano (este arquivo + artifact) | — | ✅ Concluída | — |
 | 1 | Infra de idioma + seleção na home | — | ✅ Concluída | [#23](https://github.com/betinn/GDSB.MAUI/pull/23) |
-| 2 | Migração do XAML restante | 1 | ✅ Concluída | PR B (fases 2-5) |
-| 3 | Migração dos ViewModels | 1 | ✅ Concluída | PR B (fases 2-5) |
-| 4 | Ajuda (`HelpTopics`) e tutorial | 1 | ✅ Concluída | PR B (fases 2-5) |
-| 5 | Fechamento (revisão do inglês, README, contexto, build) | 2, 3, 4 | ✅ Concluída | PR B (fases 2-5) |
+| 2 | Migração do XAML restante | 1 | ✅ Concluída | [#24](https://github.com/betinn/GDSB.MAUI/pull/24) |
+| 3 | Migração dos ViewModels | 1 | ✅ Concluída | [#24](https://github.com/betinn/GDSB.MAUI/pull/24) |
+| 4 | Ajuda (`HelpTopics`) e tutorial | 1 | ✅ Concluída | [#24](https://github.com/betinn/GDSB.MAUI/pull/24) |
+| 5 | Fechamento (revisão do inglês, README, contexto, build) | 2, 3, 4 | ✅ Concluída | [#24](https://github.com/betinn/GDSB.MAUI/pull/24) |
 
 Dependências:
 

--- a/src/GDSB.Infrastructure/Backup/VaultBackupNaming.cs
+++ b/src/GDSB.Infrastructure/Backup/VaultBackupNaming.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace GDSB.Infrastructure.Backup
 {
     // Nome de exibição do arquivo de backup. O prefixo resolve a truncagem em tela pequena (o que
@@ -15,9 +17,11 @@ namespace GDSB.Infrastructure.Backup
 
         // Usado só para Rolling, que agora acumula versões em vez de sobrescrever - o timestamp
         // é o que distingue uma versão da outra. Sem ":" no horário porque é ilegal em nome de
-        // arquivo no Windows.
+        // arquivo no Windows. CultureInfo.InvariantCulture explícito (rodada multilíngue): o
+        // idioma do app não pode mudar o nome gravado em disco, senão um backup criado em
+        // português deixaria de ser reconhecido depois de trocar para inglês.
         public static string BuildName(string vaultFileName, string suffix, DateTime createdAtUtc) =>
-            $"{Prefix}{vaultFileName} - {createdAtUtc:yyyy-MM-dd HH-mm-ss}{suffix}";
+            $"{Prefix}{vaultFileName} - {createdAtUtc.ToString("yyyy-MM-dd HH-mm-ss", CultureInfo.InvariantCulture)}{suffix}";
 
         public static bool IsBackupName(string fileName) =>
             fileName.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase)

--- a/src/GDSB.MAUI.ViewModels/Help/HelpTopics.cs
+++ b/src/GDSB.MAUI.ViewModels/Help/HelpTopics.cs
@@ -1,3 +1,6 @@
+using System.Globalization;
+using GDSB.MAUI.ViewModels.Resources;
+
 namespace GDSB.MAUI.Help
 {
     // Catálogo único do texto de ajuda do app, inteiro. Fica aqui, e não no XAML, por três motivos:
@@ -13,6 +16,14 @@ namespace GDSB.MAUI.Help
     // S2068 do Sonar flagra a declaração de qualquer campo com esses nomes e valor literal como
     // "credencial no código", mesmo quando o valor é só um identificador. Mesmo motivo do
     // VaultUnlockCode dos testes - ver claude-context.md.
+    //
+    // A prosa (Title, Text/Heading, Caption) vem do catálogo (AppStrings), lida na cultura vigente -
+    // por isso All não é mais materializado uma vez num inicializador estático: rodada 4 (multilíngue)
+    // precisa que o mesmo tópico saia diferente depois de uma troca de idioma. Como ler o
+    // ResourceManager de novo pra cada um dos 48 textos toda vez que um "?" abre seria trabalho à
+    // toa, o resultado fica em cache por cultura (só duas culturas existem - ver AppLanguage - então
+    // o cache nunca cresce fora de controle e não precisa de invalidação: a próxima leitura na
+    // cultura vigente já bate no cache dela).
     public static class HelpTopics
     {
         public static class Ids
@@ -28,192 +39,133 @@ namespace GDSB.MAUI.Help
             public const string BackupRecovery = "backup.recovery";
         }
 
-        public static IReadOnlyList<HelpTopic> All { get; } =
+        private static readonly Dictionary<string, IReadOnlyList<HelpTopic>> TopicsByCulture = new();
+        private static readonly Dictionary<string, Dictionary<string, HelpTopic>> ByIdByCulture = new();
+
+        public static IReadOnlyList<HelpTopic> All => GetTopicsForCurrentCulture();
+
+        public static bool TryGet(string id, out HelpTopic topic) =>
+            GetByIdForCurrentCulture().TryGetValue(id, out topic!);
+
+        private static IReadOnlyList<HelpTopic> GetTopicsForCurrentCulture()
+        {
+            var cultureKey = CultureInfo.CurrentUICulture.Name;
+            if (TopicsByCulture.TryGetValue(cultureKey, out var cached))
+                return cached;
+
+            var topics = BuildTopics();
+            TopicsByCulture[cultureKey] = topics;
+            ByIdByCulture[cultureKey] = topics.ToDictionary(topic => topic.Id, StringComparer.Ordinal);
+            return topics;
+        }
+
+        private static Dictionary<string, HelpTopic> GetByIdForCurrentCulture()
+        {
+            GetTopicsForCurrentCulture();
+            return ByIdByCulture[CultureInfo.CurrentUICulture.Name];
+        }
+
+        private static string Tr(string key) =>
+            AppStrings.ResourceManager.GetString(key, CultureInfo.CurrentUICulture) ?? key;
+
+        private static IReadOnlyList<HelpTopic> BuildTopics() =>
         [
             new HelpTopic(
                 Ids.MasterUnlockCode,
-                "A senha mestra",
+                Tr("Help_MasterUnlockCode_Title"),
                 [
-                    HelpBlock.OfText(
-                        "É a senha que abre este cofre. Ela não fica guardada em lugar nenhum: nem no app, " +
-                        "nem no seu celular, nem na internet. Por isso não existe \"esqueci minha senha\" " +
-                        "aqui - se você perder essa senha, ninguém consegue abrir o arquivo de novo, nem " +
-                        "você, nem quem fez o app."),
-                    HelpBlock.OfText(
-                        "Escolha algo que você lembre com folga e que ninguém adivinhe. O mínimo são 8 " +
-                        "caracteres, mas quanto mais longa, melhor."),
-                    HelpBlock.OfVisual(
-                        HelpVisuals.Ids.MasterUnlockCodeField,
-                        "É este campo. Toque nele e digite - as letras aparecem como pontinhos para " +
-                        "ninguém ler por cima do seu ombro."),
+                    HelpBlock.OfText(Tr("Help_MasterUnlockCode_Text1")),
+                    HelpBlock.OfText(Tr("Help_MasterUnlockCode_Text2")),
+                    HelpBlock.OfVisual(HelpVisuals.Ids.MasterUnlockCodeField, Tr("Help_MasterUnlockCode_VisualCaption")),
                 ]),
 
             new HelpTopic(
                 Ids.VaultName,
-                "O nome do cofre",
+                Tr("Help_VaultName_Title"),
                 [
-                    HelpBlock.OfText(
-                        "É o apelido que aparece dentro do app para você reconhecer este cofre. Trocar o " +
-                        "nome aqui não renomeia o arquivo que está salvo no seu celular ou na nuvem: o " +
-                        "arquivo continua com o nome de antes."),
-                    HelpBlock.OfText(
-                        "Por isso, depois de salvar um nome novo, o app oferece guardar também uma cópia " +
-                        "num arquivo novo. É opcional - se você recusar, está tudo certo, a mudança já foi " +
-                        "gravada no arquivo de sempre."),
-                    HelpBlock.OfVisual(
-                        HelpVisuals.Ids.SaveAsNewFileCard,
-                        "É este convite que aparece depois de salvar. Tocar em \"Salvar como novo arquivo\" " +
-                        "cria uma cópia e mantém o original intacto."),
+                    HelpBlock.OfText(Tr("Help_VaultName_Text1")),
+                    HelpBlock.OfText(Tr("Help_VaultName_Text2")),
+                    HelpBlock.OfVisual(HelpVisuals.Ids.SaveAsNewFileCard, Tr("Help_VaultName_VisualCaption")),
                 ]),
 
             new HelpTopic(
                 Ids.VaultProtections,
-                "Proteções do cofre",
+                Tr("Help_VaultProtections_Title"),
                 [
-                    HelpBlock.OfHeading("Limpar a área de transferência"),
-                    HelpBlock.OfText(
-                        "Quando você copia uma senha, ela fica na memória de \"copiar e colar\" do celular e " +
-                        "qualquer outro aplicativo pode ler de lá. Com esta proteção ligada, o app apaga " +
-                        "esse valor sozinho depois do tempo que você escolher."),
-                    HelpBlock.OfHeading("Bloqueio automático"),
-                    HelpBlock.OfText(
-                        "Se você sair do app e demorar para voltar, ele fecha o cofre e pede a senha mestra " +
-                        "de novo. Serve para o caso de você deixar o celular na mesa e alguém pegar."),
-                    HelpBlock.OfVisual(
-                        HelpVisuals.Ids.ProtectionTimeChips,
-                        "Toque em um dos tempos para escolher. O que estiver colorido é o que está valendo."),
+                    HelpBlock.OfHeading(Tr("Help_VaultProtections_Heading1")),
+                    HelpBlock.OfText(Tr("Help_VaultProtections_Text1")),
+                    HelpBlock.OfHeading(Tr("Help_VaultProtections_Heading2")),
+                    HelpBlock.OfText(Tr("Help_VaultProtections_Text2")),
+                    HelpBlock.OfVisual(HelpVisuals.Ids.ProtectionTimeChips, Tr("Help_VaultProtections_VisualCaption")),
                 ]),
 
             new HelpTopic(
                 Ids.VaultBackups,
-                "Backups automáticos",
+                Tr("Help_VaultBackups_Title"),
                 [
-                    HelpBlock.OfText(
-                        "Toda vez que você salva alguma coisa, o app guarda antes uma cópia de como o cofre " +
-                        "estava. Assim, se você apagar um item sem querer, dá para voltar atrás."),
-                    HelpBlock.OfText(
-                        "Aqui você decide quantas dessas cópias ficam guardadas. \"Por quantidade\" guarda um " +
-                        "número fixo de versões. \"Por tempo\" guarda as dos últimos dias que você escolher. " +
-                        "A cópia mais recente nunca é apagada, aconteça o que acontecer."),
-                    HelpBlock.OfVisual(
-                        HelpVisuals.Ids.BackupModeChips,
-                        "Toque em \"Por quantidade\" ou \"Por tempo\" para escolher a regra. Logo abaixo " +
-                        "aparecem os valores disponíveis."),
+                    HelpBlock.OfText(Tr("Help_VaultBackups_Text1")),
+                    HelpBlock.OfText(Tr("Help_VaultBackups_Text2")),
+                    HelpBlock.OfVisual(HelpVisuals.Ids.BackupModeChips, Tr("Help_VaultBackups_VisualCaption")),
                 ]),
 
             new HelpTopic(
                 Ids.ChangeMasterUnlockCode,
-                "Trocar a senha mestra",
+                Tr("Help_ChangeMasterUnlockCode_Title"),
                 [
-                    HelpBlock.OfText(
-                        "Para trocar, o app pede a senha atual primeiro - é assim que ele confere que é " +
-                        "você mesmo. Depois da troca, é a senha nova que abre este cofre."),
-                    HelpBlock.OfText(
-                        "Atenção com os backups: as cópias guardadas antes da troca continuam presas à " +
-                        "senha antiga. Se um dia você precisar restaurar uma delas, é a senha antiga que " +
-                        "vai funcionar, não a nova. Por isso vale anotar a antiga em algum lugar seguro, " +
-                        "ou marcar a caixa que apaga essas cópias de uma vez."),
-                    HelpBlock.OfText(
-                        "Se você usa a digital para abrir o cofre, não precisa fazer nada: o app reconfigura " +
-                        "a biometria sozinho com a senha nova."),
-                    HelpBlock.OfVisual(
-                        HelpVisuals.Ids.DeleteOldBackupsCheck,
-                        "Marque esta caixa se você não quer guardar cópias que só abrem com a senha antiga."),
+                    HelpBlock.OfText(Tr("Help_ChangeMasterUnlockCode_Text1")),
+                    HelpBlock.OfText(Tr("Help_ChangeMasterUnlockCode_Text2")),
+                    HelpBlock.OfText(Tr("Help_ChangeMasterUnlockCode_Text3")),
+                    HelpBlock.OfVisual(HelpVisuals.Ids.DeleteOldBackupsCheck, Tr("Help_ChangeMasterUnlockCode_VisualCaption")),
                 ]),
 
             new HelpTopic(
                 Ids.SecretUrl,
-                "O endereço do site",
+                Tr("Help_SecretUrl_Title"),
                 [
-                    HelpBlock.OfText(
-                        "É opcional, mas ajuda bastante: quando você preenche, o endereço vira um atalho no " +
-                        "cartão do item. Um toque e o site abre no navegador, sem você precisar digitar."),
-                    HelpBlock.OfText(
-                        "Pode escrever do jeito simples, como \"netflix.com\" - não precisa colocar o " +
-                        "\"https://\" na frente."),
-                    HelpBlock.OfVisual(
-                        HelpVisuals.Ids.SecretUrlLink,
-                        "Fica logo abaixo do nome do item, em rosa. Tocar nele abre o site."),
+                    HelpBlock.OfText(Tr("Help_SecretUrl_Text1")),
+                    HelpBlock.OfText(Tr("Help_SecretUrl_Text2")),
+                    HelpBlock.OfVisual(HelpVisuals.Ids.SecretUrlLink, Tr("Help_SecretUrl_VisualCaption")),
                 ]),
 
             new HelpTopic(
                 Ids.SecretStoredValue,
-                "A senha guardada",
+                Tr("Help_SecretStoredValue_Title"),
                 [
-                    HelpBlock.OfText(
-                        "É a senha daquele site ou aplicativo - a que você usaria para entrar. Ela fica " +
-                        "escondida atrás de pontinhos e só aparece quando você pede."),
-                    HelpBlock.OfText(
-                        "Na hora de usar, você tem duas opções: o olhinho mostra a senha na tela, e " +
-                        "\"Copiar\" manda ela direto para o \"colar\" do celular, sem precisar mostrar para " +
-                        "ninguém. Se a proteção de área de transferência estiver ligada, o app apaga o " +
-                        "valor copiado sozinho depois de alguns segundos."),
-                    HelpBlock.OfVisual(
-                        HelpVisuals.Ids.SecretValueActions,
-                        "São estes dois botões, no cartão da senha: o olhinho mostra, o \"Copiar\" copia."),
+                    HelpBlock.OfText(Tr("Help_SecretStoredValue_Text1")),
+                    HelpBlock.OfText(Tr("Help_SecretStoredValue_Text2")),
+                    HelpBlock.OfVisual(HelpVisuals.Ids.SecretValueActions, Tr("Help_SecretStoredValue_VisualCaption")),
                 ]),
 
             new HelpTopic(
                 Ids.SecretFavorite,
-                "Marcar como favorito",
+                Tr("Help_SecretFavorite_Title"),
                 [
-                    HelpBlock.OfText(
-                        "Favoritos sobem para o topo da lista e ganham uma estrelinha dourada. Serve para " +
-                        "os itens que você abre toda hora não se perderem no meio dos outros."),
-                    HelpBlock.OfText(
-                        "Não muda nada na segurança nem no conteúdo do item - é só uma forma de encontrar " +
-                        "mais rápido."),
-                    HelpBlock.OfVisual(
-                        HelpVisuals.Ids.FavoriteStar,
-                        "É esta estrelinha, que passa a aparecer no cartão do item na lista."),
+                    HelpBlock.OfText(Tr("Help_SecretFavorite_Text1")),
+                    HelpBlock.OfText(Tr("Help_SecretFavorite_Text2")),
+                    HelpBlock.OfVisual(HelpVisuals.Ids.FavoriteStar, Tr("Help_SecretFavorite_VisualCaption")),
                 ]),
 
             new HelpTopic(
                 Ids.BackupRecovery,
-                "Recuperar um backup",
+                Tr("Help_BackupRecovery_Title"),
                 [
-                    HelpBlock.OfHeading("Como estas cópias aparecem aqui"),
-                    HelpBlock.OfText(
-                        "Toda vez que você salva algo no cofre, o app guarda antes uma cópia de como ele " +
-                        "estava. Essas cópias ficam numa pasta privada do aplicativo, nunca junto do seu " +
-                        "arquivo, para não bagunçar a sua pasta. Quantas ficam guardadas é o que você " +
-                        "escolheu em Editar cofre, na parte de Backups."),
-                    HelpBlock.OfVisual(
-                        HelpVisuals.Ids.BackupCard,
-                        "Cada cópia vira um cartão como este, com a data e a hora em que foi guardada."),
+                    HelpBlock.OfHeading(Tr("Help_BackupRecovery_Heading1")),
+                    HelpBlock.OfText(Tr("Help_BackupRecovery_Text1")),
+                    HelpBlock.OfVisual(HelpVisuals.Ids.BackupCard, Tr("Help_BackupRecovery_VisualCaption1")),
 
-                    HelpBlock.OfHeading("Restaurar"),
-                    HelpBlock.OfText(
-                        "Restaurar não mexe no seu cofre atual: o app cria um arquivo novo com o conteúdo " +
-                        "daquela cópia, e você escolhe depois qual dos dois quer abrir. O app vai pedir a " +
-                        "senha mestra da época daquela cópia - se ela for de antes de você trocar a senha, " +
-                        "é a senha antiga que funciona."),
-                    HelpBlock.OfVisual(
-                        HelpVisuals.Ids.RestoreButton,
-                        "É este botão, no rodapé de cada cartão."),
+                    HelpBlock.OfHeading(Tr("Help_BackupRecovery_Heading2")),
+                    HelpBlock.OfText(Tr("Help_BackupRecovery_Text2")),
+                    HelpBlock.OfVisual(HelpVisuals.Ids.RestoreButton, Tr("Help_BackupRecovery_VisualCaption2")),
 
-                    HelpBlock.OfHeading("Excluir"),
-                    HelpBlock.OfText(
-                        "Apaga só aquela cópia da lista. Não dá para desfazer, e o seu cofre atual continua " +
-                        "intacto."),
-                    HelpBlock.OfVisual(
-                        HelpVisuals.Ids.DeleteBackupButton,
-                        "Fica ao lado de \"Restaurar\", em vermelho."),
+                    HelpBlock.OfHeading(Tr("Help_BackupRecovery_Heading3")),
+                    HelpBlock.OfText(Tr("Help_BackupRecovery_Text3")),
+                    HelpBlock.OfVisual(HelpVisuals.Ids.DeleteBackupButton, Tr("Help_BackupRecovery_VisualCaption3")),
 
-                    HelpBlock.OfHeading("Excluir todos"),
-                    HelpBlock.OfText(
-                        "Apaga de uma vez todas as cópias que estão nesta tela. Também não dá para " +
-                        "desfazer. Seu cofre atual não é afetado - só as cópias antigas somem."),
-                    HelpBlock.OfVisual(
-                        HelpVisuals.Ids.DeleteAllBackupsLink,
-                        "É este link vermelho, no fim da lista."),
+                    HelpBlock.OfHeading(Tr("Help_BackupRecovery_Heading4")),
+                    HelpBlock.OfText(Tr("Help_BackupRecovery_Text4")),
+                    HelpBlock.OfVisual(HelpVisuals.Ids.DeleteAllBackupsLink, Tr("Help_BackupRecovery_VisualCaption4")),
                 ]),
         ];
-
-        private static readonly Dictionary<string, HelpTopic> ById =
-            All.ToDictionary(topic => topic.Id, StringComparer.Ordinal);
-
-        public static bool TryGet(string id, out HelpTopic topic) => ById.TryGetValue(id, out topic!);
     }
 
     // Chaves das amostras visuais. Cada uma corresponde a um DataTemplate declarado em

--- a/src/GDSB.MAUI.ViewModels/Resources/AppStrings.Designer.cs
+++ b/src/GDSB.MAUI.ViewModels/Resources/AppStrings.Designer.cs
@@ -269,5 +269,101 @@ namespace GDSB.MAUI.ViewModels.Resources
         public static string HelpVisual_SampleBackupSize => ResourceManager.GetString("HelpVisual_SampleBackupSize", resourceCulture);
 
         public static string HelpVisual_SampleBackupKind => ResourceManager.GetString("HelpVisual_SampleBackupKind", resourceCulture);
+
+        public static string Unlock_GenericErrorMessage => ResourceManager.GetString("Unlock_GenericErrorMessage", resourceCulture);
+
+        public static string Unlock_EmptyPasswordMessage => ResourceManager.GetString("Unlock_EmptyPasswordMessage", resourceCulture);
+
+        public static string Unlock_FilePickerErrorMessage => ResourceManager.GetString("Unlock_FilePickerErrorMessage", resourceCulture);
+
+        public static string Unlock_BackupFileAlertTitle => ResourceManager.GetString("Unlock_BackupFileAlertTitle", resourceCulture);
+
+        public static string Unlock_BackupFileAlertMessage => ResourceManager.GetString("Unlock_BackupFileAlertMessage", resourceCulture);
+
+        public static string Unlock_ButtonIdleText => ResourceManager.GetString("Unlock_ButtonIdleText", resourceCulture);
+
+        public static string Unlock_ButtonBusyText => ResourceManager.GetString("Unlock_ButtonBusyText", resourceCulture);
+
+        public static string Common_Ok => ResourceManager.GetString("Common_Ok", resourceCulture);
+
+        public static string Vault_GenericSaveErrorMessage => ResourceManager.GetString("Vault_GenericSaveErrorMessage", resourceCulture);
+
+        public static string Vault_PasswordsDoNotMatchMessage => ResourceManager.GetString("Vault_PasswordsDoNotMatchMessage", resourceCulture);
+
+        public static string Vault_NameRequiredMessage => ResourceManager.GetString("Vault_NameRequiredMessage", resourceCulture);
+
+        public static string Vault_ChoosePathErrorMessage => ResourceManager.GetString("Vault_ChoosePathErrorMessage", resourceCulture);
+
+        public static string Vault_SaveToLocationErrorMessage => ResourceManager.GetString("Vault_SaveToLocationErrorMessage", resourceCulture);
+
+        public static string Vault_ConfirmDeleteMessage => ResourceManager.GetString("Vault_ConfirmDeleteMessage", resourceCulture);
+
+        public static string Vault_NewItemTitle => ResourceManager.GetString("Vault_NewItemTitle", resourceCulture);
+
+        public static string Vault_UserCopiedToast => ResourceManager.GetString("Vault_UserCopiedToast", resourceCulture);
+
+        public static string Vault_PasswordCopiedToast => ResourceManager.GetString("Vault_PasswordCopiedToast", resourceCulture);
+
+        public static string Vault_NameValidationMessage => ResourceManager.GetString("Vault_NameValidationMessage", resourceCulture);
+
+        public static string Vault_PasswordValidationMessage => ResourceManager.GetString("Vault_PasswordValidationMessage", resourceCulture);
+
+        public static string Vault_OpenUrlErrorMessage => ResourceManager.GetString("Vault_OpenUrlErrorMessage", resourceCulture);
+
+        public static string VaultSettings_WrongCurrentPasswordMessage => ResourceManager.GetString("VaultSettings_WrongCurrentPasswordMessage", resourceCulture);
+
+        public static string VaultSettings_BiometricResealFailedMessage => ResourceManager.GetString("VaultSettings_BiometricResealFailedMessage", resourceCulture);
+
+        public static string VaultSettings_MinNewPasswordLengthMessage => ResourceManager.GetString("VaultSettings_MinNewPasswordLengthMessage", resourceCulture);
+
+        public static string CreateVault_MinPasswordLengthMessage => ResourceManager.GetString("CreateVault_MinPasswordLengthMessage", resourceCulture);
+
+        public static string CreateVault_SaveErrorMessage => ResourceManager.GetString("CreateVault_SaveErrorMessage", resourceCulture);
+
+        public static string CreateVault_ButtonBusyText => ResourceManager.GetString("CreateVault_ButtonBusyText", resourceCulture);
+
+        public static string CreateVault_ButtonIdleText => ResourceManager.GetString("CreateVault_ButtonIdleText", resourceCulture);
+
+        public static string CreateVault_DefaultVaultName => ResourceManager.GetString("CreateVault_DefaultVaultName", resourceCulture);
+
+        public static string BackupRecovery_EmptyPasswordMessage => ResourceManager.GetString("BackupRecovery_EmptyPasswordMessage", resourceCulture);
+
+        public static string BiometricOptIn_UnavailableMessage => ResourceManager.GetString("BiometricOptIn_UnavailableMessage", resourceCulture);
+
+        public static string Backups_LegacyKindLabel => ResourceManager.GetString("Backups_LegacyKindLabel", resourceCulture);
+
+        public static string Format_DateTimeShort => ResourceManager.GetString("Format_DateTimeShort", resourceCulture);
+
+        public static string Format_SizeBytes => ResourceManager.GetString("Format_SizeBytes", resourceCulture);
+
+        public static string Format_SizeKilobytes => ResourceManager.GetString("Format_SizeKilobytes", resourceCulture);
+
+        public static string Format_SizeMegabytes => ResourceManager.GetString("Format_SizeMegabytes", resourceCulture);
+
+        public static string Seal_SecretCreated => ResourceManager.GetString("Seal_SecretCreated", resourceCulture);
+
+        public static string Seal_SettingsSaved => ResourceManager.GetString("Seal_SettingsSaved", resourceCulture);
+
+        public static string Seal_SecretDeleted => ResourceManager.GetString("Seal_SecretDeleted", resourceCulture);
+
+        public static string Seal_BackupDeleted => ResourceManager.GetString("Seal_BackupDeleted", resourceCulture);
+
+        public static string Seal_AllBackupsDeleted => ResourceManager.GetString("Seal_AllBackupsDeleted", resourceCulture);
+
+        public static string A11y_HelpButtonDescription => ResourceManager.GetString("A11y_HelpButtonDescription", resourceCulture);
+
+        public static string A11y_HelpAbout => ResourceManager.GetString("A11y_HelpAbout", resourceCulture);
+
+        public static string Platform_BiometricActivateSubtitle => ResourceManager.GetString("Platform_BiometricActivateSubtitle", resourceCulture);
+
+        public static string Platform_BiometricUnlockSubtitle => ResourceManager.GetString("Platform_BiometricUnlockSubtitle", resourceCulture);
+
+        public static string Platform_BiometricNegativeButton => ResourceManager.GetString("Platform_BiometricNegativeButton", resourceCulture);
+
+        public static string Platform_WindowsBiometricActivateMessage => ResourceManager.GetString("Platform_WindowsBiometricActivateMessage", resourceCulture);
+
+        public static string Platform_WindowsBiometricUnlockMessage => ResourceManager.GetString("Platform_WindowsBiometricUnlockMessage", resourceCulture);
+
+        public static string Platform_WindowsFileTypeLabel => ResourceManager.GetString("Platform_WindowsFileTypeLabel", resourceCulture);
     }
 }

--- a/src/GDSB.MAUI.ViewModels/Resources/AppStrings.Designer.cs
+++ b/src/GDSB.MAUI.ViewModels/Resources/AppStrings.Designer.cs
@@ -365,5 +365,117 @@ namespace GDSB.MAUI.ViewModels.Resources
         public static string Platform_WindowsBiometricUnlockMessage => ResourceManager.GetString("Platform_WindowsBiometricUnlockMessage", resourceCulture);
 
         public static string Platform_WindowsFileTypeLabel => ResourceManager.GetString("Platform_WindowsFileTypeLabel", resourceCulture);
+
+        public static string Help_MasterUnlockCode_Title => ResourceManager.GetString("Help_MasterUnlockCode_Title", resourceCulture);
+
+        public static string Help_MasterUnlockCode_Text1 => ResourceManager.GetString("Help_MasterUnlockCode_Text1", resourceCulture);
+
+        public static string Help_MasterUnlockCode_Text2 => ResourceManager.GetString("Help_MasterUnlockCode_Text2", resourceCulture);
+
+        public static string Help_MasterUnlockCode_VisualCaption => ResourceManager.GetString("Help_MasterUnlockCode_VisualCaption", resourceCulture);
+
+        public static string Help_VaultName_Title => ResourceManager.GetString("Help_VaultName_Title", resourceCulture);
+
+        public static string Help_VaultName_Text1 => ResourceManager.GetString("Help_VaultName_Text1", resourceCulture);
+
+        public static string Help_VaultName_Text2 => ResourceManager.GetString("Help_VaultName_Text2", resourceCulture);
+
+        public static string Help_VaultName_VisualCaption => ResourceManager.GetString("Help_VaultName_VisualCaption", resourceCulture);
+
+        public static string Help_VaultProtections_Title => ResourceManager.GetString("Help_VaultProtections_Title", resourceCulture);
+
+        public static string Help_VaultProtections_Heading1 => ResourceManager.GetString("Help_VaultProtections_Heading1", resourceCulture);
+
+        public static string Help_VaultProtections_Text1 => ResourceManager.GetString("Help_VaultProtections_Text1", resourceCulture);
+
+        public static string Help_VaultProtections_Heading2 => ResourceManager.GetString("Help_VaultProtections_Heading2", resourceCulture);
+
+        public static string Help_VaultProtections_Text2 => ResourceManager.GetString("Help_VaultProtections_Text2", resourceCulture);
+
+        public static string Help_VaultProtections_VisualCaption => ResourceManager.GetString("Help_VaultProtections_VisualCaption", resourceCulture);
+
+        public static string Help_VaultBackups_Title => ResourceManager.GetString("Help_VaultBackups_Title", resourceCulture);
+
+        public static string Help_VaultBackups_Text1 => ResourceManager.GetString("Help_VaultBackups_Text1", resourceCulture);
+
+        public static string Help_VaultBackups_Text2 => ResourceManager.GetString("Help_VaultBackups_Text2", resourceCulture);
+
+        public static string Help_VaultBackups_VisualCaption => ResourceManager.GetString("Help_VaultBackups_VisualCaption", resourceCulture);
+
+        public static string Help_ChangeMasterUnlockCode_Title => ResourceManager.GetString("Help_ChangeMasterUnlockCode_Title", resourceCulture);
+
+        public static string Help_ChangeMasterUnlockCode_Text1 => ResourceManager.GetString("Help_ChangeMasterUnlockCode_Text1", resourceCulture);
+
+        public static string Help_ChangeMasterUnlockCode_Text2 => ResourceManager.GetString("Help_ChangeMasterUnlockCode_Text2", resourceCulture);
+
+        public static string Help_ChangeMasterUnlockCode_Text3 => ResourceManager.GetString("Help_ChangeMasterUnlockCode_Text3", resourceCulture);
+
+        public static string Help_ChangeMasterUnlockCode_VisualCaption => ResourceManager.GetString("Help_ChangeMasterUnlockCode_VisualCaption", resourceCulture);
+
+        public static string Help_SecretUrl_Title => ResourceManager.GetString("Help_SecretUrl_Title", resourceCulture);
+
+        public static string Help_SecretUrl_Text1 => ResourceManager.GetString("Help_SecretUrl_Text1", resourceCulture);
+
+        public static string Help_SecretUrl_Text2 => ResourceManager.GetString("Help_SecretUrl_Text2", resourceCulture);
+
+        public static string Help_SecretUrl_VisualCaption => ResourceManager.GetString("Help_SecretUrl_VisualCaption", resourceCulture);
+
+        public static string Help_SecretStoredValue_Title => ResourceManager.GetString("Help_SecretStoredValue_Title", resourceCulture);
+
+        public static string Help_SecretStoredValue_Text1 => ResourceManager.GetString("Help_SecretStoredValue_Text1", resourceCulture);
+
+        public static string Help_SecretStoredValue_Text2 => ResourceManager.GetString("Help_SecretStoredValue_Text2", resourceCulture);
+
+        public static string Help_SecretStoredValue_VisualCaption => ResourceManager.GetString("Help_SecretStoredValue_VisualCaption", resourceCulture);
+
+        public static string Help_SecretFavorite_Title => ResourceManager.GetString("Help_SecretFavorite_Title", resourceCulture);
+
+        public static string Help_SecretFavorite_Text1 => ResourceManager.GetString("Help_SecretFavorite_Text1", resourceCulture);
+
+        public static string Help_SecretFavorite_Text2 => ResourceManager.GetString("Help_SecretFavorite_Text2", resourceCulture);
+
+        public static string Help_SecretFavorite_VisualCaption => ResourceManager.GetString("Help_SecretFavorite_VisualCaption", resourceCulture);
+
+        public static string Help_BackupRecovery_Title => ResourceManager.GetString("Help_BackupRecovery_Title", resourceCulture);
+
+        public static string Help_BackupRecovery_Heading1 => ResourceManager.GetString("Help_BackupRecovery_Heading1", resourceCulture);
+
+        public static string Help_BackupRecovery_Text1 => ResourceManager.GetString("Help_BackupRecovery_Text1", resourceCulture);
+
+        public static string Help_BackupRecovery_VisualCaption1 => ResourceManager.GetString("Help_BackupRecovery_VisualCaption1", resourceCulture);
+
+        public static string Help_BackupRecovery_Heading2 => ResourceManager.GetString("Help_BackupRecovery_Heading2", resourceCulture);
+
+        public static string Help_BackupRecovery_Text2 => ResourceManager.GetString("Help_BackupRecovery_Text2", resourceCulture);
+
+        public static string Help_BackupRecovery_VisualCaption2 => ResourceManager.GetString("Help_BackupRecovery_VisualCaption2", resourceCulture);
+
+        public static string Help_BackupRecovery_Heading3 => ResourceManager.GetString("Help_BackupRecovery_Heading3", resourceCulture);
+
+        public static string Help_BackupRecovery_Text3 => ResourceManager.GetString("Help_BackupRecovery_Text3", resourceCulture);
+
+        public static string Help_BackupRecovery_VisualCaption3 => ResourceManager.GetString("Help_BackupRecovery_VisualCaption3", resourceCulture);
+
+        public static string Help_BackupRecovery_Heading4 => ResourceManager.GetString("Help_BackupRecovery_Heading4", resourceCulture);
+
+        public static string Help_BackupRecovery_Text4 => ResourceManager.GetString("Help_BackupRecovery_Text4", resourceCulture);
+
+        public static string Help_BackupRecovery_VisualCaption4 => ResourceManager.GetString("Help_BackupRecovery_VisualCaption4", resourceCulture);
+
+        public static string Onboarding_Slide1Title => ResourceManager.GetString("Onboarding_Slide1Title", resourceCulture);
+
+        public static string Onboarding_Slide1Body => ResourceManager.GetString("Onboarding_Slide1Body", resourceCulture);
+
+        public static string Onboarding_Slide2Title => ResourceManager.GetString("Onboarding_Slide2Title", resourceCulture);
+
+        public static string Onboarding_Slide2Body => ResourceManager.GetString("Onboarding_Slide2Body", resourceCulture);
+
+        public static string Onboarding_Slide3Title => ResourceManager.GetString("Onboarding_Slide3Title", resourceCulture);
+
+        public static string Onboarding_Slide3Body => ResourceManager.GetString("Onboarding_Slide3Body", resourceCulture);
+
+        public static string Onboarding_AdvanceButtonNext => ResourceManager.GetString("Onboarding_AdvanceButtonNext", resourceCulture);
+
+        public static string Onboarding_AdvanceButtonFinish => ResourceManager.GetString("Onboarding_AdvanceButtonFinish", resourceCulture);
     }
 }

--- a/src/GDSB.MAUI.ViewModels/Resources/AppStrings.Designer.cs
+++ b/src/GDSB.MAUI.ViewModels/Resources/AppStrings.Designer.cs
@@ -71,5 +71,203 @@ namespace GDSB.MAUI.ViewModels.Resources
         public static string Unlock_RecoverBackupLink => ResourceManager.GetString("Unlock_RecoverBackupLink", resourceCulture);
 
         public static string Unlock_LanguagePickerDescription => ResourceManager.GetString("Unlock_LanguagePickerDescription", resourceCulture);
+
+        public static string Common_Back => ResourceManager.GetString("Common_Back", resourceCulture);
+
+        public static string Common_Cancel => ResourceManager.GetString("Common_Cancel", resourceCulture);
+
+        public static string Common_Copy => ResourceManager.GetString("Common_Copy", resourceCulture);
+
+        public static string Common_Delete => ResourceManager.GetString("Common_Delete", resourceCulture);
+
+        public static string Common_RequiredFieldsLegend => ResourceManager.GetString("Common_RequiredFieldsLegend", resourceCulture);
+
+        public static string Vault_NameFieldLabel => ResourceManager.GetString("Vault_NameFieldLabel", resourceCulture);
+
+        public static string Vault_MasterPasswordFieldLabel => ResourceManager.GetString("Vault_MasterPasswordFieldLabel", resourceCulture);
+
+        public static string Vault_MinPasswordPlaceholder => ResourceManager.GetString("Vault_MinPasswordPlaceholder", resourceCulture);
+
+        public static string Vault_CopyUserButton => ResourceManager.GetString("Vault_CopyUserButton", resourceCulture);
+
+        public static string Vault_CopyPasswordButton => ResourceManager.GetString("Vault_CopyPasswordButton", resourceCulture);
+
+        public static string Vault_SearchPlaceholder => ResourceManager.GetString("Vault_SearchPlaceholder", resourceCulture);
+
+        public static string Vault_FilterAllChip => ResourceManager.GetString("Vault_FilterAllChip", resourceCulture);
+
+        public static string Vault_FilterFavoritesChip => ResourceManager.GetString("Vault_FilterFavoritesChip", resourceCulture);
+
+        public static string Vault_EmptyEditorState => ResourceManager.GetString("Vault_EmptyEditorState", resourceCulture);
+
+        public static string SaveAsNewFile_Title => ResourceManager.GetString("SaveAsNewFile_Title", resourceCulture);
+
+        public static string SaveAsNewFile_Body => ResourceManager.GetString("SaveAsNewFile_Body", resourceCulture);
+
+        public static string SaveAsNewFile_DeclineButton => ResourceManager.GetString("SaveAsNewFile_DeclineButton", resourceCulture);
+
+        public static string SaveAsNewFile_AcceptButton => ResourceManager.GetString("SaveAsNewFile_AcceptButton", resourceCulture);
+
+        public static string VaultSettings_Title => ResourceManager.GetString("VaultSettings_Title", resourceCulture);
+
+        public static string VaultSettings_SaveNameButton => ResourceManager.GetString("VaultSettings_SaveNameButton", resourceCulture);
+
+        public static string VaultSettings_SaveProtectionsButton => ResourceManager.GetString("VaultSettings_SaveProtectionsButton", resourceCulture);
+
+        public static string VaultSettings_SaveBackupsButton => ResourceManager.GetString("VaultSettings_SaveBackupsButton", resourceCulture);
+
+        public static string VaultSettings_ChangePasswordTitle => ResourceManager.GetString("VaultSettings_ChangePasswordTitle", resourceCulture);
+
+        public static string VaultSettings_CurrentPasswordLabel => ResourceManager.GetString("VaultSettings_CurrentPasswordLabel", resourceCulture);
+
+        public static string VaultSettings_NewPasswordLabel => ResourceManager.GetString("VaultSettings_NewPasswordLabel", resourceCulture);
+
+        public static string VaultSettings_ConfirmNewPasswordLabel => ResourceManager.GetString("VaultSettings_ConfirmNewPasswordLabel", resourceCulture);
+
+        public static string VaultSettings_DeleteOldBackupsLabel => ResourceManager.GetString("VaultSettings_DeleteOldBackupsLabel", resourceCulture);
+
+        public static string VaultSettings_ChangePasswordButton => ResourceManager.GetString("VaultSettings_ChangePasswordButton", resourceCulture);
+
+        public static string Protections_SectionLabel => ResourceManager.GetString("Protections_SectionLabel", resourceCulture);
+
+        public static string Protections_ClipboardClearLabel => ResourceManager.GetString("Protections_ClipboardClearLabel", resourceCulture);
+
+        public static string Protections_ClipboardChip20s => ResourceManager.GetString("Protections_ClipboardChip20s", resourceCulture);
+
+        public static string Protections_ClipboardChip45s => ResourceManager.GetString("Protections_ClipboardChip45s", resourceCulture);
+
+        public static string Protections_ClipboardChip90s => ResourceManager.GetString("Protections_ClipboardChip90s", resourceCulture);
+
+        public static string Protections_AutoLockLabel => ResourceManager.GetString("Protections_AutoLockLabel", resourceCulture);
+
+        public static string Protections_AutoLockWarning => ResourceManager.GetString("Protections_AutoLockWarning", resourceCulture);
+
+        public static string Protections_AutoLockChip1min => ResourceManager.GetString("Protections_AutoLockChip1min", resourceCulture);
+
+        public static string Protections_AutoLockChip2min => ResourceManager.GetString("Protections_AutoLockChip2min", resourceCulture);
+
+        public static string Protections_AutoLockChip5min => ResourceManager.GetString("Protections_AutoLockChip5min", resourceCulture);
+
+        public static string Protections_AutoLockChip15min => ResourceManager.GetString("Protections_AutoLockChip15min", resourceCulture);
+
+        public static string Backups_SectionLabel => ResourceManager.GetString("Backups_SectionLabel", resourceCulture);
+
+        public static string Backups_RetentionQuestion => ResourceManager.GetString("Backups_RetentionQuestion", resourceCulture);
+
+        public static string Backups_ModeByCountChip => ResourceManager.GetString("Backups_ModeByCountChip", resourceCulture);
+
+        public static string Backups_ModeByDaysChip => ResourceManager.GetString("Backups_ModeByDaysChip", resourceCulture);
+
+        public static string Backups_DaysChip3 => ResourceManager.GetString("Backups_DaysChip3", resourceCulture);
+
+        public static string Backups_DaysChip5 => ResourceManager.GetString("Backups_DaysChip5", resourceCulture);
+
+        public static string Backups_DaysChip15 => ResourceManager.GetString("Backups_DaysChip15", resourceCulture);
+
+        public static string Backups_DaysChip30 => ResourceManager.GetString("Backups_DaysChip30", resourceCulture);
+
+        public static string Backups_RetentionByCountNote => ResourceManager.GetString("Backups_RetentionByCountNote", resourceCulture);
+
+        public static string Backups_RetentionByDaysNote => ResourceManager.GetString("Backups_RetentionByDaysNote", resourceCulture);
+
+        public static string CreateVault_Title => ResourceManager.GetString("CreateVault_Title", resourceCulture);
+
+        public static string CreateVault_Subtitle => ResourceManager.GetString("CreateVault_Subtitle", resourceCulture);
+
+        public static string CreateVault_ConfirmPasswordFieldLabel => ResourceManager.GetString("CreateVault_ConfirmPasswordFieldLabel", resourceCulture);
+
+        public static string CreateVault_ConfirmPasswordPlaceholder => ResourceManager.GetString("CreateVault_ConfirmPasswordPlaceholder", resourceCulture);
+
+        public static string CreateVault_ClipboardClearHelperText => ResourceManager.GetString("CreateVault_ClipboardClearHelperText", resourceCulture);
+
+        public static string CreateVault_AutoLockHelperText => ResourceManager.GetString("CreateVault_AutoLockHelperText", resourceCulture);
+
+        public static string BackupRecovery_Title => ResourceManager.GetString("BackupRecovery_Title", resourceCulture);
+
+        public static string BackupRecovery_HelperText => ResourceManager.GetString("BackupRecovery_HelperText", resourceCulture);
+
+        public static string BackupRecovery_EmptyTitle => ResourceManager.GetString("BackupRecovery_EmptyTitle", resourceCulture);
+
+        public static string BackupRecovery_EmptyBody => ResourceManager.GetString("BackupRecovery_EmptyBody", resourceCulture);
+
+        public static string BackupRecovery_DeleteAllLink => ResourceManager.GetString("BackupRecovery_DeleteAllLink", resourceCulture);
+
+        public static string BackupRecovery_RestoreButton => ResourceManager.GetString("BackupRecovery_RestoreButton", resourceCulture);
+
+        public static string BackupRecovery_RestoreModalTitle => ResourceManager.GetString("BackupRecovery_RestoreModalTitle", resourceCulture);
+
+        public static string BackupRecovery_RestoreModalHint => ResourceManager.GetString("BackupRecovery_RestoreModalHint", resourceCulture);
+
+        public static string BackupRecovery_RestorePasswordPlaceholder => ResourceManager.GetString("BackupRecovery_RestorePasswordPlaceholder", resourceCulture);
+
+        public static string BackupRecovery_DeleteModalTitle => ResourceManager.GetString("BackupRecovery_DeleteModalTitle", resourceCulture);
+
+        public static string BackupRecovery_DeleteModalWarning => ResourceManager.GetString("BackupRecovery_DeleteModalWarning", resourceCulture);
+
+        public static string BackupRecovery_DeleteAllModalTitle => ResourceManager.GetString("BackupRecovery_DeleteAllModalTitle", resourceCulture);
+
+        public static string BackupRecovery_DeleteAllModalWarning => ResourceManager.GetString("BackupRecovery_DeleteAllModalWarning", resourceCulture);
+
+        public static string BackupRecovery_DeleteAllConfirmButton => ResourceManager.GetString("BackupRecovery_DeleteAllConfirmButton", resourceCulture);
+
+        public static string ItemEditor_UserLabel => ResourceManager.GetString("ItemEditor_UserLabel", resourceCulture);
+
+        public static string ItemEditor_PasswordLabel => ResourceManager.GetString("ItemEditor_PasswordLabel", resourceCulture);
+
+        public static string ItemEditor_ObsLabel => ResourceManager.GetString("ItemEditor_ObsLabel", resourceCulture);
+
+        public static string ItemEditor_EditButton => ResourceManager.GetString("ItemEditor_EditButton", resourceCulture);
+
+        public static string ItemEditor_NameFieldLabel => ResourceManager.GetString("ItemEditor_NameFieldLabel", resourceCulture);
+
+        public static string ItemEditor_NamePlaceholder => ResourceManager.GetString("ItemEditor_NamePlaceholder", resourceCulture);
+
+        public static string ItemEditor_UrlFieldLabel => ResourceManager.GetString("ItemEditor_UrlFieldLabel", resourceCulture);
+
+        public static string ItemEditor_UrlPlaceholder => ResourceManager.GetString("ItemEditor_UrlPlaceholder", resourceCulture);
+
+        public static string ItemEditor_FavoriteCheckboxLabel => ResourceManager.GetString("ItemEditor_FavoriteCheckboxLabel", resourceCulture);
+
+        public static string ItemEditor_SaveButton => ResourceManager.GetString("ItemEditor_SaveButton", resourceCulture);
+
+        public static string Onboarding_Slide1SampleFileName => ResourceManager.GetString("Onboarding_Slide1SampleFileName", resourceCulture);
+
+        public static string Onboarding_Slide1Caption => ResourceManager.GetString("Onboarding_Slide1Caption", resourceCulture);
+
+        public static string Onboarding_Slide2Caption => ResourceManager.GetString("Onboarding_Slide2Caption", resourceCulture);
+
+        public static string Onboarding_Slide3Caption => ResourceManager.GetString("Onboarding_Slide3Caption", resourceCulture);
+
+        public static string Onboarding_SkipButton => ResourceManager.GetString("Onboarding_SkipButton", resourceCulture);
+
+        public static string BiometricOptIn_Title => ResourceManager.GetString("BiometricOptIn_Title", resourceCulture);
+
+        public static string BiometricOptIn_Body => ResourceManager.GetString("BiometricOptIn_Body", resourceCulture);
+
+        public static string BiometricOptIn_AcceptButton => ResourceManager.GetString("BiometricOptIn_AcceptButton", resourceCulture);
+
+        public static string BiometricOptIn_DeclineButton => ResourceManager.GetString("BiometricOptIn_DeclineButton", resourceCulture);
+
+        public static string HelpSheet_DismissButton => ResourceManager.GetString("HelpSheet_DismissButton", resourceCulture);
+
+        public static string HelpVisual_SaveAsNewFileShortButton => ResourceManager.GetString("HelpVisual_SaveAsNewFileShortButton", resourceCulture);
+
+        public static string HelpVisual_DeleteOldBackupsLabel => ResourceManager.GetString("HelpVisual_DeleteOldBackupsLabel", resourceCulture);
+
+        public static string HelpVisual_SampleItemName => ResourceManager.GetString("HelpVisual_SampleItemName", resourceCulture);
+
+        public static string HelpVisual_SampleItemUrl => ResourceManager.GetString("HelpVisual_SampleItemUrl", resourceCulture);
+
+        public static string HelpVisual_SampleItemInitial => ResourceManager.GetString("HelpVisual_SampleItemInitial", resourceCulture);
+
+        public static string HelpVisual_SampleVaultName => ResourceManager.GetString("HelpVisual_SampleVaultName", resourceCulture);
+
+        public static string HelpVisual_SampleBackupFileName => ResourceManager.GetString("HelpVisual_SampleBackupFileName", resourceCulture);
+
+        public static string HelpVisual_SampleBackupDate => ResourceManager.GetString("HelpVisual_SampleBackupDate", resourceCulture);
+
+        public static string HelpVisual_SampleBackupSize => ResourceManager.GetString("HelpVisual_SampleBackupSize", resourceCulture);
+
+        public static string HelpVisual_SampleBackupKind => ResourceManager.GetString("HelpVisual_SampleBackupKind", resourceCulture);
     }
 }

--- a/src/GDSB.MAUI.ViewModels/Resources/AppStrings.en.resx
+++ b/src/GDSB.MAUI.ViewModels/Resources/AppStrings.en.resx
@@ -100,4 +100,301 @@
   <data name="Unlock_LanguagePickerDescription" xml:space="preserve">
     <value>App language</value>
   </data>
+  <data name="Common_Back" xml:space="preserve">
+    <value>Back</value>
+  </data>
+  <data name="Common_Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Common_Copy" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="Common_Delete" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="Common_RequiredFieldsLegend" xml:space="preserve">
+    <value>* required fields</value>
+  </data>
+  <data name="Vault_NameFieldLabel" xml:space="preserve">
+    <value>VAULT NAME</value>
+  </data>
+  <data name="Vault_MasterPasswordFieldLabel" xml:space="preserve">
+    <value>MASTER PASSWORD</value>
+  </data>
+  <data name="Vault_MinPasswordPlaceholder" xml:space="preserve">
+    <value>At least 8 characters</value>
+  </data>
+  <data name="Vault_CopyUserButton" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Vault_CopyPasswordButton" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Vault_SearchPlaceholder" xml:space="preserve">
+    <value>Search by name...</value>
+  </data>
+  <data name="Vault_FilterAllChip" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="Vault_FilterFavoritesChip" xml:space="preserve">
+    <value>Favorites</value>
+  </data>
+  <data name="Vault_EmptyEditorState" xml:space="preserve">
+    <value>Select an item from the list or create a new one</value>
+  </data>
+  <data name="SaveAsNewFile_Title" xml:space="preserve">
+    <value>Also save to a new file?</value>
+  </data>
+  <data name="SaveAsNewFile_Body" xml:space="preserve">
+    <value>The current file has already been saved with the change. You can also save a copy to a new file, keeping the original intact. Saving ends the session, and you'll choose which of the two to open on the unlock screen.</value>
+  </data>
+  <data name="SaveAsNewFile_DeclineButton" xml:space="preserve">
+    <value>No, thanks</value>
+  </data>
+  <data name="SaveAsNewFile_AcceptButton" xml:space="preserve">
+    <value>Save as a new file</value>
+  </data>
+  <data name="VaultSettings_Title" xml:space="preserve">
+    <value>Edit vault</value>
+  </data>
+  <data name="VaultSettings_SaveNameButton" xml:space="preserve">
+    <value>Save name</value>
+  </data>
+  <data name="VaultSettings_SaveProtectionsButton" xml:space="preserve">
+    <value>Save protections</value>
+  </data>
+  <data name="VaultSettings_SaveBackupsButton" xml:space="preserve">
+    <value>Save backups</value>
+  </data>
+  <data name="VaultSettings_ChangePasswordTitle" xml:space="preserve">
+    <value>CHANGE MASTER PASSWORD</value>
+  </data>
+  <data name="VaultSettings_CurrentPasswordLabel" xml:space="preserve">
+    <value>CURRENT PASSWORD</value>
+  </data>
+  <data name="VaultSettings_NewPasswordLabel" xml:space="preserve">
+    <value>NEW PASSWORD</value>
+  </data>
+  <data name="VaultSettings_ConfirmNewPasswordLabel" xml:space="preserve">
+    <value>CONFIRM NEW PASSWORD</value>
+  </data>
+  <data name="VaultSettings_DeleteOldBackupsLabel" xml:space="preserve">
+    <value>Delete this vault's old backups (they remain encrypted with the old password)</value>
+  </data>
+  <data name="VaultSettings_ChangePasswordButton" xml:space="preserve">
+    <value>Change password</value>
+  </data>
+  <data name="Protections_SectionLabel" xml:space="preserve">
+    <value>PROTECTIONS</value>
+  </data>
+  <data name="Protections_ClipboardClearLabel" xml:space="preserve">
+    <value>Clear the clipboard</value>
+  </data>
+  <data name="Protections_ClipboardChip20s" xml:space="preserve">
+    <value>20s</value>
+  </data>
+  <data name="Protections_ClipboardChip45s" xml:space="preserve">
+    <value>45s</value>
+  </data>
+  <data name="Protections_ClipboardChip90s" xml:space="preserve">
+    <value>90s</value>
+  </data>
+  <data name="Protections_AutoLockLabel" xml:space="preserve">
+    <value>Automatic lock</value>
+  </data>
+  <data name="Protections_AutoLockWarning" xml:space="preserve">
+    <value>Turning this off leaves the vault open indefinitely in the background.</value>
+  </data>
+  <data name="Protections_AutoLockChip1min" xml:space="preserve">
+    <value>1 min</value>
+  </data>
+  <data name="Protections_AutoLockChip2min" xml:space="preserve">
+    <value>2 min</value>
+  </data>
+  <data name="Protections_AutoLockChip5min" xml:space="preserve">
+    <value>5 min</value>
+  </data>
+  <data name="Protections_AutoLockChip15min" xml:space="preserve">
+    <value>15 min</value>
+  </data>
+  <data name="Backups_SectionLabel" xml:space="preserve">
+    <value>BACKUPS</value>
+  </data>
+  <data name="Backups_RetentionQuestion" xml:space="preserve">
+    <value>How many versions to keep</value>
+  </data>
+  <data name="Backups_ModeByCountChip" xml:space="preserve">
+    <value>By count</value>
+  </data>
+  <data name="Backups_ModeByDaysChip" xml:space="preserve">
+    <value>By time</value>
+  </data>
+  <data name="Backups_DaysChip3" xml:space="preserve">
+    <value>3 days</value>
+  </data>
+  <data name="Backups_DaysChip5" xml:space="preserve">
+    <value>5 days</value>
+  </data>
+  <data name="Backups_DaysChip15" xml:space="preserve">
+    <value>15 days</value>
+  </data>
+  <data name="Backups_DaysChip30" xml:space="preserve">
+    <value>30 days</value>
+  </data>
+  <data name="Backups_RetentionByCountNote" xml:space="preserve">
+    <value>Past the version limit, the oldest one is deleted. The most recent version is never deleted.</value>
+  </data>
+  <data name="Backups_RetentionByDaysNote" xml:space="preserve">
+    <value>Backups older than the chosen limit are deleted. The most recent version is never deleted.</value>
+  </data>
+  <data name="CreateVault_Title" xml:space="preserve">
+    <value>New vault</value>
+  </data>
+  <data name="CreateVault_Subtitle" xml:space="preserve">
+    <value>Choose where to keep it and set the master password</value>
+  </data>
+  <data name="CreateVault_ConfirmPasswordFieldLabel" xml:space="preserve">
+    <value>CONFIRM PASSWORD</value>
+  </data>
+  <data name="CreateVault_ConfirmPasswordPlaceholder" xml:space="preserve">
+    <value>Enter the password again</value>
+  </data>
+  <data name="CreateVault_ClipboardClearHelperText" xml:space="preserve">
+    <value>When you copy a password or username, the app clears the clipboard after the chosen time.</value>
+  </data>
+  <data name="CreateVault_AutoLockHelperText" xml:space="preserve">
+    <value>Returns to the password screen if the app stays in the background past the chosen time.</value>
+  </data>
+  <data name="BackupRecovery_Title" xml:space="preserve">
+    <value>Recover backup</value>
+  </data>
+  <data name="BackupRecovery_HelperText" xml:space="preserve">
+    <value>Backups are created automatically before every save. Restoring always creates a new file - the original vault is never overwritten.</value>
+  </data>
+  <data name="BackupRecovery_EmptyTitle" xml:space="preserve">
+    <value>No backups yet</value>
+  </data>
+  <data name="BackupRecovery_EmptyBody" xml:space="preserve">
+    <value>Backups appear automatically after a vault's first edit.</value>
+  </data>
+  <data name="BackupRecovery_DeleteAllLink" xml:space="preserve">
+    <value>Delete all backups</value>
+  </data>
+  <data name="BackupRecovery_RestoreButton" xml:space="preserve">
+    <value>Restore</value>
+  </data>
+  <data name="BackupRecovery_RestoreModalTitle" xml:space="preserve">
+    <value>Restore backup</value>
+  </data>
+  <data name="BackupRecovery_RestoreModalHint" xml:space="preserve">
+    <value>Enter this backup's master password. If it predates a password change, use the old password.</value>
+  </data>
+  <data name="BackupRecovery_RestorePasswordPlaceholder" xml:space="preserve">
+    <value>Backup's master password</value>
+  </data>
+  <data name="BackupRecovery_DeleteModalTitle" xml:space="preserve">
+    <value>Delete this backup?</value>
+  </data>
+  <data name="BackupRecovery_DeleteModalWarning" xml:space="preserve">
+    <value>This action can't be undone.</value>
+  </data>
+  <data name="BackupRecovery_DeleteAllModalTitle" xml:space="preserve">
+    <value>Delete all backups?</value>
+  </data>
+  <data name="BackupRecovery_DeleteAllModalWarning" xml:space="preserve">
+    <value>All backups listed on this screen will be deleted. This action can't be undone.</value>
+  </data>
+  <data name="BackupRecovery_DeleteAllConfirmButton" xml:space="preserve">
+    <value>Delete all</value>
+  </data>
+  <data name="ItemEditor_UserLabel" xml:space="preserve">
+    <value>USERNAME</value>
+  </data>
+  <data name="ItemEditor_PasswordLabel" xml:space="preserve">
+    <value>PASSWORD</value>
+  </data>
+  <data name="ItemEditor_ObsLabel" xml:space="preserve">
+    <value>NOTES</value>
+  </data>
+  <data name="ItemEditor_EditButton" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+  <data name="ItemEditor_NameFieldLabel" xml:space="preserve">
+    <value>NAME</value>
+  </data>
+  <data name="ItemEditor_NamePlaceholder" xml:space="preserve">
+    <value>e.g., Netflix</value>
+  </data>
+  <data name="ItemEditor_UrlFieldLabel" xml:space="preserve">
+    <value>URL</value>
+  </data>
+  <data name="ItemEditor_UrlPlaceholder" xml:space="preserve">
+    <value>site.com</value>
+  </data>
+  <data name="ItemEditor_FavoriteCheckboxLabel" xml:space="preserve">
+    <value>Mark as favorite</value>
+  </data>
+  <data name="ItemEditor_SaveButton" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="Onboarding_Slide1SampleFileName" xml:space="preserve">
+    <value>my-vault.GDSBX</value>
+  </data>
+  <data name="Onboarding_Slide1Caption" xml:space="preserve">
+    <value>A file that's yours, kept wherever you want</value>
+  </data>
+  <data name="Onboarding_Slide2Caption" xml:space="preserve">
+    <value>It's this link, right below the password card</value>
+  </data>
+  <data name="Onboarding_Slide3Caption" xml:space="preserve">
+    <value>It appears in place of the password field once you turn on fingerprint unlock</value>
+  </data>
+  <data name="Onboarding_SkipButton" xml:space="preserve">
+    <value>Skip</value>
+  </data>
+  <data name="BiometricOptIn_Title" xml:space="preserve">
+    <value>Unlock with biometrics</value>
+  </data>
+  <data name="BiometricOptIn_Body" xml:space="preserve">
+    <value>Next time, use your fingerprint or face to open this vault without typing the password. The master password keeps working normally whenever you want it.</value>
+  </data>
+  <data name="BiometricOptIn_AcceptButton" xml:space="preserve">
+    <value>Turn on biometrics</value>
+  </data>
+  <data name="BiometricOptIn_DeclineButton" xml:space="preserve">
+    <value>Not now</value>
+  </data>
+  <data name="HelpSheet_DismissButton" xml:space="preserve">
+    <value>Got it</value>
+  </data>
+  <data name="HelpVisual_SaveAsNewFileShortButton" xml:space="preserve">
+    <value>Save as new</value>
+  </data>
+  <data name="HelpVisual_DeleteOldBackupsLabel" xml:space="preserve">
+    <value>Delete this vault's old backups</value>
+  </data>
+  <data name="HelpVisual_SampleItemName" xml:space="preserve">
+    <value>Netflix</value>
+  </data>
+  <data name="HelpVisual_SampleItemUrl" xml:space="preserve">
+    <value>netflix.com</value>
+  </data>
+  <data name="HelpVisual_SampleItemInitial" xml:space="preserve">
+    <value>N</value>
+  </data>
+  <data name="HelpVisual_SampleVaultName" xml:space="preserve">
+    <value>Personal vault</value>
+  </data>
+  <data name="HelpVisual_SampleBackupFileName" xml:space="preserve">
+    <value>BKP - Cofre pessoal.GDSBX - 2026-09-02 14-30-12.bak</value>
+  </data>
+  <data name="HelpVisual_SampleBackupDate" xml:space="preserve">
+    <value>9/2/2026 2:30 PM</value>
+  </data>
+  <data name="HelpVisual_SampleBackupSize" xml:space="preserve">
+    <value>12 KB</value>
+  </data>
+  <data name="HelpVisual_SampleBackupKind" xml:space="preserve">
+    <value>Automatic</value>
+  </data>
 </root>

--- a/src/GDSB.MAUI.ViewModels/Resources/AppStrings.en.resx
+++ b/src/GDSB.MAUI.ViewModels/Resources/AppStrings.en.resx
@@ -541,4 +541,172 @@
   <data name="Platform_WindowsFileTypeLabel" xml:space="preserve">
     <value>GDSB File</value>
   </data>
+  <data name="Help_MasterUnlockCode_Title" xml:space="preserve">
+    <value>The master password</value>
+  </data>
+  <data name="Help_MasterUnlockCode_Text1" xml:space="preserve">
+    <value>It's the password that opens this vault. It isn't stored anywhere: not in the app, not on your phone, not on the internet. That's why there's no "forgot my password" here - if you lose this password, nobody can open the file again, not you, not whoever made the app.</value>
+  </data>
+  <data name="Help_MasterUnlockCode_Text2" xml:space="preserve">
+    <value>Pick something you'll remember easily and nobody else would guess. The minimum is 8 characters, but the longer, the better.</value>
+  </data>
+  <data name="Help_MasterUnlockCode_VisualCaption" xml:space="preserve">
+    <value>This is the field. Tap it and type - the letters show up as dots so nobody can read over your shoulder.</value>
+  </data>
+  <data name="Help_VaultName_Title" xml:space="preserve">
+    <value>The vault's name</value>
+  </data>
+  <data name="Help_VaultName_Text1" xml:space="preserve">
+    <value>It's the nickname that shows up inside the app so you can recognize this vault. Changing the name here doesn't rename the file saved on your phone or in the cloud: the file keeps its old name.</value>
+  </data>
+  <data name="Help_VaultName_Text2" xml:space="preserve">
+    <value>That's why, after saving a new name, the app offers to also keep a copy in a new file. It's optional - if you decline, that's fine, the change was already saved to the usual file.</value>
+  </data>
+  <data name="Help_VaultName_VisualCaption" xml:space="preserve">
+    <value>This is the invitation that shows up after saving. Tapping "Save as a new file" creates a copy and keeps the original intact.</value>
+  </data>
+  <data name="Help_VaultProtections_Title" xml:space="preserve">
+    <value>Vault protections</value>
+  </data>
+  <data name="Help_VaultProtections_Heading1" xml:space="preserve">
+    <value>Clear the clipboard</value>
+  </data>
+  <data name="Help_VaultProtections_Text1" xml:space="preserve">
+    <value>When you copy a password, it sits in your phone's "copy and paste" memory, and any other app can read it from there. With this protection on, the app clears that value on its own after the time you choose.</value>
+  </data>
+  <data name="Help_VaultProtections_Heading2" xml:space="preserve">
+    <value>Automatic lock</value>
+  </data>
+  <data name="Help_VaultProtections_Text2" xml:space="preserve">
+    <value>If you leave the app and take a while to come back, it closes the vault and asks for the master password again. It's for when you leave your phone on the table and someone picks it up.</value>
+  </data>
+  <data name="Help_VaultProtections_VisualCaption" xml:space="preserve">
+    <value>Tap one of the times to choose. Whichever is highlighted is the one in effect.</value>
+  </data>
+  <data name="Help_VaultBackups_Title" xml:space="preserve">
+    <value>Automatic backups</value>
+  </data>
+  <data name="Help_VaultBackups_Text1" xml:space="preserve">
+    <value>Every time you save something, the app keeps a copy of how the vault was before. So if you delete an item by mistake, you can go back.</value>
+  </data>
+  <data name="Help_VaultBackups_Text2" xml:space="preserve">
+    <value>Here you decide how many of these copies are kept. "By count" keeps a fixed number of versions. "By time" keeps the ones from however many recent days you choose. The most recent copy is never deleted, no matter what.</value>
+  </data>
+  <data name="Help_VaultBackups_VisualCaption" xml:space="preserve">
+    <value>Tap "By count" or "By time" to choose the rule. The available values show up right below.</value>
+  </data>
+  <data name="Help_ChangeMasterUnlockCode_Title" xml:space="preserve">
+    <value>Change the master password</value>
+  </data>
+  <data name="Help_ChangeMasterUnlockCode_Text1" xml:space="preserve">
+    <value>To change it, the app asks for the current password first - that's how it confirms it's really you. After the change, it's the new password that opens this vault.</value>
+  </data>
+  <data name="Help_ChangeMasterUnlockCode_Text2" xml:space="preserve">
+    <value>Watch out for backups: copies saved before the change stay tied to the old password. If you ever need to restore one of them, it's the old password that works, not the new one. So it's worth writing the old one down somewhere safe, or checking the box that deletes those copies right away.</value>
+  </data>
+  <data name="Help_ChangeMasterUnlockCode_Text3" xml:space="preserve">
+    <value>If you use your fingerprint to open the vault, you don't need to do anything: the app reconfigures biometrics on its own with the new password.</value>
+  </data>
+  <data name="Help_ChangeMasterUnlockCode_VisualCaption" xml:space="preserve">
+    <value>Check this box if you don't want to keep copies that only open with the old password.</value>
+  </data>
+  <data name="Help_SecretUrl_Title" xml:space="preserve">
+    <value>The site's address</value>
+  </data>
+  <data name="Help_SecretUrl_Text1" xml:space="preserve">
+    <value>It's optional, but it helps a lot: once you fill it in, the address becomes a shortcut on the item's card. One tap and the site opens in the browser, no typing needed.</value>
+  </data>
+  <data name="Help_SecretUrl_Text2" xml:space="preserve">
+    <value>You can write it plainly, like "netflix.com" - no need to add "https://" in front.</value>
+  </data>
+  <data name="Help_SecretUrl_VisualCaption" xml:space="preserve">
+    <value>It sits right below the item's name, in pink. Tapping it opens the site.</value>
+  </data>
+  <data name="Help_SecretStoredValue_Title" xml:space="preserve">
+    <value>The stored password</value>
+  </data>
+  <data name="Help_SecretStoredValue_Text1" xml:space="preserve">
+    <value>It's the password for that site or app - the one you'd use to log in. It stays hidden behind dots and only shows up when you ask.</value>
+  </data>
+  <data name="Help_SecretStoredValue_Text2" xml:space="preserve">
+    <value>When you need it, you have two options: the eye icon shows the password on screen, and "Copy" sends it straight to your phone's clipboard, without showing it to anyone. If the clipboard protection is on, the app clears the copied value on its own after a few seconds.</value>
+  </data>
+  <data name="Help_SecretStoredValue_VisualCaption" xml:space="preserve">
+    <value>These are the two buttons, on the password's card: the eye shows it, "Copy" copies it.</value>
+  </data>
+  <data name="Help_SecretFavorite_Title" xml:space="preserve">
+    <value>Mark as favorite</value>
+  </data>
+  <data name="Help_SecretFavorite_Text1" xml:space="preserve">
+    <value>Favorites move to the top of the list and get a golden star. It's for the items you open all the time, so they don't get lost among the others.</value>
+  </data>
+  <data name="Help_SecretFavorite_Text2" xml:space="preserve">
+    <value>It doesn't change anything about the item's security or content - it's just a way to find it faster.</value>
+  </data>
+  <data name="Help_SecretFavorite_VisualCaption" xml:space="preserve">
+    <value>This is the little star, which shows up on the item's card in the list.</value>
+  </data>
+  <data name="Help_BackupRecovery_Title" xml:space="preserve">
+    <value>Recover a backup</value>
+  </data>
+  <data name="Help_BackupRecovery_Heading1" xml:space="preserve">
+    <value>How these copies show up here</value>
+  </data>
+  <data name="Help_BackupRecovery_Text1" xml:space="preserve">
+    <value>Every time you save something to the vault, the app keeps a copy of how it was before. These copies live in a private folder of the app, never alongside your file, so they don't clutter your folder. How many are kept is what you chose in Edit vault, under Backups.</value>
+  </data>
+  <data name="Help_BackupRecovery_VisualCaption1" xml:space="preserve">
+    <value>Each copy becomes a card like this one, with the date and time it was saved.</value>
+  </data>
+  <data name="Help_BackupRecovery_Heading2" xml:space="preserve">
+    <value>Restore</value>
+  </data>
+  <data name="Help_BackupRecovery_Text2" xml:space="preserve">
+    <value>Restoring doesn't touch your current vault: the app creates a new file with that copy's contents, and you choose afterward which of the two to open. The app will ask for that copy's master password at the time - if it's from before you changed the password, the old password is the one that works.</value>
+  </data>
+  <data name="Help_BackupRecovery_VisualCaption2" xml:space="preserve">
+    <value>This is the button, at the bottom of each card.</value>
+  </data>
+  <data name="Help_BackupRecovery_Heading3" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="Help_BackupRecovery_Text3" xml:space="preserve">
+    <value>Deletes just that one copy from the list. It can't be undone, and your current vault stays intact.</value>
+  </data>
+  <data name="Help_BackupRecovery_VisualCaption3" xml:space="preserve">
+    <value>It sits next to "Restore", in red.</value>
+  </data>
+  <data name="Help_BackupRecovery_Heading4" xml:space="preserve">
+    <value>Delete all</value>
+  </data>
+  <data name="Help_BackupRecovery_Text4" xml:space="preserve">
+    <value>Deletes all the copies on this screen at once. It also can't be undone. Your current vault isn't affected - only the old copies disappear.</value>
+  </data>
+  <data name="Help_BackupRecovery_VisualCaption4" xml:space="preserve">
+    <value>This is the red link, at the end of the list.</value>
+  </data>
+  <data name="Onboarding_Slide1Title" xml:space="preserve">
+    <value>Your vault is a file</value>
+  </data>
+  <data name="Onboarding_Slide1Body" xml:space="preserve">
+    <value>GDSB doesn't store anything in the cloud or inside your phone: everything lives in a .GDSBX file that's yours. The app is just the layer that opens and reads that file - without it available, there's nothing to open. Keep it somewhere you can reach again, like a Google Drive or OneDrive folder.</value>
+  </data>
+  <data name="Onboarding_Slide2Title" xml:space="preserve">
+    <value>Create a vault</value>
+  </data>
+  <data name="Onboarding_Slide2Body" xml:space="preserve">
+    <value>You choose where to save the file and set the master password. That password is the only key: it isn't stored anywhere, and there's no "forgot my password". Lose the password, lose the file's contents.</value>
+  </data>
+  <data name="Onboarding_Slide3Title" xml:space="preserve">
+    <value>Open it later</value>
+  </data>
+  <data name="Onboarding_Slide3Body" xml:space="preserve">
+    <value>Always the same: choose the file, type the password. Turn on biometrics and the app remembers your last vault, with your fingerprint as the shortcut - but the master password keeps working, and the file still needs to be accessible.</value>
+  </data>
+  <data name="Onboarding_AdvanceButtonNext" xml:space="preserve">
+    <value>Next</value>
+  </data>
+  <data name="Onboarding_AdvanceButtonFinish" xml:space="preserve">
+    <value>Start</value>
+  </data>
 </root>

--- a/src/GDSB.MAUI.ViewModels/Resources/AppStrings.en.resx
+++ b/src/GDSB.MAUI.ViewModels/Resources/AppStrings.en.resx
@@ -397,4 +397,148 @@
   <data name="HelpVisual_SampleBackupKind" xml:space="preserve">
     <value>Automatic</value>
   </data>
+  <data name="Unlock_GenericErrorMessage" xml:space="preserve">
+    <value>Incorrect password or corrupted file.</value>
+  </data>
+  <data name="Unlock_EmptyPasswordMessage" xml:space="preserve">
+    <value>Enter the vault's master password.</value>
+  </data>
+  <data name="Unlock_FilePickerErrorMessage" xml:space="preserve">
+    <value>Couldn't open the file picker.</value>
+  </data>
+  <data name="Unlock_BackupFileAlertTitle" xml:space="preserve">
+    <value>This is a backup</value>
+  </data>
+  <data name="Unlock_BackupFileAlertMessage" xml:space="preserve">
+    <value>This file looks like a backup created automatically by GDSB. You can still open it normally with the vault's master password.</value>
+  </data>
+  <data name="Unlock_ButtonIdleText" xml:space="preserve">
+    <value>Open vault</value>
+  </data>
+  <data name="Unlock_ButtonBusyText" xml:space="preserve">
+    <value>Opening...</value>
+  </data>
+  <data name="Common_Ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="Vault_GenericSaveErrorMessage" xml:space="preserve">
+    <value>Couldn't save the vault. Try again.</value>
+  </data>
+  <data name="Vault_PasswordsDoNotMatchMessage" xml:space="preserve">
+    <value>Passwords don't match.</value>
+  </data>
+  <data name="Vault_NameRequiredMessage" xml:space="preserve">
+    <value>Give the vault a name.</value>
+  </data>
+  <data name="Vault_ChoosePathErrorMessage" xml:space="preserve">
+    <value>Couldn't choose where to save the vault.</value>
+  </data>
+  <data name="Vault_SaveToLocationErrorMessage" xml:space="preserve">
+    <value>Couldn't save the vault to that location.</value>
+  </data>
+  <data name="Vault_ConfirmDeleteMessage" xml:space="preserve">
+    <value>Delete "{0}" from the vault? This action can't be undone.</value>
+  </data>
+  <data name="Vault_NewItemTitle" xml:space="preserve">
+    <value>New item</value>
+  </data>
+  <data name="Vault_UserCopiedToast" xml:space="preserve">
+    <value>Username copied</value>
+  </data>
+  <data name="Vault_PasswordCopiedToast" xml:space="preserve">
+    <value>Password copied</value>
+  </data>
+  <data name="Vault_NameValidationMessage" xml:space="preserve">
+    <value>Enter a name for the item.</value>
+  </data>
+  <data name="Vault_PasswordValidationMessage" xml:space="preserve">
+    <value>Enter the item's password.</value>
+  </data>
+  <data name="Vault_OpenUrlErrorMessage" xml:space="preserve">
+    <value>Error trying to open {0}: {1}</value>
+  </data>
+  <data name="VaultSettings_WrongCurrentPasswordMessage" xml:space="preserve">
+    <value>Current password is incorrect.</value>
+  </data>
+  <data name="VaultSettings_BiometricResealFailedMessage" xml:space="preserve">
+    <value>The password was changed, but the biometric shortcut couldn't be re-sealed. The master password keeps working normally.</value>
+  </data>
+  <data name="VaultSettings_MinNewPasswordLengthMessage" xml:space="preserve">
+    <value>The new password needs at least {0} characters.</value>
+  </data>
+  <data name="CreateVault_MinPasswordLengthMessage" xml:space="preserve">
+    <value>The master password needs at least {0} characters.</value>
+  </data>
+  <data name="CreateVault_SaveErrorMessage" xml:space="preserve">
+    <value>Couldn't create the vault in that location.</value>
+  </data>
+  <data name="CreateVault_ButtonBusyText" xml:space="preserve">
+    <value>Creating...</value>
+  </data>
+  <data name="CreateVault_ButtonIdleText" xml:space="preserve">
+    <value>Create vault</value>
+  </data>
+  <data name="CreateVault_DefaultVaultName" xml:space="preserve">
+    <value>My Vault</value>
+  </data>
+  <data name="BackupRecovery_EmptyPasswordMessage" xml:space="preserve">
+    <value>Enter this backup's master password.</value>
+  </data>
+  <data name="BiometricOptIn_UnavailableMessage" xml:space="preserve">
+    <value>Couldn't use biometrics. Enter the master password.</value>
+  </data>
+  <data name="Backups_LegacyKindLabel" xml:space="preserve">
+    <value>Migrated from the old format</value>
+  </data>
+  <data name="Format_DateTimeShort" xml:space="preserve">
+    <value>M/d/yyyy h:mm tt</value>
+  </data>
+  <data name="Format_SizeBytes" xml:space="preserve">
+    <value>B</value>
+  </data>
+  <data name="Format_SizeKilobytes" xml:space="preserve">
+    <value>KB</value>
+  </data>
+  <data name="Format_SizeMegabytes" xml:space="preserve">
+    <value>MB</value>
+  </data>
+  <data name="Seal_SecretCreated" xml:space="preserve">
+    <value>Secret saved</value>
+  </data>
+  <data name="Seal_SettingsSaved" xml:space="preserve">
+    <value>Changes saved</value>
+  </data>
+  <data name="Seal_SecretDeleted" xml:space="preserve">
+    <value>Secret deleted</value>
+  </data>
+  <data name="Seal_BackupDeleted" xml:space="preserve">
+    <value>Backup deleted</value>
+  </data>
+  <data name="Seal_AllBackupsDeleted" xml:space="preserve">
+    <value>Backups deleted</value>
+  </data>
+  <data name="A11y_HelpButtonDescription" xml:space="preserve">
+    <value>Help</value>
+  </data>
+  <data name="A11y_HelpAbout" xml:space="preserve">
+    <value>Help about {0}</value>
+  </data>
+  <data name="Platform_BiometricActivateSubtitle" xml:space="preserve">
+    <value>Confirm your biometrics to turn on quick unlock</value>
+  </data>
+  <data name="Platform_BiometricUnlockSubtitle" xml:space="preserve">
+    <value>Use your biometrics to open the vault</value>
+  </data>
+  <data name="Platform_BiometricNegativeButton" xml:space="preserve">
+    <value>Use password</value>
+  </data>
+  <data name="Platform_WindowsBiometricActivateMessage" xml:space="preserve">
+    <value>Confirm your identity to turn on quick unlock for GDSB.</value>
+  </data>
+  <data name="Platform_WindowsBiometricUnlockMessage" xml:space="preserve">
+    <value>Use Windows Hello to open the vault.</value>
+  </data>
+  <data name="Platform_WindowsFileTypeLabel" xml:space="preserve">
+    <value>GDSB File</value>
+  </data>
 </root>

--- a/src/GDSB.MAUI.ViewModels/Resources/AppStrings.resx
+++ b/src/GDSB.MAUI.ViewModels/Resources/AppStrings.resx
@@ -600,4 +600,172 @@
   <data name="Platform_WindowsFileTypeLabel" xml:space="preserve">
     <value>Arquivo GDSB</value>
   </data>
+  <data name="Help_MasterUnlockCode_Title" xml:space="preserve">
+    <value>A senha mestra</value>
+  </data>
+  <data name="Help_MasterUnlockCode_Text1" xml:space="preserve">
+    <value>É a senha que abre este cofre. Ela não fica guardada em lugar nenhum: nem no app, nem no seu celular, nem na internet. Por isso não existe "esqueci minha senha" aqui - se você perder essa senha, ninguém consegue abrir o arquivo de novo, nem você, nem quem fez o app.</value>
+  </data>
+  <data name="Help_MasterUnlockCode_Text2" xml:space="preserve">
+    <value>Escolha algo que você lembre com folga e que ninguém adivinhe. O mínimo são 8 caracteres, mas quanto mais longa, melhor.</value>
+  </data>
+  <data name="Help_MasterUnlockCode_VisualCaption" xml:space="preserve">
+    <value>É este campo. Toque nele e digite - as letras aparecem como pontinhos para ninguém ler por cima do seu ombro.</value>
+  </data>
+  <data name="Help_VaultName_Title" xml:space="preserve">
+    <value>O nome do cofre</value>
+  </data>
+  <data name="Help_VaultName_Text1" xml:space="preserve">
+    <value>É o apelido que aparece dentro do app para você reconhecer este cofre. Trocar o nome aqui não renomeia o arquivo que está salvo no seu celular ou na nuvem: o arquivo continua com o nome de antes.</value>
+  </data>
+  <data name="Help_VaultName_Text2" xml:space="preserve">
+    <value>Por isso, depois de salvar um nome novo, o app oferece guardar também uma cópia num arquivo novo. É opcional - se você recusar, está tudo certo, a mudança já foi gravada no arquivo de sempre.</value>
+  </data>
+  <data name="Help_VaultName_VisualCaption" xml:space="preserve">
+    <value>É este convite que aparece depois de salvar. Tocar em "Salvar como novo arquivo" cria uma cópia e mantém o original intacto.</value>
+  </data>
+  <data name="Help_VaultProtections_Title" xml:space="preserve">
+    <value>Proteções do cofre</value>
+  </data>
+  <data name="Help_VaultProtections_Heading1" xml:space="preserve">
+    <value>Limpar a área de transferência</value>
+  </data>
+  <data name="Help_VaultProtections_Text1" xml:space="preserve">
+    <value>Quando você copia uma senha, ela fica na memória de "copiar e colar" do celular e qualquer outro aplicativo pode ler de lá. Com esta proteção ligada, o app apaga esse valor sozinho depois do tempo que você escolher.</value>
+  </data>
+  <data name="Help_VaultProtections_Heading2" xml:space="preserve">
+    <value>Bloqueio automático</value>
+  </data>
+  <data name="Help_VaultProtections_Text2" xml:space="preserve">
+    <value>Se você sair do app e demorar para voltar, ele fecha o cofre e pede a senha mestra de novo. Serve para o caso de você deixar o celular na mesa e alguém pegar.</value>
+  </data>
+  <data name="Help_VaultProtections_VisualCaption" xml:space="preserve">
+    <value>Toque em um dos tempos para escolher. O que estiver colorido é o que está valendo.</value>
+  </data>
+  <data name="Help_VaultBackups_Title" xml:space="preserve">
+    <value>Backups automáticos</value>
+  </data>
+  <data name="Help_VaultBackups_Text1" xml:space="preserve">
+    <value>Toda vez que você salva alguma coisa, o app guarda antes uma cópia de como o cofre estava. Assim, se você apagar um item sem querer, dá para voltar atrás.</value>
+  </data>
+  <data name="Help_VaultBackups_Text2" xml:space="preserve">
+    <value>Aqui você decide quantas dessas cópias ficam guardadas. "Por quantidade" guarda um número fixo de versões. "Por tempo" guarda as dos últimos dias que você escolher. A cópia mais recente nunca é apagada, aconteça o que acontecer.</value>
+  </data>
+  <data name="Help_VaultBackups_VisualCaption" xml:space="preserve">
+    <value>Toque em "Por quantidade" ou "Por tempo" para escolher a regra. Logo abaixo aparecem os valores disponíveis.</value>
+  </data>
+  <data name="Help_ChangeMasterUnlockCode_Title" xml:space="preserve">
+    <value>Trocar a senha mestra</value>
+  </data>
+  <data name="Help_ChangeMasterUnlockCode_Text1" xml:space="preserve">
+    <value>Para trocar, o app pede a senha atual primeiro - é assim que ele confere que é você mesmo. Depois da troca, é a senha nova que abre este cofre.</value>
+  </data>
+  <data name="Help_ChangeMasterUnlockCode_Text2" xml:space="preserve">
+    <value>Atenção com os backups: as cópias guardadas antes da troca continuam presas à senha antiga. Se um dia você precisar restaurar uma delas, é a senha antiga que vai funcionar, não a nova. Por isso vale anotar a antiga em algum lugar seguro, ou marcar a caixa que apaga essas cópias de uma vez.</value>
+  </data>
+  <data name="Help_ChangeMasterUnlockCode_Text3" xml:space="preserve">
+    <value>Se você usa a digital para abrir o cofre, não precisa fazer nada: o app reconfigura a biometria sozinho com a senha nova.</value>
+  </data>
+  <data name="Help_ChangeMasterUnlockCode_VisualCaption" xml:space="preserve">
+    <value>Marque esta caixa se você não quer guardar cópias que só abrem com a senha antiga.</value>
+  </data>
+  <data name="Help_SecretUrl_Title" xml:space="preserve">
+    <value>O endereço do site</value>
+  </data>
+  <data name="Help_SecretUrl_Text1" xml:space="preserve">
+    <value>É opcional, mas ajuda bastante: quando você preenche, o endereço vira um atalho no cartão do item. Um toque e o site abre no navegador, sem você precisar digitar.</value>
+  </data>
+  <data name="Help_SecretUrl_Text2" xml:space="preserve">
+    <value>Pode escrever do jeito simples, como "netflix.com" - não precisa colocar o "https://" na frente.</value>
+  </data>
+  <data name="Help_SecretUrl_VisualCaption" xml:space="preserve">
+    <value>Fica logo abaixo do nome do item, em rosa. Tocar nele abre o site.</value>
+  </data>
+  <data name="Help_SecretStoredValue_Title" xml:space="preserve">
+    <value>A senha guardada</value>
+  </data>
+  <data name="Help_SecretStoredValue_Text1" xml:space="preserve">
+    <value>É a senha daquele site ou aplicativo - a que você usaria para entrar. Ela fica escondida atrás de pontinhos e só aparece quando você pede.</value>
+  </data>
+  <data name="Help_SecretStoredValue_Text2" xml:space="preserve">
+    <value>Na hora de usar, você tem duas opções: o olhinho mostra a senha na tela, e "Copiar" manda ela direto para o "colar" do celular, sem precisar mostrar para ninguém. Se a proteção de área de transferência estiver ligada, o app apaga o valor copiado sozinho depois de alguns segundos.</value>
+  </data>
+  <data name="Help_SecretStoredValue_VisualCaption" xml:space="preserve">
+    <value>São estes dois botões, no cartão da senha: o olhinho mostra, o "Copiar" copia.</value>
+  </data>
+  <data name="Help_SecretFavorite_Title" xml:space="preserve">
+    <value>Marcar como favorito</value>
+  </data>
+  <data name="Help_SecretFavorite_Text1" xml:space="preserve">
+    <value>Favoritos sobem para o topo da lista e ganham uma estrelinha dourada. Serve para os itens que você abre toda hora não se perderem no meio dos outros.</value>
+  </data>
+  <data name="Help_SecretFavorite_Text2" xml:space="preserve">
+    <value>Não muda nada na segurança nem no conteúdo do item - é só uma forma de encontrar mais rápido.</value>
+  </data>
+  <data name="Help_SecretFavorite_VisualCaption" xml:space="preserve">
+    <value>É esta estrelinha, que passa a aparecer no cartão do item na lista.</value>
+  </data>
+  <data name="Help_BackupRecovery_Title" xml:space="preserve">
+    <value>Recuperar um backup</value>
+  </data>
+  <data name="Help_BackupRecovery_Heading1" xml:space="preserve">
+    <value>Como estas cópias aparecem aqui</value>
+  </data>
+  <data name="Help_BackupRecovery_Text1" xml:space="preserve">
+    <value>Toda vez que você salva algo no cofre, o app guarda antes uma cópia de como ele estava. Essas cópias ficam numa pasta privada do aplicativo, nunca junto do seu arquivo, para não bagunçar a sua pasta. Quantas ficam guardadas é o que você escolheu em Editar cofre, na parte de Backups.</value>
+  </data>
+  <data name="Help_BackupRecovery_VisualCaption1" xml:space="preserve">
+    <value>Cada cópia vira um cartão como este, com a data e a hora em que foi guardada.</value>
+  </data>
+  <data name="Help_BackupRecovery_Heading2" xml:space="preserve">
+    <value>Restaurar</value>
+  </data>
+  <data name="Help_BackupRecovery_Text2" xml:space="preserve">
+    <value>Restaurar não mexe no seu cofre atual: o app cria um arquivo novo com o conteúdo daquela cópia, e você escolhe depois qual dos dois quer abrir. O app vai pedir a senha mestra da época daquela cópia - se ela for de antes de você trocar a senha, é a senha antiga que funciona.</value>
+  </data>
+  <data name="Help_BackupRecovery_VisualCaption2" xml:space="preserve">
+    <value>É este botão, no rodapé de cada cartão.</value>
+  </data>
+  <data name="Help_BackupRecovery_Heading3" xml:space="preserve">
+    <value>Excluir</value>
+  </data>
+  <data name="Help_BackupRecovery_Text3" xml:space="preserve">
+    <value>Apaga só aquela cópia da lista. Não dá para desfazer, e o seu cofre atual continua intacto.</value>
+  </data>
+  <data name="Help_BackupRecovery_VisualCaption3" xml:space="preserve">
+    <value>Fica ao lado de "Restaurar", em vermelho.</value>
+  </data>
+  <data name="Help_BackupRecovery_Heading4" xml:space="preserve">
+    <value>Excluir todos</value>
+  </data>
+  <data name="Help_BackupRecovery_Text4" xml:space="preserve">
+    <value>Apaga de uma vez todas as cópias que estão nesta tela. Também não dá para desfazer. Seu cofre atual não é afetado - só as cópias antigas somem.</value>
+  </data>
+  <data name="Help_BackupRecovery_VisualCaption4" xml:space="preserve">
+    <value>É este link vermelho, no fim da lista.</value>
+  </data>
+  <data name="Onboarding_Slide1Title" xml:space="preserve">
+    <value>Seu cofre é um arquivo</value>
+  </data>
+  <data name="Onboarding_Slide1Body" xml:space="preserve">
+    <value>O GDSB não guarda nada na nuvem nem dentro do celular: tudo mora num arquivo .GDSBX que é seu. O app é só a camada que abre e lê esse arquivo - sem ele disponível, não há o que abrir. Guarde-o onde você consiga alcançar de novo: uma pasta do Google Drive ou do OneDrive, por exemplo.</value>
+  </data>
+  <data name="Onboarding_Slide2Title" xml:space="preserve">
+    <value>Criar um cofre</value>
+  </data>
+  <data name="Onboarding_Slide2Body" xml:space="preserve">
+    <value>Você escolhe onde salvar o arquivo e define a senha mestra. Essa senha é a única chave: ela não fica guardada em lugar nenhum e não existe "esqueci minha senha". Perdeu a senha, perdeu o conteúdo do arquivo.</value>
+  </data>
+  <data name="Onboarding_Slide3Title" xml:space="preserve">
+    <value>Abrir depois</value>
+  </data>
+  <data name="Onboarding_Slide3Body" xml:space="preserve">
+    <value>Sempre igual: escolher o arquivo, digitar a senha. Ligando a biometria, o app lembra do último cofre e a digital vira o atalho - mas a senha mestra continua valendo, e o arquivo ainda precisa estar acessível.</value>
+  </data>
+  <data name="Onboarding_AdvanceButtonNext" xml:space="preserve">
+    <value>Próximo</value>
+  </data>
+  <data name="Onboarding_AdvanceButtonFinish" xml:space="preserve">
+    <value>Começar</value>
+  </data>
 </root>

--- a/src/GDSB.MAUI.ViewModels/Resources/AppStrings.resx
+++ b/src/GDSB.MAUI.ViewModels/Resources/AppStrings.resx
@@ -456,4 +456,148 @@
   <data name="HelpVisual_SampleBackupKind" xml:space="preserve">
     <value>Automático</value>
   </data>
+  <data name="Unlock_GenericErrorMessage" xml:space="preserve">
+    <value>Senha incorreta ou arquivo corrompido.</value>
+  </data>
+  <data name="Unlock_EmptyPasswordMessage" xml:space="preserve">
+    <value>Digite a senha mestra do cofre.</value>
+  </data>
+  <data name="Unlock_FilePickerErrorMessage" xml:space="preserve">
+    <value>Não foi possível abrir o seletor de arquivos.</value>
+  </data>
+  <data name="Unlock_BackupFileAlertTitle" xml:space="preserve">
+    <value>Isto é um backup</value>
+  </data>
+  <data name="Unlock_BackupFileAlertMessage" xml:space="preserve">
+    <value>Este arquivo parece ser um backup gerado automaticamente pelo GDSB. Você ainda pode abri-lo normalmente com a senha mestra do cofre.</value>
+  </data>
+  <data name="Unlock_ButtonIdleText" xml:space="preserve">
+    <value>Abrir cofre</value>
+  </data>
+  <data name="Unlock_ButtonBusyText" xml:space="preserve">
+    <value>Abrindo...</value>
+  </data>
+  <data name="Common_Ok" xml:space="preserve">
+    <value>Ok</value>
+  </data>
+  <data name="Vault_GenericSaveErrorMessage" xml:space="preserve">
+    <value>Não foi possível salvar o cofre. Tente novamente.</value>
+  </data>
+  <data name="Vault_PasswordsDoNotMatchMessage" xml:space="preserve">
+    <value>As senhas não coincidem.</value>
+  </data>
+  <data name="Vault_NameRequiredMessage" xml:space="preserve">
+    <value>Dê um nome ao cofre.</value>
+  </data>
+  <data name="Vault_ChoosePathErrorMessage" xml:space="preserve">
+    <value>Não foi possível escolher onde salvar o cofre.</value>
+  </data>
+  <data name="Vault_SaveToLocationErrorMessage" xml:space="preserve">
+    <value>Não foi possível salvar o cofre nesse local.</value>
+  </data>
+  <data name="Vault_ConfirmDeleteMessage" xml:space="preserve">
+    <value>Excluir "{0}" do cofre? Essa ação não pode ser desfeita.</value>
+  </data>
+  <data name="Vault_NewItemTitle" xml:space="preserve">
+    <value>Novo item</value>
+  </data>
+  <data name="Vault_UserCopiedToast" xml:space="preserve">
+    <value>Usuário copiado</value>
+  </data>
+  <data name="Vault_PasswordCopiedToast" xml:space="preserve">
+    <value>Senha copiada</value>
+  </data>
+  <data name="Vault_NameValidationMessage" xml:space="preserve">
+    <value>Informe um nome para o item.</value>
+  </data>
+  <data name="Vault_PasswordValidationMessage" xml:space="preserve">
+    <value>Informe a senha do item.</value>
+  </data>
+  <data name="Vault_OpenUrlErrorMessage" xml:space="preserve">
+    <value>Erro ao tentar abrir {0}: {1}</value>
+  </data>
+  <data name="VaultSettings_WrongCurrentPasswordMessage" xml:space="preserve">
+    <value>Senha atual incorreta.</value>
+  </data>
+  <data name="VaultSettings_BiometricResealFailedMessage" xml:space="preserve">
+    <value>A senha foi trocada, mas não foi possível re-selar a biometria. A senha mestra continua valendo normalmente.</value>
+  </data>
+  <data name="VaultSettings_MinNewPasswordLengthMessage" xml:space="preserve">
+    <value>A senha nova precisa ter pelo menos {0} caracteres.</value>
+  </data>
+  <data name="CreateVault_MinPasswordLengthMessage" xml:space="preserve">
+    <value>A senha mestra precisa ter pelo menos {0} caracteres.</value>
+  </data>
+  <data name="CreateVault_SaveErrorMessage" xml:space="preserve">
+    <value>Não foi possível criar o cofre nesse local.</value>
+  </data>
+  <data name="CreateVault_ButtonBusyText" xml:space="preserve">
+    <value>Criando...</value>
+  </data>
+  <data name="CreateVault_ButtonIdleText" xml:space="preserve">
+    <value>Criar cofre</value>
+  </data>
+  <data name="CreateVault_DefaultVaultName" xml:space="preserve">
+    <value>Meu Cofre</value>
+  </data>
+  <data name="BackupRecovery_EmptyPasswordMessage" xml:space="preserve">
+    <value>Digite a senha mestra deste backup.</value>
+  </data>
+  <data name="BiometricOptIn_UnavailableMessage" xml:space="preserve">
+    <value>Não foi possível usar a biometria. Digite a senha mestra.</value>
+  </data>
+  <data name="Backups_LegacyKindLabel" xml:space="preserve">
+    <value>Migrado do formato antigo</value>
+  </data>
+  <data name="Format_DateTimeShort" xml:space="preserve">
+    <value>dd/MM/yyyy HH:mm</value>
+  </data>
+  <data name="Format_SizeBytes" xml:space="preserve">
+    <value>B</value>
+  </data>
+  <data name="Format_SizeKilobytes" xml:space="preserve">
+    <value>KB</value>
+  </data>
+  <data name="Format_SizeMegabytes" xml:space="preserve">
+    <value>MB</value>
+  </data>
+  <data name="Seal_SecretCreated" xml:space="preserve">
+    <value>Segredo guardado</value>
+  </data>
+  <data name="Seal_SettingsSaved" xml:space="preserve">
+    <value>Alterações salvas</value>
+  </data>
+  <data name="Seal_SecretDeleted" xml:space="preserve">
+    <value>Segredo excluído</value>
+  </data>
+  <data name="Seal_BackupDeleted" xml:space="preserve">
+    <value>Backup excluído</value>
+  </data>
+  <data name="Seal_AllBackupsDeleted" xml:space="preserve">
+    <value>Backups excluídos</value>
+  </data>
+  <data name="A11y_HelpButtonDescription" xml:space="preserve">
+    <value>Ajuda</value>
+  </data>
+  <data name="A11y_HelpAbout" xml:space="preserve">
+    <value>Ajuda sobre {0}</value>
+  </data>
+  <data name="Platform_BiometricActivateSubtitle" xml:space="preserve">
+    <value>Confirme sua biometria para ativar o desbloqueio rápido</value>
+  </data>
+  <data name="Platform_BiometricUnlockSubtitle" xml:space="preserve">
+    <value>Use sua biometria para abrir o cofre</value>
+  </data>
+  <data name="Platform_BiometricNegativeButton" xml:space="preserve">
+    <value>Usar senha</value>
+  </data>
+  <data name="Platform_WindowsBiometricActivateMessage" xml:space="preserve">
+    <value>Confirme sua identidade para ativar o desbloqueio rápido do GDSB.</value>
+  </data>
+  <data name="Platform_WindowsBiometricUnlockMessage" xml:space="preserve">
+    <value>Use o Windows Hello para abrir o cofre.</value>
+  </data>
+  <data name="Platform_WindowsFileTypeLabel" xml:space="preserve">
+    <value>Arquivo GDSB</value>
+  </data>
 </root>

--- a/src/GDSB.MAUI.ViewModels/Resources/AppStrings.resx
+++ b/src/GDSB.MAUI.ViewModels/Resources/AppStrings.resx
@@ -159,4 +159,301 @@
   <data name="Unlock_LanguagePickerDescription" xml:space="preserve">
     <value>Idioma do app</value>
   </data>
+  <data name="Common_Back" xml:space="preserve">
+    <value>Voltar</value>
+  </data>
+  <data name="Common_Cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="Common_Copy" xml:space="preserve">
+    <value>Copiar</value>
+  </data>
+  <data name="Common_Delete" xml:space="preserve">
+    <value>Excluir</value>
+  </data>
+  <data name="Common_RequiredFieldsLegend" xml:space="preserve">
+    <value>* campos obrigatórios</value>
+  </data>
+  <data name="Vault_NameFieldLabel" xml:space="preserve">
+    <value>NOME DO COFRE</value>
+  </data>
+  <data name="Vault_MasterPasswordFieldLabel" xml:space="preserve">
+    <value>SENHA MESTRA</value>
+  </data>
+  <data name="Vault_MinPasswordPlaceholder" xml:space="preserve">
+    <value>Mínimo de 8 caracteres</value>
+  </data>
+  <data name="Vault_CopyUserButton" xml:space="preserve">
+    <value>Usuário</value>
+  </data>
+  <data name="Vault_CopyPasswordButton" xml:space="preserve">
+    <value>Senha</value>
+  </data>
+  <data name="Vault_SearchPlaceholder" xml:space="preserve">
+    <value>Buscar por nome...</value>
+  </data>
+  <data name="Vault_FilterAllChip" xml:space="preserve">
+    <value>Todos</value>
+  </data>
+  <data name="Vault_FilterFavoritesChip" xml:space="preserve">
+    <value>Favoritos</value>
+  </data>
+  <data name="Vault_EmptyEditorState" xml:space="preserve">
+    <value>Selecione um item na lista ao lado ou crie um novo</value>
+  </data>
+  <data name="SaveAsNewFile_Title" xml:space="preserve">
+    <value>Salvar também num arquivo novo?</value>
+  </data>
+  <data name="SaveAsNewFile_Body" xml:space="preserve">
+    <value>O arquivo atual já foi gravado com a mudança. Você também pode salvar uma cópia num arquivo novo, mantendo o original intacto. Ao salvar, a sessão é encerrada e você escolhe qual dos dois abrir na tela de desbloqueio.</value>
+  </data>
+  <data name="SaveAsNewFile_DeclineButton" xml:space="preserve">
+    <value>Não, obrigado</value>
+  </data>
+  <data name="SaveAsNewFile_AcceptButton" xml:space="preserve">
+    <value>Salvar como novo arquivo</value>
+  </data>
+  <data name="VaultSettings_Title" xml:space="preserve">
+    <value>Editar cofre</value>
+  </data>
+  <data name="VaultSettings_SaveNameButton" xml:space="preserve">
+    <value>Salvar nome</value>
+  </data>
+  <data name="VaultSettings_SaveProtectionsButton" xml:space="preserve">
+    <value>Salvar proteções</value>
+  </data>
+  <data name="VaultSettings_SaveBackupsButton" xml:space="preserve">
+    <value>Salvar backups</value>
+  </data>
+  <data name="VaultSettings_ChangePasswordTitle" xml:space="preserve">
+    <value>TROCAR SENHA MESTRA</value>
+  </data>
+  <data name="VaultSettings_CurrentPasswordLabel" xml:space="preserve">
+    <value>SENHA ATUAL</value>
+  </data>
+  <data name="VaultSettings_NewPasswordLabel" xml:space="preserve">
+    <value>SENHA NOVA</value>
+  </data>
+  <data name="VaultSettings_ConfirmNewPasswordLabel" xml:space="preserve">
+    <value>CONFIRMAR SENHA NOVA</value>
+  </data>
+  <data name="VaultSettings_DeleteOldBackupsLabel" xml:space="preserve">
+    <value>Excluir os backups antigos deste cofre (continuam cifrados com a senha antiga)</value>
+  </data>
+  <data name="VaultSettings_ChangePasswordButton" xml:space="preserve">
+    <value>Trocar senha</value>
+  </data>
+  <data name="Protections_SectionLabel" xml:space="preserve">
+    <value>PROTEÇÕES</value>
+  </data>
+  <data name="Protections_ClipboardClearLabel" xml:space="preserve">
+    <value>Limpar a área de transferência</value>
+  </data>
+  <data name="Protections_ClipboardChip20s" xml:space="preserve">
+    <value>20s</value>
+  </data>
+  <data name="Protections_ClipboardChip45s" xml:space="preserve">
+    <value>45s</value>
+  </data>
+  <data name="Protections_ClipboardChip90s" xml:space="preserve">
+    <value>90s</value>
+  </data>
+  <data name="Protections_AutoLockLabel" xml:space="preserve">
+    <value>Bloqueio automático</value>
+  </data>
+  <data name="Protections_AutoLockWarning" xml:space="preserve">
+    <value>Desligar deixa o cofre aberto indefinidamente em segundo plano.</value>
+  </data>
+  <data name="Protections_AutoLockChip1min" xml:space="preserve">
+    <value>1 min</value>
+  </data>
+  <data name="Protections_AutoLockChip2min" xml:space="preserve">
+    <value>2 min</value>
+  </data>
+  <data name="Protections_AutoLockChip5min" xml:space="preserve">
+    <value>5 min</value>
+  </data>
+  <data name="Protections_AutoLockChip15min" xml:space="preserve">
+    <value>15 min</value>
+  </data>
+  <data name="Backups_SectionLabel" xml:space="preserve">
+    <value>BACKUPS</value>
+  </data>
+  <data name="Backups_RetentionQuestion" xml:space="preserve">
+    <value>Manter quantas versões</value>
+  </data>
+  <data name="Backups_ModeByCountChip" xml:space="preserve">
+    <value>Por quantidade</value>
+  </data>
+  <data name="Backups_ModeByDaysChip" xml:space="preserve">
+    <value>Por tempo</value>
+  </data>
+  <data name="Backups_DaysChip3" xml:space="preserve">
+    <value>3 dias</value>
+  </data>
+  <data name="Backups_DaysChip5" xml:space="preserve">
+    <value>5 dias</value>
+  </data>
+  <data name="Backups_DaysChip15" xml:space="preserve">
+    <value>15 dias</value>
+  </data>
+  <data name="Backups_DaysChip30" xml:space="preserve">
+    <value>30 dias</value>
+  </data>
+  <data name="Backups_RetentionByCountNote" xml:space="preserve">
+    <value>Ao passar do limite de versões, a mais antiga é apagada. A versão mais recente nunca é apagada.</value>
+  </data>
+  <data name="Backups_RetentionByDaysNote" xml:space="preserve">
+    <value>Backups mais antigos que o limite escolhido são apagados. A versão mais recente nunca é apagada.</value>
+  </data>
+  <data name="CreateVault_Title" xml:space="preserve">
+    <value>Novo cofre</value>
+  </data>
+  <data name="CreateVault_Subtitle" xml:space="preserve">
+    <value>Escolha onde guardar e defina a senha mestra</value>
+  </data>
+  <data name="CreateVault_ConfirmPasswordFieldLabel" xml:space="preserve">
+    <value>CONFIRMAR SENHA</value>
+  </data>
+  <data name="CreateVault_ConfirmPasswordPlaceholder" xml:space="preserve">
+    <value>Digite a senha novamente</value>
+  </data>
+  <data name="CreateVault_ClipboardClearHelperText" xml:space="preserve">
+    <value>Ao copiar uma senha ou usuário, o app apaga o valor da área de transferência depois do tempo escolhido.</value>
+  </data>
+  <data name="CreateVault_AutoLockHelperText" xml:space="preserve">
+    <value>Volta pra tela de senha se o app ficar em segundo plano além do tempo escolhido.</value>
+  </data>
+  <data name="BackupRecovery_Title" xml:space="preserve">
+    <value>Recuperar backup</value>
+  </data>
+  <data name="BackupRecovery_HelperText" xml:space="preserve">
+    <value>Backups são gerados automaticamente antes de cada gravação. Restaurar sempre cria um arquivo novo - o cofre original nunca é sobrescrito.</value>
+  </data>
+  <data name="BackupRecovery_EmptyTitle" xml:space="preserve">
+    <value>Nenhum backup por aqui</value>
+  </data>
+  <data name="BackupRecovery_EmptyBody" xml:space="preserve">
+    <value>Backups aparecem automaticamente depois da primeira edição de um cofre.</value>
+  </data>
+  <data name="BackupRecovery_DeleteAllLink" xml:space="preserve">
+    <value>Excluir todos os backups</value>
+  </data>
+  <data name="BackupRecovery_RestoreButton" xml:space="preserve">
+    <value>Restaurar</value>
+  </data>
+  <data name="BackupRecovery_RestoreModalTitle" xml:space="preserve">
+    <value>Restaurar backup</value>
+  </data>
+  <data name="BackupRecovery_RestoreModalHint" xml:space="preserve">
+    <value>Digite a senha mestra deste backup. Se ele for anterior a uma troca de senha, use a senha antiga.</value>
+  </data>
+  <data name="BackupRecovery_RestorePasswordPlaceholder" xml:space="preserve">
+    <value>Senha mestra do backup</value>
+  </data>
+  <data name="BackupRecovery_DeleteModalTitle" xml:space="preserve">
+    <value>Excluir este backup?</value>
+  </data>
+  <data name="BackupRecovery_DeleteModalWarning" xml:space="preserve">
+    <value>Essa ação não pode ser desfeita.</value>
+  </data>
+  <data name="BackupRecovery_DeleteAllModalTitle" xml:space="preserve">
+    <value>Excluir todos os backups?</value>
+  </data>
+  <data name="BackupRecovery_DeleteAllModalWarning" xml:space="preserve">
+    <value>Todos os backups listados nesta tela serão apagados. Essa ação não pode ser desfeita.</value>
+  </data>
+  <data name="BackupRecovery_DeleteAllConfirmButton" xml:space="preserve">
+    <value>Excluir todos</value>
+  </data>
+  <data name="ItemEditor_UserLabel" xml:space="preserve">
+    <value>USUÁRIO</value>
+  </data>
+  <data name="ItemEditor_PasswordLabel" xml:space="preserve">
+    <value>SENHA</value>
+  </data>
+  <data name="ItemEditor_ObsLabel" xml:space="preserve">
+    <value>OBSERVAÇÕES</value>
+  </data>
+  <data name="ItemEditor_EditButton" xml:space="preserve">
+    <value>Editar</value>
+  </data>
+  <data name="ItemEditor_NameFieldLabel" xml:space="preserve">
+    <value>NOME</value>
+  </data>
+  <data name="ItemEditor_NamePlaceholder" xml:space="preserve">
+    <value>Ex.: Netflix</value>
+  </data>
+  <data name="ItemEditor_UrlFieldLabel" xml:space="preserve">
+    <value>URL</value>
+  </data>
+  <data name="ItemEditor_UrlPlaceholder" xml:space="preserve">
+    <value>site.com</value>
+  </data>
+  <data name="ItemEditor_FavoriteCheckboxLabel" xml:space="preserve">
+    <value>Marcar como favorito</value>
+  </data>
+  <data name="ItemEditor_SaveButton" xml:space="preserve">
+    <value>Salvar</value>
+  </data>
+  <data name="Onboarding_Slide1SampleFileName" xml:space="preserve">
+    <value>meu-cofre.GDSBX</value>
+  </data>
+  <data name="Onboarding_Slide1Caption" xml:space="preserve">
+    <value>Um arquivo seu, guardado onde você quiser</value>
+  </data>
+  <data name="Onboarding_Slide2Caption" xml:space="preserve">
+    <value>É este link, logo abaixo do cartão de senha</value>
+  </data>
+  <data name="Onboarding_Slide3Caption" xml:space="preserve">
+    <value>Aparece no lugar do campo de senha depois que você liga a digital</value>
+  </data>
+  <data name="Onboarding_SkipButton" xml:space="preserve">
+    <value>Pular</value>
+  </data>
+  <data name="BiometricOptIn_Title" xml:space="preserve">
+    <value>Desbloqueio por biometria</value>
+  </data>
+  <data name="BiometricOptIn_Body" xml:space="preserve">
+    <value>Da próxima vez, use sua digital ou rosto pra abrir este cofre sem digitar a senha. A senha mestra continua funcionando normalmente quando você quiser.</value>
+  </data>
+  <data name="BiometricOptIn_AcceptButton" xml:space="preserve">
+    <value>Ativar biometria</value>
+  </data>
+  <data name="BiometricOptIn_DeclineButton" xml:space="preserve">
+    <value>Agora não</value>
+  </data>
+  <data name="HelpSheet_DismissButton" xml:space="preserve">
+    <value>Entendi</value>
+  </data>
+  <data name="HelpVisual_SaveAsNewFileShortButton" xml:space="preserve">
+    <value>Salvar como novo</value>
+  </data>
+  <data name="HelpVisual_DeleteOldBackupsLabel" xml:space="preserve">
+    <value>Excluir os backups antigos deste cofre</value>
+  </data>
+  <data name="HelpVisual_SampleItemName" xml:space="preserve">
+    <value>Netflix</value>
+  </data>
+  <data name="HelpVisual_SampleItemUrl" xml:space="preserve">
+    <value>netflix.com</value>
+  </data>
+  <data name="HelpVisual_SampleItemInitial" xml:space="preserve">
+    <value>N</value>
+  </data>
+  <data name="HelpVisual_SampleVaultName" xml:space="preserve">
+    <value>Cofre pessoal</value>
+  </data>
+  <data name="HelpVisual_SampleBackupFileName" xml:space="preserve">
+    <value>BKP - Cofre pessoal.GDSBX - 2026-09-02 14-30-12.bak</value>
+  </data>
+  <data name="HelpVisual_SampleBackupDate" xml:space="preserve">
+    <value>02/09/2026 14:30</value>
+  </data>
+  <data name="HelpVisual_SampleBackupSize" xml:space="preserve">
+    <value>12 KB</value>
+  </data>
+  <data name="HelpVisual_SampleBackupKind" xml:space="preserve">
+    <value>Automático</value>
+  </data>
 </root>

--- a/src/GDSB.MAUI.ViewModels/ViewModels/BackupItemViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/BackupItemViewModel.cs
@@ -1,32 +1,45 @@
+using System.Globalization;
 using GDSB.Domain.Entities;
+using GDSB.MAUI.Services;
 
 namespace GDSB.MAUI.ViewModels
 {
     // Envolve um VaultBackupInfo com propriedades já prontas pra UI (data local, tamanho legível,
     // rótulo do tipo), em vez de espalhar conversores pelo XAML - mesmo padrão de
-    // SecretBoxItemViewModel.
+    // SecretBoxItemViewModel. Não é ObservableObject: BackupRecoveryViewModel reconstrói a coleção
+    // inteira no LanguageChanged (ver Refresh), mais barato que cada item assinar o evento.
     public class BackupItemViewModel
     {
+        private readonly ILocalizationService _localization;
+
         public VaultBackupInfo Info { get; }
 
-        public BackupItemViewModel(VaultBackupInfo info)
+        public BackupItemViewModel(VaultBackupInfo info, ILocalizationService localization)
         {
             Info = info;
+            _localization = localization;
         }
 
         public string VaultName => Info.VaultName;
 
         public string DisplayName => Info.DisplayName;
 
-        public string CreatedAtDisplay => Info.CreatedAtUtc.ToLocalTime().ToString("dd/MM/yyyy HH:mm");
+        // Formato e separador de data vêm do catálogo (Format_DateTimeShort); CultureInfo.CurrentCulture
+        // explícito para não depender de a formatação de data respeitar a cultura da thread por
+        // acaso.
+        public string CreatedAtDisplay => Info.CreatedAtUtc.ToLocalTime()
+            .ToString(_localization.Get("Format_DateTimeShort"), CultureInfo.CurrentCulture);
 
+        // O separador decimal (",5" vs ".5") segue a cultura vigente; as unidades (B/KB/MB) também
+        // vêm do catálogo, ainda que hoje o valor seja igual nos dois idiomas.
         public string SizeDisplay => Info.SizeBytes switch
         {
-            < 1024 => $"{Info.SizeBytes} B",
-            < 1024 * 1024 => $"{Info.SizeBytes / 1024.0:0.#} KB",
-            _ => $"{Info.SizeBytes / (1024.0 * 1024.0):0.#} MB",
+            < 1024 => $"{Info.SizeBytes.ToString(CultureInfo.CurrentCulture)} {_localization.Get("Format_SizeBytes")}",
+            < 1024 * 1024 => $"{(Info.SizeBytes / 1024.0).ToString("0.#", CultureInfo.CurrentCulture)} {_localization.Get("Format_SizeKilobytes")}",
+            _ => $"{(Info.SizeBytes / (1024.0 * 1024.0)).ToString("0.#", CultureInfo.CurrentCulture)} {_localization.Get("Format_SizeMegabytes")}",
         };
 
-        public string KindLabel => Info.Kind == VaultBackupKind.LegacyV1 ? "Migrado do formato antigo" : "Automático";
+        public string KindLabel => _localization.Get(
+            Info.Kind == VaultBackupKind.LegacyV1 ? "Backups_LegacyKindLabel" : "HelpVisual_SampleBackupKind");
     }
 }

--- a/src/GDSB.MAUI.ViewModels/ViewModels/BackupRecoveryViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/BackupRecoveryViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.Input;
 using GDSB.Domain.Entities;
 using GDSB.Domain.Interfaces;
 using GDSB.MAUI.Interfaces;
+using GDSB.MAUI.Localization;
 using GDSB.MAUI.Services;
 
 namespace GDSB.MAUI.ViewModels
@@ -11,15 +12,19 @@ namespace GDSB.MAUI.ViewModels
     // Tela de recuperação: lista os backups do IVaultBackupStore (sempre fora da pasta do cofre,
     // ver FileSystemVaultBackupStore), restaura um deles pra um arquivo novo escolhido pelo usuário
     // (nunca sobrescreve o cofre original) ou exclui backups, um por vez ou todos de uma vez.
-    public partial class BackupRecoveryViewModel : ObservableObject
+    public partial class BackupRecoveryViewModel : LocalizedObject
     {
-        // Nome de propósito sem "password": a regra S2068 do Sonar ("Hard-coded credentials") flaga
-        // qualquer identificador nesses moldes atribuído a um valor literal, mesmo sendo só uma
-        // mensagem de UI (mesmo caso já registrado em VaultSettingsViewModel).
-        private const string GenericRestoreErrorMessage = "Senha incorreta ou arquivo corrompido.";
-        private const string EmptyCodeMessage = "Digite a senha mestra deste backup.";
-        private const string FilePickerErrorMessage = "Não foi possível escolher onde salvar o cofre.";
-        private const string GenericSaveErrorMessage = "Não foi possível salvar o cofre nesse local.";
+        // Deixam de ser const porque passam a vir do catálogo (ILocalizationService), que resolve
+        // na cultura vigente a cada leitura. Nome de propósito sem "password": a regra S2068 do
+        // Sonar ("Hard-coded credentials") flaga qualquer identificador nesses moldes atribuído a
+        // um valor literal, mesmo sendo só uma mensagem de UI.
+        private string GenericRestoreErrorMessage => Localization.Get("Unlock_GenericErrorMessage");
+
+        private string EmptyCodeMessage => Localization.Get("BackupRecovery_EmptyPasswordMessage");
+
+        private string FilePickerErrorMessage => Localization.Get("Vault_ChoosePathErrorMessage");
+
+        private string GenericSaveErrorMessage => Localization.Get("Vault_SaveToLocationErrorMessage");
 
         private readonly IVaultBackupStore _backupStore;
         private readonly IProfileFileService _profileFileService;
@@ -32,13 +37,36 @@ namespace GDSB.MAUI.ViewModels
             IProfileFileService profileFileService,
             IFilePickerService filePickerService,
             INavigationService navigationService,
-            IVaultSessionService vaultSessionService)
+            IVaultSessionService vaultSessionService,
+            ILocalizationService localizationService)
+            : base(localizationService)
         {
             _backupStore = backupStore;
             _profileFileService = profileFileService;
             _filePickerService = filePickerService;
             _navigationService = navigationService;
             _vaultSessionService = vaultSessionService;
+
+            // LocalizedObject só reemite OnPropertyChanged("") na troca de idioma - suficiente para
+            // propriedades calculadas, mas não para os itens já materializados em Backups: cada
+            // BackupItemViewModel não é ObservableObject (ver comentário na classe), então a
+            // CollectionView não percebe que CreatedAtDisplay/SizeDisplay/KindLabel mudaram sem a
+            // coleção ser reconstruída. Assina LanguageChanged direto, além do que a base já faz.
+            Localization.LanguageChanged += OnLanguageChangedRefresh;
+        }
+
+        private void OnLanguageChangedRefresh(object? sender, EventArgs e)
+        {
+            if (Backups.Count > 0)
+                Refresh();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                Localization.LanguageChanged -= OnLanguageChangedRefresh;
+
+            base.Dispose(disposing);
         }
 
         /// <summary>
@@ -99,7 +127,7 @@ namespace GDSB.MAUI.ViewModels
         {
             Backups.Clear();
             foreach (var info in _backupStore.List().OrderByDescending(i => i.CreatedAtUtc))
-                Backups.Add(new BackupItemViewModel(info));
+                Backups.Add(new BackupItemViewModel(info, Localization));
 
             OnPropertyChanged(nameof(HasBackups));
         }

--- a/src/GDSB.MAUI.ViewModels/ViewModels/BiometricOptInCoordinator.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/BiometricOptInCoordinator.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using GDSB.Domain.Interfaces;
+using GDSB.MAUI.Localization;
 using GDSB.MAUI.Services;
 using System.Security.Cryptography;
 using System.Text;
@@ -12,13 +13,15 @@ namespace GDSB.MAUI.ViewModels
     // depois de criar um novo (CreateVaultViewModel) - por isso vive num lugar só em vez de
     // duplicado nos dois, incluindo as chaves de Preferences que amarram a biometria a um cofre
     // específico (ver RememberVault/ForgetVault).
-    public partial class BiometricOptInCoordinator : ObservableObject
+    public partial class BiometricOptInCoordinator : LocalizedObject
     {
         public const string PromptedPreferenceKey = "gdsb.biometricPrompted";
         public const string LastLocationPreferenceKey = "gdsb.lastVaultLocation";
         public const string LastVaultNamePreferenceKey = "gdsb.lastVaultName";
 
-        private const string UnavailableMessage = "Não foi possível usar a biometria. Digite a senha mestra.";
+        // Deixa de ser const porque passa a vir do catálogo (ILocalizationService), que resolve na
+        // cultura vigente a cada leitura.
+        private string UnavailableMessage => Localization.Get("BiometricOptIn_UnavailableMessage");
 
         private readonly IBiometricUnlockService _biometricUnlockService;
         private readonly IAlertService _alertService;
@@ -29,7 +32,9 @@ namespace GDSB.MAUI.ViewModels
         public BiometricOptInCoordinator(
             IBiometricUnlockService biometricUnlockService,
             IAlertService alertService,
-            IPreferencesService preferencesService)
+            IPreferencesService preferencesService,
+            ILocalizationService localizationService)
+            : base(localizationService)
         {
             _biometricUnlockService = biometricUnlockService;
             _alertService = alertService;
@@ -83,7 +88,7 @@ namespace GDSB.MAUI.ViewModels
             {
                 var stored = await _biometricUnlockService.StoreKeyAsync(secret);
                 if (!stored)
-                    await _alertService.DisplayAlertAsync(null, UnavailableMessage, "Ok");
+                    await _alertService.DisplayAlertAsync(null, UnavailableMessage, Localization.Get("Common_Ok"));
             }
             finally
             {

--- a/src/GDSB.MAUI.ViewModels/ViewModels/CreateVaultViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/CreateVaultViewModel.cs
@@ -26,7 +26,9 @@ namespace GDSB.MAUI.ViewModels
             INavigationService navigationService,
             IBiometricUnlockService biometricUnlockService,
             IVaultSessionService vaultSessionService,
+            ILocalizationService localizationService,
             BiometricOptInCoordinator biometricOptIn)
+            : base(localizationService)
         {
             _profileFileService = profileFileService;
             _filePickerService = filePickerService;
@@ -34,14 +36,18 @@ namespace GDSB.MAUI.ViewModels
             _biometricUnlockService = biometricUnlockService;
             _vaultSessionService = vaultSessionService;
             BiometricOptIn = biometricOptIn;
+            VaultName = Localization.Get("CreateVault_DefaultVaultName");
         }
 
         // Exposto pra CreateVaultPage.xaml hospedar a BiometricOptInView (BindingContext="{Binding
         // BiometricOptIn}") - ver GDSB.MAUI.ViewModels.BiometricOptInCoordinator.
         public BiometricOptInCoordinator BiometricOptIn { get; }
 
+        // Valor inicial vem do catálogo (semeado no construtor, ver CreateVault_DefaultVaultName) -
+        // não é um rótulo fixo, é só o nome padrão sugerido; se o usuário não trocar, é esse texto
+        // (traduzido) que é gravado no arquivo, como qualquer outro nome digitado.
         [ObservableProperty]
-        private string vaultName = "Meu Cofre";
+        private string vaultName = string.Empty;
 
         [ObservableProperty]
         private string password = string.Empty;
@@ -62,7 +68,7 @@ namespace GDSB.MAUI.ViewModels
 
         public bool CanInteract => !IsBusy;
 
-        public string CreateButtonText => IsBusy ? "Criando..." : "Criar cofre";
+        public string CreateButtonText => IsBusy ? Localization.Get("CreateVault_ButtonBusyText") : Localization.Get("CreateVault_ButtonIdleText");
 #pragma warning restore S2325
 
         [RelayCommand]
@@ -75,19 +81,19 @@ namespace GDSB.MAUI.ViewModels
 
             if (string.IsNullOrWhiteSpace(VaultName))
             {
-                ErrorMessage = "Dê um nome ao cofre.";
+                ErrorMessage = Localization.Get("Vault_NameRequiredMessage");
                 return;
             }
 
             if (Password.Length < MinPasswordLength)
             {
-                ErrorMessage = $"A senha mestra precisa ter pelo menos {MinPasswordLength} caracteres.";
+                ErrorMessage = Localization.Format("CreateVault_MinPasswordLengthMessage", MinPasswordLength);
                 return;
             }
 
             if (Password != ConfirmPassword)
             {
-                ErrorMessage = "As senhas não coincidem.";
+                ErrorMessage = Localization.Get("Vault_PasswordsDoNotMatchMessage");
                 return;
             }
 
@@ -98,7 +104,7 @@ namespace GDSB.MAUI.ViewModels
             }
             catch (Exception)
             {
-                ErrorMessage = "Não foi possível escolher onde salvar o cofre.";
+                ErrorMessage = Localization.Get("Vault_ChoosePathErrorMessage");
                 return;
             }
 
@@ -155,7 +161,7 @@ namespace GDSB.MAUI.ViewModels
             }
             catch (Exception)
             {
-                ErrorMessage = "Não foi possível criar o cofre nesse local.";
+                ErrorMessage = Localization.Get("CreateVault_SaveErrorMessage");
             }
             finally
             {

--- a/src/GDSB.MAUI.ViewModels/ViewModels/OnboardingViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/OnboardingViewModel.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using GDSB.MAUI.Localization;
 using GDSB.MAUI.Services;
 
 namespace GDSB.MAUI.ViewModels
@@ -14,37 +15,27 @@ namespace GDSB.MAUI.ViewModels
     /// meus dados ficam, como eu começo, e como eu volto depois. Nada de vocabulário técnico -
     /// "arquivo" e "senha", não "cofre criptografado" nem "derivação de chave".
     /// </summary>
-    public partial class OnboardingViewModel : ObservableObject
+    public partial class OnboardingViewModel : LocalizedObject
     {
         public const string SeenPreferenceKey = "gdsb.onboardingSeen";
 
         private readonly IPreferencesService _preferencesService;
 
-        public OnboardingViewModel(IPreferencesService preferencesService)
+        public OnboardingViewModel(IPreferencesService preferencesService, ILocalizationService localizationService)
+            : base(localizationService)
         {
             _preferencesService = preferencesService;
         }
 
-        public IReadOnlyList<OnboardingSlide> Slides { get; } =
+        // Calculada sobre o catálogo (em vez de um inicializador de campo) porque este ViewModel
+        // vive uma vez por app (ver UnlockOverlays) - reler a cada acesso é o que faz uma troca de
+        // idioma valer aqui também, sem recriar nada. Só três slides: diferente de HelpTopics.All,
+        // não vale a pena cachear por cultura.
+        public IReadOnlyList<OnboardingSlide> Slides =>
         [
-            new OnboardingSlide(
-                "Seu cofre é um arquivo",
-                "O GDSB não guarda nada na nuvem nem dentro do celular: tudo mora num arquivo .GDSBX " +
-                "que é seu. O app é só a camada que abre e lê esse arquivo - sem ele disponível, não há " +
-                "o que abrir. Guarde-o onde você consiga alcançar de novo: uma pasta do Google Drive ou " +
-                "do OneDrive, por exemplo."),
-
-            new OnboardingSlide(
-                "Criar um cofre",
-                "Você escolhe onde salvar o arquivo e define a senha mestra. Essa senha é a única " +
-                "chave: ela não fica guardada em lugar nenhum e não existe \"esqueci minha senha\". " +
-                "Perdeu a senha, perdeu o conteúdo do arquivo."),
-
-            new OnboardingSlide(
-                "Abrir depois",
-                "Sempre igual: escolher o arquivo, digitar a senha. Ligando a biometria, o app lembra " +
-                "do último cofre e a digital vira o atalho - mas a senha mestra continua valendo, e o " +
-                "arquivo ainda precisa estar acessível."),
+            new OnboardingSlide(Localization.Get("Onboarding_Slide1Title"), Localization.Get("Onboarding_Slide1Body")),
+            new OnboardingSlide(Localization.Get("Onboarding_Slide2Title"), Localization.Get("Onboarding_Slide2Body")),
+            new OnboardingSlide(Localization.Get("Onboarding_Slide3Title"), Localization.Get("Onboarding_Slide3Body")),
         ];
 
         [ObservableProperty]
@@ -71,7 +62,7 @@ namespace GDSB.MAUI.ViewModels
         // sem parecer que o usuário está abandonando algo pela metade.
         public bool ShowSkip => !IsLastSlide;
 
-        public string AdvanceButtonText => IsLastSlide ? "Começar" : "Próximo";
+        public string AdvanceButtonText => IsLastSlide ? Localization.Get("Onboarding_AdvanceButtonFinish") : Localization.Get("Onboarding_AdvanceButtonNext");
 #pragma warning restore S2325
 
         public bool HasBeenSeen => _preferencesService.GetBool(SeenPreferenceKey, false);

--- a/src/GDSB.MAUI.ViewModels/ViewModels/UnlockViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/UnlockViewModel.cs
@@ -17,18 +17,20 @@ namespace GDSB.MAUI.ViewModels
     public partial class UnlockViewModel : LocalizedObject
     {
         // Senha errada e arquivo corrompido devem ser indistinguíveis pra quem usa o app -
-        // nunca mostrar ex.Message cru, sempre essa mensagem genérica.
-        private const string GenericErrorMessage = "Senha incorreta ou arquivo corrompido.";
-        // Sem "password"/"pwd"/"passphrase" no nome: a regra S2068 do Sonar flaga a declaração de
-        // qualquer campo com esses nomes e valor literal como credencial no código, mesmo quando o
-        // valor é só uma mensagem de erro. Mesma renomeação já feita nas constantes de teste.
-        private const string EmptyUnlockCodeMessage = "Digite a senha mestra do cofre.";
-        private const string FilePickerErrorMessage = "Não foi possível abrir o seletor de arquivos.";
-        private const string BackupFileAlertTitle = "Isto é um backup";
-        private const string BackupFileAlertMessage =
-            "Este arquivo parece ser um backup gerado automaticamente pelo GDSB. Você ainda pode " +
-            "abri-lo normalmente com a senha mestra do cofre.";
-        private const string BackupFileAlertCancel = "Entendi";
+        // nunca mostrar ex.Message cru, sempre essa mensagem genérica. Deixam de ser const porque
+        // passam a vir do catálogo (ILocalizationService), que resolve na cultura vigente a cada
+        // leitura.
+        private string GenericErrorMessage => Localization.Get("Unlock_GenericErrorMessage");
+
+        private string EmptyUnlockCodeMessage => Localization.Get("Unlock_EmptyPasswordMessage");
+
+        private string FilePickerErrorMessage => Localization.Get("Unlock_FilePickerErrorMessage");
+
+        private string BackupFileAlertTitle => Localization.Get("Unlock_BackupFileAlertTitle");
+
+        private string BackupFileAlertMessage => Localization.Get("Unlock_BackupFileAlertMessage");
+
+        private string BackupFileAlertCancel => Localization.Get("HelpSheet_DismissButton");
 
         private readonly IProfileFileService _profileFileService;
         private readonly IFilePickerService _filePickerService;
@@ -114,7 +116,7 @@ namespace GDSB.MAUI.ViewModels
 #pragma warning disable S2325
         public bool ShowManualUnlock => !CanUseBiometric;
 
-        public string UnlockButtonText => IsBusy ? "Abrindo..." : "Abrir cofre";
+        public string UnlockButtonText => IsBusy ? Localization.Get("Unlock_ButtonBusyText") : Localization.Get("Unlock_ButtonIdleText");
 
         public string EyeGlyph => IsPasswordHidden ? "👁" : "🙈";
 #pragma warning restore S2325

--- a/src/GDSB.MAUI.ViewModels/ViewModels/VaultProtectionsFormViewModelBase.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/VaultProtectionsFormViewModelBase.cs
@@ -1,6 +1,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using GDSB.Domain.Entities;
+using GDSB.MAUI.Localization;
+using GDSB.MAUI.Services;
 
 namespace GDSB.MAUI.ViewModels
 {
@@ -9,8 +11,16 @@ namespace GDSB.MAUI.ViewModels
     // (edição de um cofre existente) e CreateVaultViewModel (criação), que espelham exatamente
     // os mesmos campos e comandos de seleção. SaveProtectionsAsync/CreateVaultAsync continuam em
     // cada ViewModel, porque os dois fazem coisas fundamentalmente diferentes com esses valores.
-    public abstract partial class VaultProtectionsFormViewModelBase : ObservableObject
+    // Herda de LocalizedObject (em vez de ObservableObject direto) porque os textos dos chips de
+    // opção (CreateVault_.../Protections_.../Backups_...) vêm do XAML via {loc:Tr}, não daqui -
+    // trocar a base cobre VaultSettingsViewModel e CreateVaultViewModel de uma vez só.
+    public abstract partial class VaultProtectionsFormViewModelBase : LocalizedObject
     {
+        protected VaultProtectionsFormViewModelBase(ILocalizationService localizationService)
+            : base(localizationService)
+        {
+        }
+
         public static IReadOnlyList<int> ClipboardClearSecondsOptions { get; } = new[] { 20, 45, 90 };
 
         public static IReadOnlyList<int> AutoLockMinutesOptions { get; } = new[] { 1, 2, 5, 15 };

--- a/src/GDSB.MAUI.ViewModels/ViewModels/VaultSettingsViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/VaultSettingsViewModel.cs
@@ -15,14 +15,18 @@ namespace GDSB.MAUI.ViewModels
     public partial class VaultSettingsViewModel : VaultProtectionsFormViewModelBase, IQueryAttributable
     {
         private const int MinPasswordLength = 8;
-        private const string GenericSaveErrorMessage = "Não foi possível salvar o cofre. Tente novamente.";
-        // Nomes de propósito sem "password": a regra S2068 do Sonar flaga qualquer identificador
-        // nesses moldes (declaração ou atribuição) associado a um valor literal, mesmo sendo só
-        // uma mensagem de UI.
-        private const string WrongCurrentCodeMessage = "Senha atual incorreta.";
-        private const string CodesDoNotMatchMessage = "As senhas não coincidem.";
-        private const string BiometricReseloFailedMessage =
-            "A senha foi trocada, mas não foi possível re-selar a biometria. A senha mestra continua valendo normalmente.";
+
+        // Deixam de ser const porque passam a vir do catálogo (ILocalizationService), que resolve
+        // na cultura vigente a cada leitura. Nomes de propósito sem "password": a regra S2068 do
+        // Sonar flaga qualquer identificador nesses moldes associado a um valor literal, mesmo
+        // sendo só uma mensagem de UI.
+        private string GenericSaveErrorMessage => Localization.Get("Vault_GenericSaveErrorMessage");
+
+        private string WrongCurrentCodeMessage => Localization.Get("VaultSettings_WrongCurrentPasswordMessage");
+
+        private string CodesDoNotMatchMessage => Localization.Get("Vault_PasswordsDoNotMatchMessage");
+
+        private string BiometricReseloFailedMessage => Localization.Get("VaultSettings_BiometricResealFailedMessage");
 
         private readonly IProfileFileService _profileFileService;
         private readonly IFilePickerService _filePickerService;
@@ -43,7 +47,9 @@ namespace GDSB.MAUI.ViewModels
             IBiometricUnlockService biometricUnlockService,
             IVaultBackupStore backupStore,
             IAlertService alertService,
+            ILocalizationService localizationService,
             BiometricOptInCoordinator biometricOptIn)
+            : base(localizationService)
         {
             _profileFileService = vaultAccess.ProfileFileService;
             _filePickerService = filePickerService;
@@ -145,7 +151,7 @@ namespace GDSB.MAUI.ViewModels
 
             if (string.IsNullOrWhiteSpace(VaultName))
             {
-                NameErrorMessage = "Dê um nome ao cofre.";
+                NameErrorMessage = Localization.Get("Vault_NameRequiredMessage");
                 return;
             }
 
@@ -215,7 +221,7 @@ namespace GDSB.MAUI.ViewModels
 
             if (NewPassword.Length < MinPasswordLength)
             {
-                PasswordErrorMessage = $"A senha nova precisa ter pelo menos {MinPasswordLength} caracteres.";
+                PasswordErrorMessage = Localization.Format("VaultSettings_MinNewPasswordLengthMessage", MinPasswordLength);
                 return;
             }
 
@@ -255,7 +261,7 @@ namespace GDSB.MAUI.ViewModels
                     {
                         var reselado = await _biometricUnlockService.StoreKeyAsync(secret);
                         if (!reselado)
-                            await _alertService.DisplayAlertAsync(null, BiometricReseloFailedMessage, "Ok");
+                            await _alertService.DisplayAlertAsync(null, BiometricReseloFailedMessage, Localization.Get("Common_Ok"));
                     }
                     finally
                     {
@@ -294,7 +300,7 @@ namespace GDSB.MAUI.ViewModels
             }
             catch (Exception)
             {
-                ErrorMessage = "Não foi possível escolher onde salvar o cofre.";
+                ErrorMessage = Localization.Get("Vault_ChoosePathErrorMessage");
                 return;
             }
 
@@ -332,7 +338,7 @@ namespace GDSB.MAUI.ViewModels
             }
             catch (Exception)
             {
-                ErrorMessage = "Não foi possível salvar o cofre nesse local.";
+                ErrorMessage = Localization.Get("Vault_SaveToLocationErrorMessage");
             }
             finally
             {

--- a/src/GDSB.MAUI.ViewModels/ViewModels/VaultViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/VaultViewModel.cs
@@ -3,12 +3,13 @@ using CommunityToolkit.Mvvm.Input;
 using GDSB.Domain.Entities;
 using GDSB.Domain.Interfaces;
 using GDSB.MAUI.Constants;
+using GDSB.MAUI.Localization;
 using GDSB.MAUI.Services;
 using System.Collections.ObjectModel;
 
 namespace GDSB.MAUI.ViewModels
 {
-    public partial class VaultViewModel : ObservableObject, IQueryAttributable
+    public partial class VaultViewModel : LocalizedObject, IQueryAttributable
     {
         private readonly IClipboardService _clipboardService;
         private readonly IAlertService _alertService;
@@ -27,7 +28,9 @@ namespace GDSB.MAUI.ViewModels
             IProfileFileService profileFileService,
             INavigationService navigationService,
             IAppLauncherService appLauncherService,
-            IVaultSessionService vaultSessionService)
+            IVaultSessionService vaultSessionService,
+            ILocalizationService localizationService)
+            : base(localizationService)
         {
             _clipboardService = clipboardService;
             _alertService = alertService;
@@ -130,7 +133,7 @@ namespace GDSB.MAUI.ViewModels
 
         public string ConfirmDeleteMessage => SelectedItem is null
             ? string.Empty
-            : $"Excluir \"{SelectedItem.BoxName}\" do cofre? Essa ação não pode ser desfeita.";
+            : Localization.Format("Vault_ConfirmDeleteMessage", SelectedItem.BoxName);
 
         public bool IsCompactLayout => !IsWideLayout;
 
@@ -157,7 +160,7 @@ namespace GDSB.MAUI.ViewModels
 
         public bool ShowEmptyState => !ShowItemEditor;
 
-        public string EditorHeaderTitle => SelectedItem is null ? "Novo item" : SelectedItem.BoxName;
+        public string EditorHeaderTitle => SelectedItem is null ? Localization.Get("Vault_NewItemTitle") : SelectedItem.BoxName;
 
         public string EditorHeaderInitial => SelectedItem?.Initial ?? "+";
 #pragma warning restore S2325
@@ -302,7 +305,7 @@ namespace GDSB.MAUI.ViewModels
             }
             catch (Exception)
             {
-                await _alertService.DisplayAlertAsync(null, "Não foi possível salvar o cofre. Tente novamente.", "Ok");
+                await _alertService.DisplayAlertAsync(null, Localization.Get("Vault_GenericSaveErrorMessage"), Localization.Get("Common_Ok"));
                 return false;
             }
             finally
@@ -383,13 +386,13 @@ namespace GDSB.MAUI.ViewModels
         {
             if (string.IsNullOrWhiteSpace(EditBoxName))
             {
-                ValidationError = "Informe um nome para o item.";
+                ValidationError = Localization.Get("Vault_NameValidationMessage");
                 return;
             }
 
             if (string.IsNullOrWhiteSpace(EditPassword))
             {
-                ValidationError = "Informe a senha do item.";
+                ValidationError = Localization.Get("Vault_PasswordValidationMessage");
                 return;
             }
 
@@ -493,7 +496,7 @@ namespace GDSB.MAUI.ViewModels
                 return;
 
             await _clipboardService.SetTextAsync(item.User);
-            ToastRequested?.Invoke(this, "Usuário copiado");
+            ToastRequested?.Invoke(this, Localization.Get("Vault_UserCopiedToast"));
         }
 
         [RelayCommand]
@@ -503,7 +506,7 @@ namespace GDSB.MAUI.ViewModels
                 return;
 
             await _clipboardService.SetTextAsync(item.Pass);
-            ToastRequested?.Invoke(this, "Senha copiada");
+            ToastRequested?.Invoke(this, Localization.Get("Vault_PasswordCopiedToast"));
         }
 
         [RelayCommand]
@@ -519,7 +522,7 @@ namespace GDSB.MAUI.ViewModels
             }
             catch (Exception ex)
             {
-                await _alertService.DisplayAlertAsync(null, $"Erro ao tentar abrir {item.Url}: {ex.Message}", "Ok");
+                await _alertService.DisplayAlertAsync(null, Localization.Format("Vault_OpenUrlErrorMessage", item.Url, ex.Message), Localization.Get("Common_Ok"));
             }
         }
     }

--- a/src/GDSB.MAUI/BackupRecoveryPage.xaml
+++ b/src/GDSB.MAUI/BackupRecoveryPage.xaml
@@ -4,6 +4,7 @@
              xmlns:behaviors="clr-namespace:GDSB.MAUI.Behaviors"
              xmlns:converters="clr-namespace:GDSB.MAUI.Converters"
              xmlns:views="clr-namespace:GDSB.MAUI.Views"
+             xmlns:loc="clr-namespace:GDSB.MAUI.Localization"
              x:Class="GDSB.MAUI.BackupRecoveryPage"
              Shell.NavBarIsVisible="False"
              BackgroundColor="{StaticResource SurfaceDark}">
@@ -30,11 +31,11 @@
                         </Label.FormattedText>
                     </Label>
                     <Grid ColumnDefinitions="*,*" ColumnSpacing="10" Margin="0,6,0,0">
-                        <Button Grid.Column="0" Text="Restaurar" Style="{StaticResource SecondaryActionButtonStyle}"
+                        <Button Grid.Column="0" Text="{loc:Tr BackupRecovery_RestoreButton}" Style="{StaticResource SecondaryActionButtonStyle}"
                                 HeightRequest="42"
                                 Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.BeginRestoreCommand}"
                                 CommandParameter="{Binding .}" />
-                        <Button Grid.Column="1" Text="Excluir" HeightRequest="42"
+                        <Button Grid.Column="1" Text="{loc:Tr Common_Delete}" HeightRequest="42"
                                 BackgroundColor="Transparent" TextColor="{StaticResource Danger}"
                                 BorderColor="{StaticResource Danger}" BorderWidth="1"
                                 Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.PromptDeleteCommand}"
@@ -50,8 +51,14 @@
             <Grid RowDefinitions="Auto,*" Padding="32">
 
                 <VerticalStackLayout Grid.Row="0" Spacing="4">
-                    <Label Text="&#8592; Voltar" TextColor="{StaticResource TextSecondaryDark}"
+                    <Label TextColor="{StaticResource TextSecondaryDark}"
                            FontSize="14" Margin="0,8,0,12" behaviors:HoverCursor.IsHand="True">
+                        <Label.FormattedText>
+                            <FormattedString>
+                                <Span Text="&#8592; " />
+                                <Span Text="{loc:Tr Common_Back}" />
+                            </FormattedString>
+                        </Label.FormattedText>
                         <Label.GestureRecognizers>
                             <TapGestureRecognizer Command="{Binding GoBackCommand}" />
                         </Label.GestureRecognizers>
@@ -61,12 +68,12 @@
                          todos). Nada de "?" nos cartões, nos botões nem no "Excluir todos" -
                          numa lista com N cartões isso viraria N vezes o mesmo ícone. -->
                     <HorizontalStackLayout Spacing="10">
-                        <Label Text="Recuperar backup" FontSize="22" FontFamily="OpenSansSemibold"
+                        <Label Text="{loc:Tr BackupRecovery_Title}" FontSize="22" FontFamily="OpenSansSemibold"
                                TextColor="{StaticResource TextPrimaryDark}" VerticalOptions="Center" />
                         <views:HelpButton TopicId="backup.recovery" Style="{StaticResource HelpButtonStyle}"
                                           VerticalOptions="Center" />
                     </HorizontalStackLayout>
-                    <Label Text="Backups são gerados automaticamente antes de cada gravação. Restaurar sempre cria um arquivo novo - o cofre original nunca é sobrescrito."
+                    <Label Text="{loc:Tr BackupRecovery_HelperText}"
                            TextColor="{StaticResource TextSecondaryDark}" FontSize="13" Margin="0,4,0,0" />
                 </VerticalStackLayout>
 
@@ -78,9 +85,9 @@
                     <!-- Estado vazio. -->
                     <VerticalStackLayout Spacing="6" Margin="0,30,0,0" HorizontalOptions="Center"
                                           IsVisible="{Binding HasBackups, Converter={StaticResource InvertedBoolConverter}}">
-                        <Label Text="Nenhum backup por aqui" FontFamily="OpenSansSemibold" FontSize="15"
+                        <Label Text="{loc:Tr BackupRecovery_EmptyTitle}" FontFamily="OpenSansSemibold" FontSize="15"
                                TextColor="{StaticResource TextPrimaryDark}" HorizontalOptions="Center" />
-                        <Label Text="Backups aparecem automaticamente depois da primeira edição de um cofre."
+                        <Label Text="{loc:Tr BackupRecovery_EmptyBody}"
                                TextColor="{StaticResource TextSecondaryDark}" FontSize="13" HorizontalOptions="Center"
                                HorizontalTextAlignment="Center" />
                     </VerticalStackLayout>
@@ -88,7 +95,7 @@
                     <CollectionView ItemsSource="{Binding Backups}" ItemTemplate="{StaticResource BackupCardTemplate}"
                                     IsVisible="{Binding HasBackups}" />
 
-                    <Label Text="Excluir todos os backups"
+                    <Label Text="{loc:Tr BackupRecovery_DeleteAllLink}"
                            TextColor="{StaticResource Danger}"
                            FontSize="13"
                            HorizontalOptions="Center"
@@ -113,17 +120,17 @@
             <Border Style="{StaticResource CardBorderStyle}" Padding="24" StrokeShape="RoundRectangle 20"
                     VerticalOptions="Center" MaximumWidthRequest="380">
                 <VerticalStackLayout Spacing="14">
-                    <Label Text="Restaurar backup" FontFamily="OpenSansSemibold" FontSize="18"
+                    <Label Text="{loc:Tr BackupRecovery_RestoreModalTitle}" FontFamily="OpenSansSemibold" FontSize="18"
                            TextColor="{StaticResource TextPrimaryDark}" />
                     <Label Text="{Binding PendingRestoreItem.DisplayName}" FontFamily="OpenSansSemibold"
                            FontSize="14" TextColor="{StaticResource TextSecondaryDark}"
                            LineBreakMode="HeadTruncation" MaxLines="1" />
-                    <Label Text="Digite a senha mestra deste backup. Se ele for anterior a uma troca de senha, use a senha antiga."
+                    <Label Text="{loc:Tr BackupRecovery_RestoreModalHint}"
                            TextColor="{StaticResource TextSecondaryDark}" FontSize="13.5" />
                     <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                             StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="48">
                         <Entry Text="{Binding RestorePassword}" IsPassword="True"
-                               Placeholder="Senha mestra do backup"
+                               Placeholder="{loc:Tr BackupRecovery_RestorePasswordPlaceholder}"
                                TextColor="{StaticResource TextPrimaryDark}" PlaceholderColor="{StaticResource TextMutedDark}"
                                BackgroundColor="Transparent" VerticalOptions="Center"
                                ReturnCommand="{Binding ConfirmRestoreCommand}" />
@@ -131,9 +138,9 @@
                     <Label Text="{Binding RestoreErrorMessage}" TextColor="{StaticResource Danger}" FontSize="13"
                            IsVisible="{Binding HasRestoreErrorMessage}" />
                     <Grid ColumnDefinitions="*,*" ColumnSpacing="10" Margin="0,6,0,0">
-                        <Button Grid.Column="0" Text="Cancelar" Style="{StaticResource SecondaryActionButtonStyle}"
+                        <Button Grid.Column="0" Text="{loc:Tr Common_Cancel}" Style="{StaticResource SecondaryActionButtonStyle}"
                                 Command="{Binding CancelRestoreCommand}" IsEnabled="{Binding CanInteract}" />
-                        <Button Grid.Column="1" Text="Restaurar" Style="{StaticResource PrimaryActionButtonStyle}"
+                        <Button Grid.Column="1" Text="{loc:Tr BackupRecovery_RestoreButton}" Style="{StaticResource PrimaryActionButtonStyle}"
                                 HeightRequest="46" Command="{Binding ConfirmRestoreCommand}" IsEnabled="{Binding CanInteract}" />
                     </Grid>
                 </VerticalStackLayout>
@@ -146,16 +153,16 @@
             <Border Style="{StaticResource CardBorderStyle}" Padding="24" StrokeShape="RoundRectangle 20"
                     VerticalOptions="Center" MaximumWidthRequest="380">
                 <VerticalStackLayout Spacing="14">
-                    <Label Text="Excluir este backup?" FontFamily="OpenSansSemibold" FontSize="18"
+                    <Label Text="{loc:Tr BackupRecovery_DeleteModalTitle}" FontFamily="OpenSansSemibold" FontSize="18"
                            TextColor="{StaticResource TextPrimaryDark}" />
                     <Label Text="{Binding PendingDeleteItem.DisplayName}" FontSize="13.5"
                            TextColor="{StaticResource TextSecondaryDark}"
                            LineBreakMode="HeadTruncation" MaxLines="1" />
-                    <Label Text="Essa ação não pode ser desfeita." TextColor="{StaticResource Danger}" FontSize="13.5" />
+                    <Label Text="{loc:Tr BackupRecovery_DeleteModalWarning}" TextColor="{StaticResource Danger}" FontSize="13.5" />
                     <Grid ColumnDefinitions="*,*" ColumnSpacing="10" Margin="0,6,0,0">
-                        <Button Grid.Column="0" Text="Cancelar" Style="{StaticResource SecondaryActionButtonStyle}"
+                        <Button Grid.Column="0" Text="{loc:Tr Common_Cancel}" Style="{StaticResource SecondaryActionButtonStyle}"
                                 Command="{Binding CancelDeleteCommand}" IsEnabled="{Binding CanInteract}" />
-                        <Button Grid.Column="1" Text="Excluir" HeightRequest="46"
+                        <Button Grid.Column="1" Text="{loc:Tr Common_Delete}" HeightRequest="46"
                                 BackgroundColor="{StaticResource Danger}" TextColor="{StaticResource White}"
                                 Command="{Binding ConfirmDeleteCommand}" IsEnabled="{Binding CanInteract}" />
                     </Grid>
@@ -168,14 +175,14 @@
             <Border Style="{StaticResource CardBorderStyle}" Padding="24" StrokeShape="RoundRectangle 20"
                     VerticalOptions="Center" MaximumWidthRequest="380">
                 <VerticalStackLayout Spacing="14">
-                    <Label Text="Excluir todos os backups?" FontFamily="OpenSansSemibold" FontSize="18"
+                    <Label Text="{loc:Tr BackupRecovery_DeleteAllModalTitle}" FontFamily="OpenSansSemibold" FontSize="18"
                            TextColor="{StaticResource TextPrimaryDark}" />
-                    <Label Text="Todos os backups listados nesta tela serão apagados. Essa ação não pode ser desfeita."
+                    <Label Text="{loc:Tr BackupRecovery_DeleteAllModalWarning}"
                            TextColor="{StaticResource Danger}" FontSize="13.5" />
                     <Grid ColumnDefinitions="*,*" ColumnSpacing="10" Margin="0,6,0,0">
-                        <Button Grid.Column="0" Text="Cancelar" Style="{StaticResource SecondaryActionButtonStyle}"
+                        <Button Grid.Column="0" Text="{loc:Tr Common_Cancel}" Style="{StaticResource SecondaryActionButtonStyle}"
                                 Command="{Binding CancelDeleteAllCommand}" IsEnabled="{Binding CanInteract}" />
-                        <Button Grid.Column="1" Text="Excluir todos" HeightRequest="46"
+                        <Button Grid.Column="1" Text="{loc:Tr BackupRecovery_DeleteAllConfirmButton}" HeightRequest="46"
                                 BackgroundColor="{StaticResource Danger}" TextColor="{StaticResource White}"
                                 Command="{Binding ConfirmDeleteAllCommand}" IsEnabled="{Binding CanInteract}" />
                     </Grid>

--- a/src/GDSB.MAUI/BackupRecoveryPage.xaml.cs
+++ b/src/GDSB.MAUI/BackupRecoveryPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using GDSB.MAUI.ViewModels;
+﻿using GDSB.MAUI.Services;
+using GDSB.MAUI.ViewModels;
 using GDSB.MAUI.Views;
 
 namespace GDSB.MAUI;
@@ -6,11 +7,13 @@ namespace GDSB.MAUI;
 public partial class BackupRecoveryPage : ContentPage
 {
     private readonly BackupRecoveryViewModel _viewModel;
+    private readonly ILocalizationService _localization;
 
-    public BackupRecoveryPage(BackupRecoveryViewModel viewModel)
+    public BackupRecoveryPage(BackupRecoveryViewModel viewModel, ILocalizationService localization)
     {
         InitializeComponent();
         _viewModel = viewModel;
+        _localization = localization;
         BindingContext = _viewModel;
         _viewModel.BackupDeleted += OnBackupDeleted;
         _viewModel.AllBackupsDeleted += OnAllBackupsDeleted;
@@ -38,9 +41,9 @@ public partial class BackupRecoveryPage : ContentPage
     // gerado - mesmo caso de VaultPage.OnSecretDeleted.
 #pragma warning disable S2325
     private async void OnBackupDeleted(object? sender, EventArgs e)
-        => await SealOverlay.PlayAsync(LockSealMode.Delete, "Backup excluído", 740);
+        => await SealOverlay.PlayAsync(LockSealMode.Delete, _localization.Get("Seal_BackupDeleted"), 740);
 
     private async void OnAllBackupsDeleted(object? sender, EventArgs e)
-        => await SealOverlay.PlayAsync(LockSealMode.Delete, "Backups excluídos", 740);
+        => await SealOverlay.PlayAsync(LockSealMode.Delete, _localization.Get("Seal_AllBackupsDeleted"), 740);
 #pragma warning restore S2325
 }

--- a/src/GDSB.MAUI/CreateVaultPage.xaml
+++ b/src/GDSB.MAUI/CreateVaultPage.xaml
@@ -5,6 +5,7 @@
              xmlns:controls="clr-namespace:GDSB.MAUI.Controls"
              xmlns:views="clr-namespace:GDSB.MAUI.Views"
              xmlns:converters="clr-namespace:GDSB.MAUI.Converters"
+             xmlns:loc="clr-namespace:GDSB.MAUI.Localization"
              x:Class="GDSB.MAUI.CreateVaultPage"
              Shell.NavBarIsVisible="False"
              BackgroundColor="{StaticResource SurfaceDark}">
@@ -17,8 +18,14 @@
 
         <Grid RowDefinitions="Auto,*,Auto" Padding="32">
 
-            <Label Grid.Row="0" Text="&#8592; Voltar" TextColor="{StaticResource TextSecondaryDark}"
+            <Label Grid.Row="0" TextColor="{StaticResource TextSecondaryDark}"
                    FontSize="14" Margin="0,8,0,0" behaviors:HoverCursor.IsHand="True">
+                <Label.FormattedText>
+                    <FormattedString>
+                        <Span Text="&#8592; " />
+                        <Span Text="{loc:Tr Common_Back}" />
+                    </FormattedString>
+                </Label.FormattedText>
                 <Label.GestureRecognizers>
                     <TapGestureRecognizer Command="{Binding GoBackCommand}" />
                 </Label.GestureRecognizers>
@@ -34,9 +41,9 @@
                              emoji 🔑, que muda de desenho a cada plataforma. -->
                         <GraphicsView x:Name="BrandMark" WidthRequest="72" HeightRequest="72"
                                       HorizontalOptions="Center" />
-                        <Label Text="Novo cofre" FontSize="22" FontFamily="OpenSansSemibold"
+                        <Label Text="{loc:Tr CreateVault_Title}" FontSize="22" FontFamily="OpenSansSemibold"
                                TextColor="{StaticResource TextPrimaryDark}" HorizontalOptions="Center" />
-                        <Label Text="Escolha onde guardar e defina a senha mestra" FontSize="13"
+                        <Label Text="{loc:Tr CreateVault_Subtitle}" FontSize="13"
                                TextColor="{StaticResource TextSecondaryDark}" HorizontalOptions="Center"
                                HorizontalTextAlignment="Center" />
                     </VerticalStackLayout>
@@ -45,7 +52,7 @@
                         <VerticalStackLayout Spacing="16">
 
                             <VerticalStackLayout Spacing="8">
-                                <views:FieldLabelView Text="NOME DO COFRE" IsRequired="True" />
+                                <views:FieldLabelView Text="{loc:Tr Vault_NameFieldLabel}" IsRequired="True" />
                                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                                         StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="48">
                                     <Entry Text="{Binding VaultName}" TextColor="{StaticResource TextPrimaryDark}"
@@ -55,30 +62,30 @@
                             </VerticalStackLayout>
 
                             <VerticalStackLayout Spacing="8">
-                                <views:FieldLabelView Text="SENHA MESTRA" IsRequired="True"
+                                <views:FieldLabelView Text="{loc:Tr Vault_MasterPasswordFieldLabel}" IsRequired="True"
                                                       HelpTopicId="vault.masterUnlockCode" />
                                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                                         StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="48">
                                     <Entry Text="{Binding Password}" IsPassword="True"
-                                           Placeholder="Mínimo de 8 caracteres"
+                                           Placeholder="{loc:Tr Vault_MinPasswordPlaceholder}"
                                            TextColor="{StaticResource TextPrimaryDark}" PlaceholderColor="{StaticResource TextMutedDark}"
                                            BackgroundColor="Transparent" VerticalOptions="Center" />
                                 </Border>
                             </VerticalStackLayout>
 
                             <VerticalStackLayout Spacing="8">
-                                <views:FieldLabelView Text="CONFIRMAR SENHA" IsRequired="True" />
+                                <views:FieldLabelView Text="{loc:Tr CreateVault_ConfirmPasswordFieldLabel}" IsRequired="True" />
                                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                                         StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="48">
                                     <Entry Text="{Binding ConfirmPassword}" IsPassword="True"
-                                           Placeholder="Digite a senha novamente"
+                                           Placeholder="{loc:Tr CreateVault_ConfirmPasswordPlaceholder}"
                                            TextColor="{StaticResource TextPrimaryDark}" PlaceholderColor="{StaticResource TextMutedDark}"
                                            BackgroundColor="Transparent" VerticalOptions="Center"
                                            ReturnCommand="{Binding CreateVaultCommand}" />
                                 </Border>
                             </VerticalStackLayout>
 
-                            <Label Text="* campos obrigatórios" Style="{StaticResource RequiredFieldsLegendStyle}" />
+                            <Label Text="{loc:Tr Common_RequiredFieldsLegend}" Style="{StaticResource RequiredFieldsLegendStyle}" />
 
                             <Label Text="{Binding ErrorMessage}" TextColor="{StaticResource Danger}" FontSize="13"
                                    IsVisible="{Binding HasErrorMessage}" />
@@ -92,25 +99,25 @@
                     <Border Style="{StaticResource CardBorderStyle}" Padding="22" StrokeShape="RoundRectangle 20">
                         <VerticalStackLayout Spacing="18">
 
-                            <views:FieldLabelView Text="PROTEÇÕES" HelpTopicId="vault.protections" />
+                            <views:FieldLabelView Text="{loc:Tr Protections_SectionLabel}" HelpTopicId="vault.protections" />
 
                             <VerticalStackLayout Spacing="6">
                                 <Grid ColumnDefinitions="*,Auto">
-                                    <Label Grid.Column="0" Text="Limpar a área de transferência"
+                                    <Label Grid.Column="0" Text="{loc:Tr Protections_ClipboardClearLabel}"
                                            TextColor="{StaticResource TextPrimaryDark}" FontSize="14" VerticalOptions="Center" />
                                     <Switch Grid.Column="1" IsToggled="{Binding ClipboardClearEnabled}"
                                             OnColor="{StaticResource Primary}" />
                                 </Grid>
-                                <Label Text="Ao copiar uma senha ou usuário, o app apaga o valor da área de transferência depois do tempo escolhido."
+                                <Label Text="{loc:Tr CreateVault_ClipboardClearHelperText}"
                                        TextColor="{StaticResource TextSecondaryDark}" FontSize="12" />
                                 <HorizontalStackLayout Spacing="8" IsVisible="{Binding ClipboardClearEnabled}">
-                                    <controls:SelectableChip Text="20s" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Protections_ClipboardChip20s}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectClipboardClearSecondsCommand}" CommandParameter="20"
                                             IsSelected="{Binding ClipboardClearSeconds, Converter={StaticResource EqualsConverter}, ConverterParameter=20}" />
-                                    <controls:SelectableChip Text="45s" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Protections_ClipboardChip45s}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectClipboardClearSecondsCommand}" CommandParameter="45"
                                             IsSelected="{Binding ClipboardClearSeconds, Converter={StaticResource EqualsConverter}, ConverterParameter=45}" />
-                                    <controls:SelectableChip Text="90s" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Protections_ClipboardChip90s}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectClipboardClearSecondsCommand}" CommandParameter="90"
                                             IsSelected="{Binding ClipboardClearSeconds, Converter={StaticResource EqualsConverter}, ConverterParameter=90}" />
                                 </HorizontalStackLayout>
@@ -120,27 +127,27 @@
 
                             <VerticalStackLayout Spacing="6">
                                 <Grid ColumnDefinitions="*,Auto">
-                                    <Label Grid.Column="0" Text="Bloqueio automático"
+                                    <Label Grid.Column="0" Text="{loc:Tr Protections_AutoLockLabel}"
                                            TextColor="{StaticResource TextPrimaryDark}" FontSize="14" VerticalOptions="Center" />
                                     <Switch Grid.Column="1" IsToggled="{Binding AutoLockEnabled}"
                                             OnColor="{StaticResource Primary}" />
                                 </Grid>
-                                <Label Text="Volta pra tela de senha se o app ficar em segundo plano além do tempo escolhido."
+                                <Label Text="{loc:Tr CreateVault_AutoLockHelperText}"
                                        TextColor="{StaticResource TextSecondaryDark}" FontSize="12" />
-                                <Label Text="Desligar deixa o cofre aberto indefinidamente em segundo plano."
+                                <Label Text="{loc:Tr Protections_AutoLockWarning}"
                                        TextColor="{StaticResource Danger}" FontSize="12"
                                        IsVisible="{Binding AutoLockEnabled, Converter={StaticResource InvertedBoolConverter}}" />
                                 <HorizontalStackLayout Spacing="8" IsVisible="{Binding AutoLockEnabled}">
-                                    <controls:SelectableChip Text="1 min" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Protections_AutoLockChip1min}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="1"
                                             IsSelected="{Binding AutoLockMinutes, Converter={StaticResource EqualsConverter}, ConverterParameter=1}" />
-                                    <controls:SelectableChip Text="2 min" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Protections_AutoLockChip2min}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="2"
                                             IsSelected="{Binding AutoLockMinutes, Converter={StaticResource EqualsConverter}, ConverterParameter=2}" />
-                                    <controls:SelectableChip Text="5 min" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Protections_AutoLockChip5min}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="5"
                                             IsSelected="{Binding AutoLockMinutes, Converter={StaticResource EqualsConverter}, ConverterParameter=5}" />
-                                    <controls:SelectableChip Text="15 min" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Protections_AutoLockChip15min}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="15"
                                             IsSelected="{Binding AutoLockMinutes, Converter={StaticResource EqualsConverter}, ConverterParameter=15}" />
                                 </HorizontalStackLayout>
@@ -149,14 +156,14 @@
                             <BoxView HeightRequest="1" Color="{StaticResource BorderDark}" />
 
                             <VerticalStackLayout Spacing="6">
-                                <views:FieldLabelView Text="BACKUPS" HelpTopicId="vault.backups" />
-                                <Label Text="Manter quantas versões"
+                                <views:FieldLabelView Text="{loc:Tr Backups_SectionLabel}" HelpTopicId="vault.backups" />
+                                <Label Text="{loc:Tr Backups_RetentionQuestion}"
                                        TextColor="{StaticResource TextPrimaryDark}" FontSize="14" />
                                 <HorizontalStackLayout Spacing="8">
-                                    <controls:SelectableChip Text="Por quantidade" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Backups_ModeByCountChip}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectBackupRetentionModeCountCommand}"
                                             IsSelected="{Binding IsBackupRetentionByCount}" />
-                                    <controls:SelectableChip Text="Por tempo" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Backups_ModeByDaysChip}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectBackupRetentionModeDaysCommand}"
                                             IsSelected="{Binding IsBackupRetentionByDays}" />
                                 </HorizontalStackLayout>
@@ -177,24 +184,24 @@
                                 </HorizontalStackLayout>
 
                                 <HorizontalStackLayout Spacing="8" IsVisible="{Binding IsBackupRetentionByDays}">
-                                    <controls:SelectableChip Text="3 dias" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Backups_DaysChip3}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="3"
                                             IsSelected="{Binding BackupRetentionDays, Converter={StaticResource EqualsConverter}, ConverterParameter=3}" />
-                                    <controls:SelectableChip Text="5 dias" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Backups_DaysChip5}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="5"
                                             IsSelected="{Binding BackupRetentionDays, Converter={StaticResource EqualsConverter}, ConverterParameter=5}" />
-                                    <controls:SelectableChip Text="15 dias" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Backups_DaysChip15}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="15"
                                             IsSelected="{Binding BackupRetentionDays, Converter={StaticResource EqualsConverter}, ConverterParameter=15}" />
-                                    <controls:SelectableChip Text="30 dias" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Backups_DaysChip30}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="30"
                                             IsSelected="{Binding BackupRetentionDays, Converter={StaticResource EqualsConverter}, ConverterParameter=30}" />
                                 </HorizontalStackLayout>
 
-                                <Label Text="Ao passar do limite de versões, a mais antiga é apagada. A versão mais recente nunca é apagada."
+                                <Label Text="{loc:Tr Backups_RetentionByCountNote}"
                                        TextColor="{StaticResource TextSecondaryDark}" FontSize="12"
                                        IsVisible="{Binding IsBackupRetentionByCount}" />
-                                <Label Text="Backups mais antigos que o limite escolhido são apagados. A versão mais recente nunca é apagada."
+                                <Label Text="{loc:Tr Backups_RetentionByDaysNote}"
                                        TextColor="{StaticResource TextSecondaryDark}" FontSize="12"
                                        IsVisible="{Binding IsBackupRetentionByDays}" />
                             </VerticalStackLayout>

--- a/src/GDSB.MAUI/Localization/LocalizationServiceLocator.cs
+++ b/src/GDSB.MAUI/Localization/LocalizationServiceLocator.cs
@@ -1,0 +1,24 @@
+using GDSB.MAUI.Services;
+
+namespace GDSB.MAUI.Localization
+{
+    // Resolve ILocalizationService fora do container de DI, para os poucos pontos que não passam
+    // por ele: TrExtension (markup extension, instanciado pelo parser XAML) e os controles que o
+    // XAML cria direto (HelpButton, FieldLabelView) - todos sem construtor chamado pela DI. Página e
+    // ViewModel recebem o serviço por injeção normal; só isto aqui precisa do atalho.
+    internal static class LocalizationServiceLocator
+    {
+        // "?? throw" em vez de "!": prova a não-nulidade pro compilador sem um null-forgiving
+        // operator (que o SonarCloud aponta como redundante aqui, apesar do compilador continuar
+        // exigindo a checagem - IPlatformApplication.Current é anulável de verdade) e falha com uma
+        // mensagem clara em vez de NullReferenceException, no caso extremo de isto rodar antes do
+        // host da plataforma estar pronto.
+        public static ILocalizationService Resolve()
+        {
+            var platformApplication = IPlatformApplication.Current
+                ?? throw new InvalidOperationException("IPlatformApplication.Current não está definido.");
+
+            return platformApplication.Services.GetRequiredService<ILocalizationService>();
+        }
+    }
+}

--- a/src/GDSB.MAUI/Localization/TrExtension.cs
+++ b/src/GDSB.MAUI/Localization/TrExtension.cs
@@ -1,5 +1,3 @@
-using GDSB.MAUI.Services;
-
 namespace GDSB.MAUI.Localization
 {
     // Ponte entre "{loc:Tr Chave}" no XAML e o catálogo. Devolve um BindingBase (não uma string
@@ -19,23 +17,9 @@ namespace GDSB.MAUI.Localization
 
         public BindingBase ProvideValue(IServiceProvider serviceProvider)
         {
-            var localizationService = Source ?? ResolveLocalizationServiceFromPlatformApplication();
+            var localizationService = Source ?? (object)LocalizationServiceLocator.Resolve();
 
             return new Binding($"[{Key}]", BindingMode.OneWay, source: localizationService);
-        }
-
-        // "?? throw" em vez de "!": prova a não-nulidade pro compilador sem um null-forgiving
-        // operator (que o SonarCloud aponta como redundante aqui, apesar do compilador continuar
-        // exigindo a checagem - IPlatformApplication.Current é anulável de verdade) e falha com uma
-        // mensagem clara em vez de NullReferenceException, no caso extremo de o markup extension
-        // avaliar antes do host da plataforma estar pronto. Em método próprio pra continuar só
-        // sendo chamado quando Source não foi setado, preservando o curto-circuito do "??" de cima.
-        private static object ResolveLocalizationServiceFromPlatformApplication()
-        {
-            var platformApplication = IPlatformApplication.Current
-                ?? throw new InvalidOperationException("IPlatformApplication.Current não está definido.");
-
-            return platformApplication.Services.GetRequiredService<ILocalizationService>();
         }
 
         object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider) => ProvideValue(serviceProvider);

--- a/src/GDSB.MAUI/Platforms/Android/Services/BiometricUnlockService.cs
+++ b/src/GDSB.MAUI/Platforms/Android/Services/BiometricUnlockService.cs
@@ -5,6 +5,7 @@ using AndroidX.Biometric;
 using AndroidX.Core.Content;
 using AndroidX.Fragment.App;
 using GDSB.Domain.Interfaces;
+using GDSB.MAUI.Services;
 using Java.Security;
 using Javax.Crypto;
 using Javax.Crypto.Spec;
@@ -27,6 +28,13 @@ namespace GDSB.MAUI.Platforms.Android.Services
         private const string PrefsName = "gdsb_biometric";
         private const string IvPrefKey = "iv";
         private const string CiphertextPrefKey = "ciphertext";
+
+        private readonly ILocalizationService _localization;
+
+        public BiometricUnlockService(ILocalizationService localization)
+        {
+            _localization = localization;
+        }
 
         public Task<bool> IsAvailableAsync()
         {
@@ -52,7 +60,8 @@ namespace GDSB.MAUI.Platforms.Android.Services
                 var cipher = Cipher.GetInstance(Transformation);
                 cipher.Init(CipherMode.EncryptMode, key);
 
-                var authenticatedCipher = await AuthenticateAsync(activity, cipher, "Confirme sua biometria para ativar o desbloqueio rápido");
+                var authenticatedCipher = await AuthenticateAsync(
+                    activity, cipher, _localization.Get("Platform_BiometricActivateSubtitle"), _localization.Get("Platform_BiometricNegativeButton"));
                 if (authenticatedCipher is null)
                     return false;
 
@@ -95,7 +104,8 @@ namespace GDSB.MAUI.Platforms.Android.Services
                 var iv = Convert.FromBase64String(ivBase64);
                 cipher.Init(CipherMode.DecryptMode, key, new GCMParameterSpec(GcmTagLengthBits, iv));
 
-                var authenticatedCipher = await AuthenticateAsync(activity, cipher, "Use sua biometria para abrir o cofre");
+                var authenticatedCipher = await AuthenticateAsync(
+                    activity, cipher, _localization.Get("Platform_BiometricUnlockSubtitle"), _localization.Get("Platform_BiometricNegativeButton"));
                 if (authenticatedCipher is null)
                     return null;
 
@@ -162,7 +172,9 @@ namespace GDSB.MAUI.Platforms.Android.Services
 
         // Devolve o Cipher já autorizado (mesma instância passada em CryptoObject) depois de uma
         // biometria bem-sucedida, ou null se o usuário cancelar/errar ou o prompt der erro.
-        private static async Task<Cipher?> AuthenticateAsync(FragmentActivity activity, Cipher cipher, string subtitle)
+        // negativeButtonText entra como parâmetro (em vez de ler _localization aqui) só para poder
+        // continuar static, como o resto dos métodos auxiliares desta classe.
+        private static async Task<Cipher?> AuthenticateAsync(FragmentActivity activity, Cipher cipher, string subtitle, string negativeButtonText)
         {
             // BiometricPrompt.Authenticate chamado antes da janela ter foco (ex.: disparado sozinho
             // assim que a UnlockPage aparece, seja na abertura do app ou voltando de background)
@@ -181,7 +193,7 @@ namespace GDSB.MAUI.Platforms.Android.Services
                 var promptInfo = new BiometricPrompt.PromptInfo.Builder()
                     .SetTitle("GDSB")
                     .SetSubtitle(subtitle)
-                    .SetNegativeButtonText("Usar senha")
+                    .SetNegativeButtonText(negativeButtonText)
                     .SetAllowedAuthenticators((int)BiometricManager.Authenticators.BiometricStrong)
                     .Build();
 

--- a/src/GDSB.MAUI/Platforms/Windows/Services/BiometricUnlockService.cs
+++ b/src/GDSB.MAUI/Platforms/Windows/Services/BiometricUnlockService.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using GDSB.Domain.Interfaces;
+using GDSB.MAUI.Services;
 using Microsoft.Maui.Storage;
 using Windows.Security.Credentials.UI;
 
@@ -13,8 +14,17 @@ namespace GDSB.MAUI.Platforms.Windows.Services
     public class BiometricUnlockService : IBiometricUnlockService
     {
         private const string FileName = "biometric-unlock.bin";
-        private const string ActivateMessage = "Confirme sua identidade para ativar o desbloqueio rápido do GDSB.";
-        private const string UnlockMessage = "Use o Windows Hello para abrir o cofre.";
+
+        private readonly ILocalizationService _localization;
+
+        public BiometricUnlockService(ILocalizationService localization)
+        {
+            _localization = localization;
+        }
+
+        private string ActivateMessage => _localization.Get("Platform_WindowsBiometricActivateMessage");
+
+        private string UnlockMessage => _localization.Get("Platform_WindowsBiometricUnlockMessage");
 
         public async Task<bool> IsAvailableAsync()
         {

--- a/src/GDSB.MAUI/Platforms/Windows/Services/FilePickerService.cs
+++ b/src/GDSB.MAUI/Platforms/Windows/Services/FilePickerService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using GDSB.MAUI.Interfaces;
+using GDSB.MAUI.Services;
 using Windows.Storage.Pickers;
 using Windows.Storage;
 
@@ -12,6 +13,12 @@ namespace GDSB.MAUI.Platforms.Windows.Services
 {
     public class FilePickerService : IFilePickerService
     {
+        private readonly ILocalizationService _localization;
+
+        public FilePickerService(ILocalizationService localization)
+        {
+            _localization = localization;
+        }
 
         public async Task<PickedFile?> PickFileNameAsync()
         {
@@ -30,7 +37,7 @@ namespace GDSB.MAUI.Platforms.Windows.Services
             var picker = new FileSavePicker();
             picker.SuggestedFileName = Path.GetFileNameWithoutExtension(suggestedName);
             picker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
-            picker.FileTypeChoices.Add("Arquivo GDSB", new List<string> { ".GDSBX" });
+            picker.FileTypeChoices.Add(_localization.Get("Platform_WindowsFileTypeLabel"), new List<string> { ".GDSBX" });
 
             var hwnd = ((MauiWinUIWindow)App.Current.Windows[0].Handler.PlatformView).WindowHandle;
             WinRT.Interop.InitializeWithWindow.Initialize(picker, hwnd);

--- a/src/GDSB.MAUI/Resources/HelpVisuals.xaml
+++ b/src/GDSB.MAUI/Resources/HelpVisuals.xaml
@@ -21,14 +21,15 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:controls="clr-namespace:GDSB.MAUI.Controls"
-    xmlns:views="clr-namespace:GDSB.MAUI.Views">
+    xmlns:views="clr-namespace:GDSB.MAUI.Views"
+    xmlns:loc="clr-namespace:GDSB.MAUI.Localization">
 
     <!-- ============ Cofre: criação e edição ============ -->
 
     <DataTemplate x:Key="HelpVisual.MasterUnlockCodeField">
         <VerticalStackLayout InputTransparent="True" Spacing="8">
             <HorizontalStackLayout Spacing="4">
-                <Label Text="SENHA MESTRA" Style="{StaticResource FieldLabelStyle}" VerticalOptions="Center" />
+                <Label Text="{loc:Tr Vault_MasterPasswordFieldLabel}" Style="{StaticResource FieldLabelStyle}" VerticalOptions="Center" />
                 <Label Text="*" Style="{StaticResource RequiredMarkStyle}" VerticalOptions="Center" />
             </HorizontalStackLayout>
             <Grid Padding="0,0,0,16">
@@ -47,12 +48,12 @@
             <Border Style="{StaticResource CardBorderStyle}" Padding="16" StrokeShape="RoundRectangle 16"
                     VerticalOptions="Start">
                 <VerticalStackLayout Spacing="10">
-                    <Label Text="Salvar também num arquivo novo?" FontFamily="OpenSansSemibold" FontSize="14"
+                    <Label Text="{loc:Tr SaveAsNewFile_Title}" FontFamily="OpenSansSemibold" FontSize="14"
                            TextColor="{StaticResource TextPrimaryDark}" />
                     <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
-                        <Button Grid.Column="0" Text="Não, obrigado" Style="{StaticResource SecondaryActionButtonStyle}"
+                        <Button Grid.Column="0" Text="{loc:Tr SaveAsNewFile_DeclineButton}" Style="{StaticResource SecondaryActionButtonStyle}"
                                 FontSize="12" HeightRequest="40" />
-                        <Button Grid.Column="1" Text="Salvar como novo" Style="{StaticResource PrimaryActionButtonStyle}"
+                        <Button Grid.Column="1" Text="{loc:Tr HelpVisual_SaveAsNewFileShortButton}" Style="{StaticResource PrimaryActionButtonStyle}"
                                 FontSize="12" HeightRequest="40" />
                     </Grid>
                 </VerticalStackLayout>
@@ -64,9 +65,9 @@
     <DataTemplate x:Key="HelpVisual.ProtectionTimeChips">
         <Grid InputTransparent="True" Padding="0,0,0,20" HorizontalOptions="Start">
             <HorizontalStackLayout Spacing="8" VerticalOptions="Start">
-                <controls:SelectableChip Text="20s" Style="{StaticResource FilterChipStyle}" />
-                <controls:SelectableChip Text="45s" Style="{StaticResource FilterChipStyle}" IsSelected="True" />
-                <controls:SelectableChip Text="90s" Style="{StaticResource FilterChipStyle}" />
+                <controls:SelectableChip Text="{loc:Tr Protections_ClipboardChip20s}" Style="{StaticResource FilterChipStyle}" />
+                <controls:SelectableChip Text="{loc:Tr Protections_ClipboardChip45s}" Style="{StaticResource FilterChipStyle}" IsSelected="True" />
+                <controls:SelectableChip Text="{loc:Tr Protections_ClipboardChip90s}" Style="{StaticResource FilterChipStyle}" />
             </HorizontalStackLayout>
             <views:TapHintView HorizontalOptions="Start" VerticalOptions="Start" Margin="83,9,0,0" />
         </Grid>
@@ -75,8 +76,8 @@
     <DataTemplate x:Key="HelpVisual.BackupModeChips">
         <Grid InputTransparent="True" Padding="0,0,0,20" HorizontalOptions="Start">
             <HorizontalStackLayout Spacing="8" VerticalOptions="Start">
-                <controls:SelectableChip Text="Por quantidade" Style="{StaticResource FilterChipStyle}" IsSelected="True" />
-                <controls:SelectableChip Text="Por tempo" Style="{StaticResource FilterChipStyle}" />
+                <controls:SelectableChip Text="{loc:Tr Backups_ModeByCountChip}" Style="{StaticResource FilterChipStyle}" IsSelected="True" />
+                <controls:SelectableChip Text="{loc:Tr Backups_ModeByDaysChip}" Style="{StaticResource FilterChipStyle}" />
             </HorizontalStackLayout>
             <views:TapHintView HorizontalOptions="Start" VerticalOptions="Start" Margin="153,9,0,0" />
         </Grid>
@@ -86,7 +87,7 @@
         <Grid InputTransparent="True" Padding="0,0,0,16">
             <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8" VerticalOptions="Start">
                 <CheckBox Grid.Column="0" IsChecked="True" Color="{StaticResource Primary}" VerticalOptions="Center" />
-                <Label Grid.Column="1" Text="Excluir os backups antigos deste cofre"
+                <Label Grid.Column="1" Text="{loc:Tr HelpVisual_DeleteOldBackupsLabel}"
                        TextColor="{StaticResource TextSecondaryDark}" FontSize="13" VerticalOptions="Center" />
             </Grid>
             <views:TapHintView HorizontalOptions="Start" VerticalOptions="Start" Margin="6,14,0,0" />
@@ -98,9 +99,9 @@
     <DataTemplate x:Key="HelpVisual.SecretUrlLink">
         <Grid InputTransparent="True" Padding="0,0,0,18">
             <VerticalStackLayout Spacing="2" VerticalOptions="Start">
-                <Label Text="Netflix" FontFamily="OpenSansSemibold" FontSize="15"
+                <Label Text="{loc:Tr HelpVisual_SampleItemName}" FontFamily="OpenSansSemibold" FontSize="15"
                        TextColor="{StaticResource TextPrimaryDark}" />
-                <Label Text="netflix.com" FontSize="13" TextColor="{StaticResource PrimaryDark}" />
+                <Label Text="{loc:Tr HelpVisual_SampleItemUrl}" FontSize="13" TextColor="{StaticResource PrimaryDark}" />
             </VerticalStackLayout>
             <views:TapHintView HorizontalOptions="Start" VerticalOptions="Start" Margin="16,20,0,0" />
         </Grid>
@@ -111,13 +112,13 @@
             <Border Style="{StaticResource CardBorderStyle}" VerticalOptions="Start">
                 <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
                     <VerticalStackLayout Grid.Column="0" Spacing="4" VerticalOptions="Center">
-                        <Label Text="SENHA" Style="{StaticResource FieldLabelStyle}" />
+                        <Label Text="{loc:Tr ItemEditor_PasswordLabel}" Style="{StaticResource FieldLabelStyle}" />
                         <Label Text="&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;"
                                TextColor="{StaticResource TextPrimaryDark}" FontSize="15" />
                     </VerticalStackLayout>
                     <Button Grid.Column="1" Text="&#128065;" BackgroundColor="{StaticResource SurfaceDark}"
                             WidthRequest="36" HeightRequest="36" Padding="0" FontSize="14" VerticalOptions="Center" />
-                    <Button Grid.Column="2" Text="Copiar" BackgroundColor="{StaticResource SurfaceDark}"
+                    <Button Grid.Column="2" Text="{loc:Tr Common_Copy}" BackgroundColor="{StaticResource SurfaceDark}"
                             TextColor="{StaticResource TextPrimaryDark}" FontSize="12" HeightRequest="36"
                             VerticalOptions="Center" />
                 </Grid>
@@ -132,13 +133,13 @@
                 <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
                     <Border Grid.Column="0" WidthRequest="36" HeightRequest="36" StrokeShape="RoundRectangle 11"
                             BackgroundColor="{StaticResource Tertiary}" StrokeThickness="0">
-                        <Label Text="N" TextColor="{StaticResource White}" FontFamily="OpenSansSemibold"
+                        <Label Text="{loc:Tr HelpVisual_SampleItemInitial}" TextColor="{StaticResource White}" FontFamily="OpenSansSemibold"
                                FontSize="14" HorizontalOptions="Center" VerticalOptions="Center" />
                     </Border>
                     <VerticalStackLayout Grid.Column="1" VerticalOptions="Center" Spacing="1">
-                        <Label Text="Netflix" FontFamily="OpenSansSemibold" FontSize="14.5"
+                        <Label Text="{loc:Tr HelpVisual_SampleItemName}" FontFamily="OpenSansSemibold" FontSize="14.5"
                                TextColor="{StaticResource TextPrimaryDark}" />
-                        <Label Text="netflix.com" FontSize="12" TextColor="{StaticResource TextSecondaryDark}" />
+                        <Label Text="{loc:Tr HelpVisual_SampleItemUrl}" FontSize="12" TextColor="{StaticResource TextSecondaryDark}" />
                     </VerticalStackLayout>
                     <Label Grid.Column="2" Text="&#9733;" FontSize="20" TextColor="{StaticResource FavoriteGold}"
                            VerticalOptions="Center" />
@@ -154,18 +155,18 @@
     <DataTemplate x:Key="HelpVisual.BackupCard">
         <Border InputTransparent="True" Style="{StaticResource CardBorderStyle}">
             <VerticalStackLayout Spacing="6">
-                <Label Text="Cofre pessoal" FontFamily="OpenSansSemibold" FontSize="14"
+                <Label Text="{loc:Tr HelpVisual_SampleVaultName}" FontFamily="OpenSansSemibold" FontSize="14"
                        TextColor="{StaticResource TextPrimaryDark}" />
-                <Label Text="BKP - Cofre pessoal.GDSBX - 2026-09-02 14-30-12.bak" FontSize="12"
+                <Label Text="{loc:Tr HelpVisual_SampleBackupFileName}" FontSize="12"
                        TextColor="{StaticResource TextSecondaryDark}" LineBreakMode="HeadTruncation" MaxLines="1" />
                 <Label FontSize="12" TextColor="{StaticResource TextMutedDark}">
                     <Label.FormattedText>
                         <FormattedString>
-                            <Span Text="02/09/2026 14:30" />
+                            <Span Text="{loc:Tr HelpVisual_SampleBackupDate}" />
                             <Span Text="  &#183;  " />
-                            <Span Text="12 KB" />
+                            <Span Text="{loc:Tr HelpVisual_SampleBackupSize}" />
                             <Span Text="  &#183;  " />
-                            <Span Text="Automático" />
+                            <Span Text="{loc:Tr HelpVisual_SampleBackupKind}" />
                         </FormattedString>
                     </Label.FormattedText>
                 </Label>
@@ -175,7 +176,7 @@
 
     <DataTemplate x:Key="HelpVisual.RestoreButton">
         <Grid InputTransparent="True" Padding="0,0,0,18" HorizontalOptions="Start">
-            <Button Text="Restaurar" Style="{StaticResource SecondaryActionButtonStyle}"
+            <Button Text="{loc:Tr BackupRecovery_RestoreButton}" Style="{StaticResource SecondaryActionButtonStyle}"
                     WidthRequest="150" HeightRequest="42" VerticalOptions="Start" />
             <views:TapHintView HorizontalOptions="Start" VerticalOptions="Start" Margin="58,14,0,0" />
         </Grid>
@@ -183,7 +184,7 @@
 
     <DataTemplate x:Key="HelpVisual.DeleteBackupButton">
         <Grid InputTransparent="True" Padding="0,0,0,18" HorizontalOptions="Start">
-            <Button Text="Excluir" HeightRequest="42" WidthRequest="150" VerticalOptions="Start"
+            <Button Text="{loc:Tr Common_Delete}" HeightRequest="42" WidthRequest="150" VerticalOptions="Start"
                     BackgroundColor="Transparent" TextColor="{StaticResource Danger}"
                     BorderColor="{StaticResource Danger}" BorderWidth="1" CornerRadius="12"
                     FontFamily="OpenSansSemibold" FontSize="14" />
@@ -193,7 +194,7 @@
 
     <DataTemplate x:Key="HelpVisual.DeleteAllBackupsLink">
         <Grid InputTransparent="True" Padding="0,0,0,18" HorizontalOptions="Start">
-            <Label Text="Excluir todos os backups" TextColor="{StaticResource Danger}" FontSize="13"
+            <Label Text="{loc:Tr BackupRecovery_DeleteAllLink}" TextColor="{StaticResource Danger}" FontSize="13"
                    VerticalOptions="Start" />
             <views:TapHintView HorizontalOptions="Start" VerticalOptions="Start" Margin="58,8,0,0" />
         </Grid>

--- a/src/GDSB.MAUI/UnlockPage.xaml
+++ b/src/GDSB.MAUI/UnlockPage.xaml
@@ -39,16 +39,23 @@
                             BackgroundColor="{StaticResource SurfaceCardDark}" Stroke="{StaticResource BorderStrongDarkBrush}"
                             StrokeThickness="1" StrokeShape="RoundRectangle 17" Padding="12,0"
                             SemanticProperties.Description="{loc:Tr Unlock_LanguagePickerDescription}">
-                        <Picker ItemsSource="{Binding Language.Options}"
-                                ItemDisplayBinding="{Binding DisplayName}"
-                                SelectedItem="{Binding Language.Selected}"
-                                TextColor="{StaticResource TextSecondaryDark}"
-                                BackgroundColor="Transparent"
-                                FontSize="13"
-                                MinimumHeightRequest="34"
-                                MinimumWidthRequest="0"
-                                HorizontalTextAlignment="Center"
-                                VerticalOptions="Center" />
+                        <HorizontalStackLayout Spacing="4" VerticalOptions="Center">
+                            <!-- Glifo do globo: puramente decorativo (o Picker ao lado já carrega a
+                                 descrição semântica da pílula inteira), por isso não entra no
+                                 catálogo - mesmo tratamento dos outros glifos do app (?, *, ←). -->
+                            <Label Text="&#127760;" FontSize="12" TextColor="{StaticResource TextSecondaryDark}"
+                                   VerticalOptions="Center" InputTransparent="True" />
+                            <Picker ItemsSource="{Binding Language.Options}"
+                                    ItemDisplayBinding="{Binding DisplayName}"
+                                    SelectedItem="{Binding Language.Selected}"
+                                    TextColor="{StaticResource TextSecondaryDark}"
+                                    BackgroundColor="Transparent"
+                                    FontSize="13"
+                                    MinimumHeightRequest="34"
+                                    MinimumWidthRequest="0"
+                                    HorizontalTextAlignment="Center"
+                                    VerticalOptions="Center" />
+                        </HorizontalStackLayout>
                     </Border>
 
                     <!-- Porta de entrada do tutorial, não junto dos links de rodapé: quem não

--- a/src/GDSB.MAUI/VaultPage.xaml
+++ b/src/GDSB.MAUI/VaultPage.xaml
@@ -4,6 +4,7 @@
              xmlns:views="clr-namespace:GDSB.MAUI.Views"
              xmlns:behaviors="clr-namespace:GDSB.MAUI.Behaviors"
              xmlns:controls="clr-namespace:GDSB.MAUI.Controls"
+             xmlns:loc="clr-namespace:GDSB.MAUI.Localization"
              x:Class="GDSB.MAUI.VaultPage"
              x:Name="ThisPage"
              BackgroundColor="{StaticResource SurfaceDark}">
@@ -64,12 +65,12 @@
                         </Button>
                     </Grid>
                     <Grid ColumnDefinitions="*,*,Auto" ColumnSpacing="8">
-                        <Button Grid.Column="0" Text="Usuário" FontSize="12.5" HeightRequest="36"
+                        <Button Grid.Column="0" Text="{loc:Tr Vault_CopyUserButton}" FontSize="12.5" HeightRequest="36"
                                 BackgroundColor="{StaticResource SurfaceDark}" TextColor="{StaticResource TextPrimaryDark}"
                                 IsVisible="{Binding HasUser}"
                                 Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.CopyUserCommand}"
                                 CommandParameter="{Binding .}" />
-                        <Button Grid.Column="1" Text="Senha" FontSize="12.5" HeightRequest="36"
+                        <Button Grid.Column="1" Text="{loc:Tr Vault_CopyPasswordButton}" FontSize="12.5" HeightRequest="36"
                                 BackgroundColor="{StaticResource SurfaceDark}" TextColor="{StaticResource TextPrimaryDark}"
                                 Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.CopyPasswordCommand}"
                                 CommandParameter="{Binding .}" />
@@ -137,7 +138,7 @@
                 <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
                     <Border Grid.Column="0" BackgroundColor="{StaticResource SurfaceCardDark}" Stroke="{StaticResource BorderDarkBrush}"
                             StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="44">
-                        <Entry Placeholder="Buscar por nome..." Text="{Binding SearchText}"
+                        <Entry Placeholder="{loc:Tr Vault_SearchPlaceholder}" Text="{Binding SearchText}"
                                TextColor="{StaticResource TextPrimaryDark}" PlaceholderColor="{StaticResource TextMutedDark}"
                                BackgroundColor="Transparent" VerticalOptions="Center" />
                     </Border>
@@ -146,9 +147,9 @@
                             Command="{Binding AddNewItemCommand}" />
                 </Grid>
                 <HorizontalStackLayout Spacing="8">
-                    <controls:SelectableChip Text="Todos" Style="{StaticResource FilterChipStyle}"
+                    <controls:SelectableChip Text="{loc:Tr Vault_FilterAllChip}" Style="{StaticResource FilterChipStyle}"
                             Command="{Binding SetFilterAllCommand}" IsSelected="{Binding IsAllFilterSelected}" />
-                    <controls:SelectableChip Text="Favoritos" Style="{StaticResource FilterChipStyle}"
+                    <controls:SelectableChip Text="{loc:Tr Vault_FilterFavoritesChip}" Style="{StaticResource FilterChipStyle}"
                             Command="{Binding SetFilterFavoritesCommand}" IsSelected="{Binding FilterFavoritesOnly}" />
                 </HorizontalStackLayout>
             </VerticalStackLayout>
@@ -189,7 +190,7 @@
                     <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
                         <Border Grid.Column="0" BackgroundColor="{StaticResource SurfaceCardDark}" Stroke="{StaticResource BorderDarkBrush}"
                                 StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="42">
-                            <Entry Placeholder="Buscar por nome..." Text="{Binding SearchText}"
+                            <Entry Placeholder="{loc:Tr Vault_SearchPlaceholder}" Text="{Binding SearchText}"
                                    TextColor="{StaticResource TextPrimaryDark}" PlaceholderColor="{StaticResource TextMutedDark}"
                                    BackgroundColor="Transparent" VerticalOptions="Center" />
                         </Border>
@@ -198,9 +199,9 @@
                                 Command="{Binding AddNewItemCommand}" />
                     </Grid>
                     <HorizontalStackLayout Spacing="8">
-                        <controls:SelectableChip Text="Todos" Style="{StaticResource FilterChipStyle}"
+                        <controls:SelectableChip Text="{loc:Tr Vault_FilterAllChip}" Style="{StaticResource FilterChipStyle}"
                                 Command="{Binding SetFilterAllCommand}" IsSelected="{Binding IsAllFilterSelected}" />
-                        <controls:SelectableChip Text="Favoritos" Style="{StaticResource FilterChipStyle}"
+                        <controls:SelectableChip Text="{loc:Tr Vault_FilterFavoritesChip}" Style="{StaticResource FilterChipStyle}"
                                 Command="{Binding SetFilterFavoritesCommand}" IsSelected="{Binding FilterFavoritesOnly}" />
                     </HorizontalStackLayout>
                 </VerticalStackLayout>
@@ -215,7 +216,7 @@
                 <ScrollView IsVisible="{Binding ShowItemEditor}">
                     <views:ItemEditorView MaximumWidthRequest="560" HorizontalOptions="Start" />
                 </ScrollView>
-                <Label Text="Selecione um item na lista ao lado ou crie um novo" IsVisible="{Binding ShowEmptyState}"
+                <Label Text="{loc:Tr Vault_EmptyEditorState}" IsVisible="{Binding ShowEmptyState}"
                        TextColor="{StaticResource TextSecondaryDark}" FontSize="14"
                        HorizontalOptions="Center" VerticalOptions="Center" />
             </Grid>

--- a/src/GDSB.MAUI/VaultPage.xaml.cs
+++ b/src/GDSB.MAUI/VaultPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using GDSB.MAUI.ViewModels;
+﻿using GDSB.MAUI.Services;
+using GDSB.MAUI.ViewModels;
 using GDSB.MAUI.Views;
 
 namespace GDSB.MAUI;
@@ -6,12 +7,14 @@ namespace GDSB.MAUI;
 public partial class VaultPage : ContentPage
 {
     private readonly VaultViewModel _viewModel;
+    private readonly ILocalizationService _localization;
     private CancellationTokenSource? _toastCts;
 
-    public VaultPage(VaultViewModel viewModel)
+    public VaultPage(VaultViewModel viewModel, ILocalizationService localization)
     {
         InitializeComponent();
         _viewModel = viewModel;
+        _localization = localization;
         BindingContext = _viewModel;
         _viewModel.ToastRequested += OnToastRequested;
         _viewModel.SecretCreated += OnSecretCreated;
@@ -75,12 +78,12 @@ public partial class VaultPage : ContentPage
     // gerado - mesmo caso de HasErrorMessage/CanInteract em VaultSettingsViewModel.
 #pragma warning disable S2325
     private async void OnSecretCreated(object? sender, EventArgs e)
-        => await SealOverlay.PlayAsync(LockSealMode.Create, "Segredo guardado", 760);
+        => await SealOverlay.PlayAsync(LockSealMode.Create, _localization.Get("Seal_SecretCreated"), 760);
 
     private async void OnSecretUpdated(object? sender, EventArgs e)
-        => await SealOverlay.PlayAsync(LockSealMode.Update, "Alterações salvas", 620);
+        => await SealOverlay.PlayAsync(LockSealMode.Update, _localization.Get("Seal_SettingsSaved"), 620);
 
     private async void OnSecretDeleted(object? sender, EventArgs e)
-        => await SealOverlay.PlayAsync(LockSealMode.Delete, "Segredo excluído", 740);
+        => await SealOverlay.PlayAsync(LockSealMode.Delete, _localization.Get("Seal_SecretDeleted"), 740);
 #pragma warning restore S2325
 }

--- a/src/GDSB.MAUI/VaultSettingsPage.xaml
+++ b/src/GDSB.MAUI/VaultSettingsPage.xaml
@@ -5,6 +5,7 @@
              xmlns:controls="clr-namespace:GDSB.MAUI.Controls"
              xmlns:converters="clr-namespace:GDSB.MAUI.Converters"
              xmlns:views="clr-namespace:GDSB.MAUI.Views"
+             xmlns:loc="clr-namespace:GDSB.MAUI.Localization"
              x:Class="GDSB.MAUI.VaultSettingsPage"
              Shell.NavBarIsVisible="False"
              BackgroundColor="{StaticResource SurfaceDark}">
@@ -17,8 +18,14 @@
         <ScrollView>
             <Grid RowDefinitions="Auto,*" Padding="32">
 
-                <Label Grid.Row="0" Text="&#8592; Voltar" TextColor="{StaticResource TextSecondaryDark}"
+                <Label Grid.Row="0" TextColor="{StaticResource TextSecondaryDark}"
                        FontSize="14" Margin="0,8,0,0" behaviors:HoverCursor.IsHand="True">
+                    <Label.FormattedText>
+                        <FormattedString>
+                            <Span Text="&#8592; " />
+                            <Span Text="{loc:Tr Common_Back}" />
+                        </FormattedString>
+                    </Label.FormattedText>
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer Command="{Binding GoBackCommand}" />
                     </Label.GestureRecognizers>
@@ -26,7 +33,7 @@
 
                 <VerticalStackLayout Grid.Row="1" Spacing="20" Margin="0,20,0,0">
 
-                    <Label Text="Editar cofre" FontSize="22" FontFamily="OpenSansSemibold"
+                    <Label Text="{loc:Tr VaultSettings_Title}" FontSize="22" FontFamily="OpenSansSemibold"
                            TextColor="{StaticResource TextPrimaryDark}" />
 
                     <!-- Oferta condicional: aparece só depois de salvar nome ou senha, que mexem no
@@ -37,14 +44,14 @@
                     <Border Style="{StaticResource CardBorderStyle}" Padding="18" StrokeShape="RoundRectangle 16"
                             IsVisible="{Binding ShowSaveAsNewFileOffer}">
                         <VerticalStackLayout Spacing="12">
-                            <Label Text="Salvar também num arquivo novo?" FontFamily="OpenSansSemibold" FontSize="15"
+                            <Label Text="{loc:Tr SaveAsNewFile_Title}" FontFamily="OpenSansSemibold" FontSize="15"
                                    TextColor="{StaticResource TextPrimaryDark}" />
-                            <Label Text="O arquivo atual já foi gravado com a mudança. Você também pode salvar uma cópia num arquivo novo, mantendo o original intacto. Ao salvar, a sessão é encerrada e você escolhe qual dos dois abrir na tela de desbloqueio."
+                            <Label Text="{loc:Tr SaveAsNewFile_Body}"
                                    TextColor="{StaticResource TextSecondaryDark}" FontSize="13" />
                             <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
-                                <Button Grid.Column="0" Text="Não, obrigado" Style="{StaticResource SecondaryActionButtonStyle}"
+                                <Button Grid.Column="0" Text="{loc:Tr SaveAsNewFile_DeclineButton}" Style="{StaticResource SecondaryActionButtonStyle}"
                                         Command="{Binding DeclineSaveAsNewFileCommand}" />
-                                <Button Grid.Column="1" Text="Salvar como novo arquivo" Style="{StaticResource PrimaryActionButtonStyle}"
+                                <Button Grid.Column="1" Text="{loc:Tr SaveAsNewFile_AcceptButton}" Style="{StaticResource PrimaryActionButtonStyle}"
                                         HeightRequest="46" Command="{Binding AcceptSaveAsNewFileCommand}" />
                             </Grid>
                         </VerticalStackLayout>
@@ -56,7 +63,7 @@
                     <!-- Bloco 1: nome -->
                     <Border Style="{StaticResource CardBorderStyle}" Padding="22" StrokeShape="RoundRectangle 20">
                         <VerticalStackLayout Spacing="14">
-                            <views:FieldLabelView Text="NOME DO COFRE" HelpTopicId="vault.name" />
+                            <views:FieldLabelView Text="{loc:Tr Vault_NameFieldLabel}" HelpTopicId="vault.name" />
                             <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                                     StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="48">
                                 <Entry Text="{Binding VaultName}" TextColor="{StaticResource TextPrimaryDark}"
@@ -65,7 +72,7 @@
                             </Border>
                             <Label Text="{Binding NameErrorMessage}" TextColor="{StaticResource Danger}" FontSize="13"
                                    IsVisible="{Binding HasNameErrorMessage}" />
-                            <Button Text="Salvar nome" Style="{StaticResource PrimaryActionButtonStyle}" HeightRequest="46"
+                            <Button Text="{loc:Tr VaultSettings_SaveNameButton}" Style="{StaticResource PrimaryActionButtonStyle}" HeightRequest="46"
                                     Command="{Binding SaveNameCommand}" IsEnabled="{Binding CanInteract}" />
                         </VerticalStackLayout>
                     </Border>
@@ -74,23 +81,23 @@
                     <Border Style="{StaticResource CardBorderStyle}" Padding="22" StrokeShape="RoundRectangle 20">
                         <VerticalStackLayout Spacing="18">
 
-                            <views:FieldLabelView Text="PROTEÇÕES" HelpTopicId="vault.protections" />
+                            <views:FieldLabelView Text="{loc:Tr Protections_SectionLabel}" HelpTopicId="vault.protections" />
 
                             <VerticalStackLayout Spacing="6">
                                 <Grid ColumnDefinitions="*,Auto">
-                                    <Label Grid.Column="0" Text="Limpar a área de transferência"
+                                    <Label Grid.Column="0" Text="{loc:Tr Protections_ClipboardClearLabel}"
                                            TextColor="{StaticResource TextPrimaryDark}" FontSize="14" VerticalOptions="Center" />
                                     <Switch Grid.Column="1" IsToggled="{Binding ClipboardClearEnabled}"
                                             OnColor="{StaticResource Primary}" />
                                 </Grid>
                                 <HorizontalStackLayout Spacing="8" IsVisible="{Binding ClipboardClearEnabled}">
-                                    <controls:SelectableChip Text="20s" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Protections_ClipboardChip20s}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectClipboardClearSecondsCommand}" CommandParameter="20"
                                             IsSelected="{Binding ClipboardClearSeconds, Converter={StaticResource EqualsConverter}, ConverterParameter=20}" />
-                                    <controls:SelectableChip Text="45s" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Protections_ClipboardChip45s}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectClipboardClearSecondsCommand}" CommandParameter="45"
                                             IsSelected="{Binding ClipboardClearSeconds, Converter={StaticResource EqualsConverter}, ConverterParameter=45}" />
-                                    <controls:SelectableChip Text="90s" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Protections_ClipboardChip90s}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectClipboardClearSecondsCommand}" CommandParameter="90"
                                             IsSelected="{Binding ClipboardClearSeconds, Converter={StaticResource EqualsConverter}, ConverterParameter=90}" />
                                 </HorizontalStackLayout>
@@ -100,31 +107,31 @@
 
                             <VerticalStackLayout Spacing="6">
                                 <Grid ColumnDefinitions="*,Auto">
-                                    <Label Grid.Column="0" Text="Bloqueio automático"
+                                    <Label Grid.Column="0" Text="{loc:Tr Protections_AutoLockLabel}"
                                            TextColor="{StaticResource TextPrimaryDark}" FontSize="14" VerticalOptions="Center" />
                                     <Switch Grid.Column="1" IsToggled="{Binding AutoLockEnabled}"
                                             OnColor="{StaticResource Primary}" />
                                 </Grid>
-                                <Label Text="Desligar deixa o cofre aberto indefinidamente em segundo plano."
+                                <Label Text="{loc:Tr Protections_AutoLockWarning}"
                                        TextColor="{StaticResource Danger}" FontSize="12"
                                        IsVisible="{Binding AutoLockEnabled, Converter={StaticResource InvertedBoolConverter}}" />
                                 <HorizontalStackLayout Spacing="8" IsVisible="{Binding AutoLockEnabled}">
-                                    <controls:SelectableChip Text="1 min" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Protections_AutoLockChip1min}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="1"
                                             IsSelected="{Binding AutoLockMinutes, Converter={StaticResource EqualsConverter}, ConverterParameter=1}" />
-                                    <controls:SelectableChip Text="2 min" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Protections_AutoLockChip2min}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="2"
                                             IsSelected="{Binding AutoLockMinutes, Converter={StaticResource EqualsConverter}, ConverterParameter=2}" />
-                                    <controls:SelectableChip Text="5 min" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Protections_AutoLockChip5min}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="5"
                                             IsSelected="{Binding AutoLockMinutes, Converter={StaticResource EqualsConverter}, ConverterParameter=5}" />
-                                    <controls:SelectableChip Text="15 min" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Protections_AutoLockChip15min}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectAutoLockMinutesCommand}" CommandParameter="15"
                                             IsSelected="{Binding AutoLockMinutes, Converter={StaticResource EqualsConverter}, ConverterParameter=15}" />
                                 </HorizontalStackLayout>
                             </VerticalStackLayout>
 
-                            <Button Text="Salvar proteções" Style="{StaticResource PrimaryActionButtonStyle}" HeightRequest="46"
+                            <Button Text="{loc:Tr VaultSettings_SaveProtectionsButton}" Style="{StaticResource PrimaryActionButtonStyle}" HeightRequest="46"
                                     Command="{Binding SaveProtectionsCommand}" IsEnabled="{Binding CanInteract}" />
 
                         </VerticalStackLayout>
@@ -134,16 +141,16 @@
                     <Border Style="{StaticResource CardBorderStyle}" Padding="22" StrokeShape="RoundRectangle 20">
                         <VerticalStackLayout Spacing="18">
 
-                            <views:FieldLabelView Text="BACKUPS" HelpTopicId="vault.backups" />
+                            <views:FieldLabelView Text="{loc:Tr Backups_SectionLabel}" HelpTopicId="vault.backups" />
 
                             <VerticalStackLayout Spacing="6">
-                                <Label Text="Manter quantas versões"
+                                <Label Text="{loc:Tr Backups_RetentionQuestion}"
                                        TextColor="{StaticResource TextPrimaryDark}" FontSize="14" />
                                 <HorizontalStackLayout Spacing="8">
-                                    <controls:SelectableChip Text="Por quantidade" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Backups_ModeByCountChip}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectBackupRetentionModeCountCommand}"
                                             IsSelected="{Binding IsBackupRetentionByCount}" />
-                                    <controls:SelectableChip Text="Por tempo" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Backups_ModeByDaysChip}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectBackupRetentionModeDaysCommand}"
                                             IsSelected="{Binding IsBackupRetentionByDays}" />
                                 </HorizontalStackLayout>
@@ -164,29 +171,29 @@
                                 </HorizontalStackLayout>
 
                                 <HorizontalStackLayout Spacing="8" IsVisible="{Binding IsBackupRetentionByDays}">
-                                    <controls:SelectableChip Text="3 dias" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Backups_DaysChip3}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="3"
                                             IsSelected="{Binding BackupRetentionDays, Converter={StaticResource EqualsConverter}, ConverterParameter=3}" />
-                                    <controls:SelectableChip Text="5 dias" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Backups_DaysChip5}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="5"
                                             IsSelected="{Binding BackupRetentionDays, Converter={StaticResource EqualsConverter}, ConverterParameter=5}" />
-                                    <controls:SelectableChip Text="15 dias" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Backups_DaysChip15}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="15"
                                             IsSelected="{Binding BackupRetentionDays, Converter={StaticResource EqualsConverter}, ConverterParameter=15}" />
-                                    <controls:SelectableChip Text="30 dias" Style="{StaticResource FilterChipStyle}"
+                                    <controls:SelectableChip Text="{loc:Tr Backups_DaysChip30}" Style="{StaticResource FilterChipStyle}"
                                             Command="{Binding SelectBackupRetentionDaysCommand}" CommandParameter="30"
                                             IsSelected="{Binding BackupRetentionDays, Converter={StaticResource EqualsConverter}, ConverterParameter=30}" />
                                 </HorizontalStackLayout>
 
-                                <Label Text="Ao passar do limite de versões, a mais antiga é apagada. A versão mais recente nunca é apagada."
+                                <Label Text="{loc:Tr Backups_RetentionByCountNote}"
                                        TextColor="{StaticResource TextSecondaryDark}" FontSize="12"
                                        IsVisible="{Binding IsBackupRetentionByCount}" />
-                                <Label Text="Backups mais antigos que o limite escolhido são apagados. A versão mais recente nunca é apagada."
+                                <Label Text="{loc:Tr Backups_RetentionByDaysNote}"
                                        TextColor="{StaticResource TextSecondaryDark}" FontSize="12"
                                        IsVisible="{Binding IsBackupRetentionByDays}" />
                             </VerticalStackLayout>
 
-                            <Button Text="Salvar backups" Style="{StaticResource PrimaryActionButtonStyle}" HeightRequest="46"
+                            <Button Text="{loc:Tr VaultSettings_SaveBackupsButton}" Style="{StaticResource PrimaryActionButtonStyle}" HeightRequest="46"
                                     Command="{Binding SaveProtectionsCommand}" IsEnabled="{Binding CanInteract}" />
 
                         </VerticalStackLayout>
@@ -196,11 +203,11 @@
                     <Border Style="{StaticResource CardBorderStyle}" Padding="22" StrokeShape="RoundRectangle 20">
                         <VerticalStackLayout Spacing="14">
 
-                            <views:FieldLabelView Text="TROCAR SENHA MESTRA"
+                            <views:FieldLabelView Text="{loc:Tr VaultSettings_ChangePasswordTitle}"
                                                   HelpTopicId="vault.changeMasterUnlockCode" />
 
                             <VerticalStackLayout Spacing="8">
-                                <Label Text="SENHA ATUAL" Style="{StaticResource FieldLabelStyle}" />
+                                <Label Text="{loc:Tr VaultSettings_CurrentPasswordLabel}" Style="{StaticResource FieldLabelStyle}" />
                                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                                         StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="48">
                                     <Entry Text="{Binding CurrentPassword}" IsPassword="True"
@@ -210,18 +217,18 @@
                             </VerticalStackLayout>
 
                             <VerticalStackLayout Spacing="8">
-                                <Label Text="SENHA NOVA" Style="{StaticResource FieldLabelStyle}" />
+                                <Label Text="{loc:Tr VaultSettings_NewPasswordLabel}" Style="{StaticResource FieldLabelStyle}" />
                                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                                         StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="48">
                                     <Entry Text="{Binding NewPassword}" IsPassword="True"
-                                           Placeholder="Mínimo de 8 caracteres"
+                                           Placeholder="{loc:Tr Vault_MinPasswordPlaceholder}"
                                            TextColor="{StaticResource TextPrimaryDark}" PlaceholderColor="{StaticResource TextMutedDark}"
                                            BackgroundColor="Transparent" VerticalOptions="Center" />
                                 </Border>
                             </VerticalStackLayout>
 
                             <VerticalStackLayout Spacing="8">
-                                <Label Text="CONFIRMAR SENHA NOVA" Style="{StaticResource FieldLabelStyle}" />
+                                <Label Text="{loc:Tr VaultSettings_ConfirmNewPasswordLabel}" Style="{StaticResource FieldLabelStyle}" />
                                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                                         StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="48">
                                     <Entry Text="{Binding ConfirmNewPassword}" IsPassword="True"
@@ -233,14 +240,14 @@
 
                             <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
                                 <CheckBox Grid.Column="0" IsChecked="{Binding DeleteOldBackups}" Color="{StaticResource Primary}" />
-                                <Label Grid.Column="1" Text="Excluir os backups antigos deste cofre (continuam cifrados com a senha antiga)"
+                                <Label Grid.Column="1" Text="{loc:Tr VaultSettings_DeleteOldBackupsLabel}"
                                        TextColor="{StaticResource TextSecondaryDark}" FontSize="13" VerticalOptions="Center" />
                             </Grid>
 
                             <Label Text="{Binding PasswordErrorMessage}" TextColor="{StaticResource Danger}" FontSize="13"
                                    IsVisible="{Binding HasPasswordErrorMessage}" />
 
-                            <Button Text="Trocar senha" Style="{StaticResource PrimaryActionButtonStyle}" HeightRequest="46"
+                            <Button Text="{loc:Tr VaultSettings_ChangePasswordButton}" Style="{StaticResource PrimaryActionButtonStyle}" HeightRequest="46"
                                     Command="{Binding ChangePasswordCommand}" IsEnabled="{Binding CanInteract}" />
 
                         </VerticalStackLayout>

--- a/src/GDSB.MAUI/VaultSettingsPage.xaml.cs
+++ b/src/GDSB.MAUI/VaultSettingsPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using GDSB.MAUI.ViewModels;
+﻿using GDSB.MAUI.Services;
+using GDSB.MAUI.ViewModels;
 using GDSB.MAUI.Views;
 
 namespace GDSB.MAUI;
@@ -6,11 +7,13 @@ namespace GDSB.MAUI;
 public partial class VaultSettingsPage : ContentPage
 {
     private readonly VaultSettingsViewModel _viewModel;
+    private readonly ILocalizationService _localization;
 
-    public VaultSettingsPage(VaultSettingsViewModel viewModel)
+    public VaultSettingsPage(VaultSettingsViewModel viewModel, ILocalizationService localization)
     {
         InitializeComponent();
         _viewModel = viewModel;
+        _localization = localization;
         BindingContext = _viewModel;
         _viewModel.SettingsSaved += OnSettingsSaved;
     }
@@ -35,6 +38,6 @@ public partial class VaultSettingsPage : ContentPage
     // VaultSettingsViewModel.
 #pragma warning disable S2325
     private async void OnSettingsSaved(object? sender, EventArgs e)
-        => await SealOverlay.PlayAsync(LockSealMode.Update, "Alterações salvas", 620);
+        => await SealOverlay.PlayAsync(LockSealMode.Update, _localization.Get("Seal_SettingsSaved"), 620);
 #pragma warning restore S2325
 }

--- a/src/GDSB.MAUI/Views/BiometricOptInView.xaml
+++ b/src/GDSB.MAUI/Views/BiometricOptInView.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:loc="clr-namespace:GDSB.MAUI.Localization"
              x:Class="GDSB.MAUI.Views.BiometricOptInView">
 
     <!-- Dialog no lugar de um DisplayAlert nativo, pra manter as cores/estilos do app (o alerta
@@ -20,20 +21,20 @@
                 </Border>
 
                 <VerticalStackLayout Spacing="8">
-                    <Label Text="Desbloqueio por biometria"
+                    <Label Text="{loc:Tr BiometricOptIn_Title}"
                            FontFamily="OpenSansSemibold" FontSize="18"
                            TextColor="{StaticResource TextPrimaryDark}"
                            HorizontalTextAlignment="Center" />
-                    <Label Text="Da próxima vez, use sua digital ou rosto pra abrir este cofre sem digitar a senha. A senha mestra continua funcionando normalmente quando você quiser."
+                    <Label Text="{loc:Tr BiometricOptIn_Body}"
                            FontSize="13.5" TextColor="{StaticResource TextSecondaryDark}"
                            HorizontalTextAlignment="Center" />
                 </VerticalStackLayout>
 
                 <VerticalStackLayout Spacing="10">
-                    <Button Text="Ativar biometria"
+                    <Button Text="{loc:Tr BiometricOptIn_AcceptButton}"
                             Style="{StaticResource PrimaryActionButtonStyle}"
                             Command="{Binding AcceptCommand}" />
-                    <Button Text="Agora não"
+                    <Button Text="{loc:Tr BiometricOptIn_DeclineButton}"
                             Style="{StaticResource SecondaryActionButtonStyle}"
                             Command="{Binding DeclineCommand}" />
                 </VerticalStackLayout>

--- a/src/GDSB.MAUI/Views/FieldLabelView.xaml.cs
+++ b/src/GDSB.MAUI/Views/FieldLabelView.xaml.cs
@@ -1,3 +1,5 @@
+using GDSB.MAUI.Localization;
+
 namespace GDSB.MAUI.Views;
 
 public partial class FieldLabelView : ContentView
@@ -68,8 +70,10 @@ public partial class FieldLabelView : ContentView
 
     /// <summary>
     /// O "?" sozinho não diz nada para um leitor de tela - a descrição precisa citar o campo de
-    /// que ele fala.
+    /// que ele fala. Reavaliado a cada troca de Text (ver OnTextChanged) - como Text já chega
+    /// traduzido via binding "{loc:Tr}", isso também mantém esta descrição em dia numa troca de
+    /// idioma, sem assinar LanguageChanged à parte.
     /// </summary>
     private void RefreshHelpSemantics() =>
-        SemanticProperties.SetDescription(HelpAction, $"Ajuda sobre {Text}");
+        SemanticProperties.SetDescription(HelpAction, LocalizationServiceLocator.Resolve().Format("A11y_HelpAbout", Text));
 }

--- a/src/GDSB.MAUI/Views/HelpButton.cs
+++ b/src/GDSB.MAUI/Views/HelpButton.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.Messaging;
 using GDSB.MAUI.Help;
+using GDSB.MAUI.Localization;
 
 namespace GDSB.MAUI.Views;
 
@@ -30,7 +31,10 @@ public class HelpButton : Button
     public HelpButton()
     {
         IsVisible = false;
-        SemanticProperties.SetDescription(this, "Ajuda");
+        // Setado uma vez, na construção - resolvido fora da DI porque o XAML instancia este
+        // controle direto (ver LocalizationServiceLocator). Não reage a uma troca de idioma
+        // durante a vida do botão: é texto só de leitor de tela, e o "?" visível não muda.
+        SemanticProperties.SetDescription(this, LocalizationServiceLocator.Resolve().Get("A11y_HelpButtonDescription"));
         Clicked += OnClicked;
     }
 

--- a/src/GDSB.MAUI/Views/HelpSheetView.xaml
+++ b/src/GDSB.MAUI/Views/HelpSheetView.xaml
@@ -10,6 +10,7 @@
 -->
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:loc="clr-namespace:GDSB.MAUI.Localization"
              x:Class="GDSB.MAUI.Views.HelpSheetView">
 
     <Grid x:Name="Overlay" IsVisible="False" BackgroundColor="#CC141414" Padding="20,44">
@@ -25,7 +26,7 @@
                     <VerticalStackLayout x:Name="BlocksHost" Spacing="14" />
                 </ScrollView>
 
-                <Button Grid.Row="2" Text="Entendi" Style="{StaticResource PrimaryActionButtonStyle}"
+                <Button Grid.Row="2" Text="{loc:Tr HelpSheet_DismissButton}" Style="{StaticResource PrimaryActionButtonStyle}"
                         Clicked="OnDismissClicked" />
 
             </Grid>

--- a/src/GDSB.MAUI/Views/ItemEditorView.xaml
+++ b/src/GDSB.MAUI/Views/ItemEditorView.xaml
@@ -9,6 +9,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:behaviors="clr-namespace:GDSB.MAUI.Behaviors"
              xmlns:views="clr-namespace:GDSB.MAUI.Views"
+             xmlns:loc="clr-namespace:GDSB.MAUI.Localization"
              x:Class="GDSB.MAUI.Views.ItemEditorView">
 
     <VerticalStackLayout Spacing="16">
@@ -43,10 +44,10 @@
             <Border Style="{StaticResource CardBorderStyle}" IsVisible="{Binding SelectedItem.HasUser}">
                 <Grid ColumnDefinitions="*,Auto">
                     <VerticalStackLayout Grid.Column="0" Spacing="4" VerticalOptions="Center">
-                        <Label Text="USUÁRIO" Style="{StaticResource FieldLabelStyle}" />
+                        <Label Text="{loc:Tr ItemEditor_UserLabel}" Style="{StaticResource FieldLabelStyle}" />
                         <Label Text="{Binding SelectedItem.User}" TextColor="{StaticResource TextPrimaryDark}" FontSize="15" />
                     </VerticalStackLayout>
-                    <Button Grid.Column="1" Text="Copiar"
+                    <Button Grid.Column="1" Text="{loc:Tr Common_Copy}"
                             Command="{Binding CopyUserCommand}" CommandParameter="{Binding SelectedItem}"
                             BackgroundColor="{StaticResource SurfaceDark}" TextColor="{StaticResource TextPrimaryDark}"
                             FontSize="12" HeightRequest="36" VerticalOptions="Center" />
@@ -56,14 +57,14 @@
             <Border Style="{StaticResource CardBorderStyle}">
                 <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
                     <VerticalStackLayout Grid.Column="0" Spacing="4" VerticalOptions="Center">
-                        <Label Text="SENHA" Style="{StaticResource FieldLabelStyle}" />
+                        <Label Text="{loc:Tr ItemEditor_PasswordLabel}" Style="{StaticResource FieldLabelStyle}" />
                         <Label Text="{Binding PasswordDisplay}" TextColor="{StaticResource TextPrimaryDark}" FontSize="15" />
                     </VerticalStackLayout>
                     <Button Grid.Column="1" Text="{Binding RevealPasswordGlyph}"
                             Command="{Binding ToggleRevealPasswordCommand}"
                             BackgroundColor="{StaticResource SurfaceDark}" WidthRequest="36" HeightRequest="36"
                             Padding="0" FontSize="14" VerticalOptions="Center" />
-                    <Button Grid.Column="2" Text="Copiar"
+                    <Button Grid.Column="2" Text="{loc:Tr Common_Copy}"
                             Command="{Binding CopyPasswordCommand}" CommandParameter="{Binding SelectedItem}"
                             BackgroundColor="{StaticResource SurfaceDark}" TextColor="{StaticResource TextPrimaryDark}"
                             FontSize="12" HeightRequest="36" VerticalOptions="Center" />
@@ -72,7 +73,7 @@
 
             <Border Style="{StaticResource CardBorderStyle}" IsVisible="{Binding SelectedItem.HasObs}">
                 <VerticalStackLayout Spacing="4">
-                    <Label Text="OBSERVAÇÕES" Style="{StaticResource FieldLabelStyle}" />
+                    <Label Text="{loc:Tr ItemEditor_ObsLabel}" Style="{StaticResource FieldLabelStyle}" />
                     <Label Text="{Binding SelectedItem.Obs}" TextColor="{StaticResource TextPrimaryDark}" FontSize="14" />
                 </VerticalStackLayout>
             </Border>
@@ -82,9 +83,9 @@
                 <VerticalStackLayout Spacing="12">
                     <Label Text="{Binding ConfirmDeleteMessage}" TextColor="{StaticResource TextPrimaryDark}" FontSize="14" />
                     <HorizontalStackLayout Spacing="10">
-                        <Button Text="Cancelar" Style="{StaticResource SecondaryActionButtonStyle}"
+                        <Button Text="{loc:Tr Common_Cancel}" Style="{StaticResource SecondaryActionButtonStyle}"
                                 Command="{Binding CancelDeleteCommand}" HeightRequest="40" />
-                        <Button Text="Excluir" BackgroundColor="{StaticResource Danger}" TextColor="{StaticResource White}"
+                        <Button Text="{loc:Tr Common_Delete}" BackgroundColor="{StaticResource Danger}" TextColor="{StaticResource White}"
                                 CornerRadius="10" HeightRequest="40" FontFamily="OpenSansSemibold"
                                 Command="{Binding ConfirmDeleteCommand}" CommandParameter="{Binding SelectedItem}" />
                     </HorizontalStackLayout>
@@ -92,9 +93,9 @@
             </Border>
 
             <HorizontalStackLayout Spacing="12" IsVisible="{Binding ShowItemActions}">
-                <Button Text="Editar" Style="{StaticResource SecondaryActionButtonStyle}"
+                <Button Text="{loc:Tr ItemEditor_EditButton}" Style="{StaticResource SecondaryActionButtonStyle}"
                         Command="{Binding EditItemCommand}" CommandParameter="{Binding SelectedItem}" />
-                <Button Text="Excluir" Style="{StaticResource SecondaryActionButtonStyle}" TextColor="{StaticResource Danger}"
+                <Button Text="{loc:Tr Common_Delete}" Style="{StaticResource SecondaryActionButtonStyle}" TextColor="{StaticResource Danger}"
                         BorderColor="{StaticResource Danger}" Command="{Binding PromptDeleteCommand}" />
             </HorizontalStackLayout>
 
@@ -104,27 +105,27 @@
         <VerticalStackLayout Spacing="16" IsVisible="{Binding IsEditingItem}">
 
             <VerticalStackLayout Spacing="8">
-                <views:FieldLabelView Text="NOME" IsRequired="True" />
+                <views:FieldLabelView Text="{loc:Tr ItemEditor_NameFieldLabel}" IsRequired="True" />
                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                         StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="46">
-                    <Entry Text="{Binding EditBoxName}" Placeholder="Ex.: Netflix"
+                    <Entry Text="{Binding EditBoxName}" Placeholder="{loc:Tr ItemEditor_NamePlaceholder}"
                            TextColor="{StaticResource TextPrimaryDark}" PlaceholderColor="{StaticResource TextMutedDark}"
                            BackgroundColor="Transparent" VerticalOptions="Center" />
                 </Border>
             </VerticalStackLayout>
 
             <VerticalStackLayout Spacing="8">
-                <views:FieldLabelView Text="URL" HelpTopicId="secret.url" />
+                <views:FieldLabelView Text="{loc:Tr ItemEditor_UrlFieldLabel}" HelpTopicId="secret.url" />
                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                         StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="46">
-                    <Entry Text="{Binding EditUrl}" Placeholder="site.com" Keyboard="Url"
+                    <Entry Text="{Binding EditUrl}" Placeholder="{loc:Tr ItemEditor_UrlPlaceholder}" Keyboard="Url"
                            TextColor="{StaticResource TextPrimaryDark}" PlaceholderColor="{StaticResource TextMutedDark}"
                            BackgroundColor="Transparent" VerticalOptions="Center" />
                 </Border>
             </VerticalStackLayout>
 
             <VerticalStackLayout Spacing="8">
-                <views:FieldLabelView Text="USUÁRIO" />
+                <views:FieldLabelView Text="{loc:Tr ItemEditor_UserLabel}" />
                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                         StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="46">
                     <Entry Text="{Binding EditUser}"
@@ -134,7 +135,7 @@
             </VerticalStackLayout>
 
             <VerticalStackLayout Spacing="8">
-                <views:FieldLabelView Text="SENHA" IsRequired="True" HelpTopicId="secret.storedValue" />
+                <views:FieldLabelView Text="{loc:Tr ItemEditor_PasswordLabel}" IsRequired="True" HelpTopicId="secret.storedValue" />
                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                         StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="46">
                     <Entry Text="{Binding EditPassword}" IsPassword="True"
@@ -144,7 +145,7 @@
             </VerticalStackLayout>
 
             <VerticalStackLayout Spacing="8">
-                <views:FieldLabelView Text="OBSERVAÇÕES" />
+                <views:FieldLabelView Text="{loc:Tr ItemEditor_ObsLabel}" />
                 <Border BackgroundColor="{StaticResource SurfaceDark}" Stroke="{StaticResource BorderDarkBrush}"
                         StrokeShape="RoundRectangle 12" Padding="14,10">
                     <Editor Text="{Binding EditObs}" AutoSize="TextChanges" MinimumHeightRequest="72"
@@ -155,20 +156,20 @@
 
             <HorizontalStackLayout Spacing="10">
                 <CheckBox IsChecked="{Binding EditFavorito}" Color="{StaticResource FavoriteGold}" />
-                <Label Text="Marcar como favorito" TextColor="{StaticResource TextPrimaryDark}" FontSize="14" VerticalOptions="Center" />
+                <Label Text="{loc:Tr ItemEditor_FavoriteCheckboxLabel}" TextColor="{StaticResource TextPrimaryDark}" FontSize="14" VerticalOptions="Center" />
                 <views:HelpButton TopicId="secret.favorite" Style="{StaticResource HelpButtonStyle}"
                                   VerticalOptions="Center" />
             </HorizontalStackLayout>
 
-            <Label Text="* campos obrigatórios" Style="{StaticResource RequiredFieldsLegendStyle}" />
+            <Label Text="{loc:Tr Common_RequiredFieldsLegend}" Style="{StaticResource RequiredFieldsLegendStyle}" />
 
             <Label Text="{Binding ValidationError}" TextColor="{StaticResource Danger}" FontSize="13"
                    IsVisible="{Binding HasValidationError}" />
 
             <HorizontalStackLayout Spacing="10">
-                <Button Text="Cancelar" Style="{StaticResource SecondaryActionButtonStyle}"
+                <Button Text="{loc:Tr Common_Cancel}" Style="{StaticResource SecondaryActionButtonStyle}"
                         Command="{Binding CancelEditItemCommand}" />
-                <Button Text="Salvar" Style="{StaticResource PrimaryActionButtonStyle}"
+                <Button Text="{loc:Tr ItemEditor_SaveButton}" Style="{StaticResource PrimaryActionButtonStyle}"
                         Command="{Binding SaveItemCommand}" IsEnabled="{Binding CanInteract}" HeightRequest="46" />
             </HorizontalStackLayout>
 

--- a/src/GDSB.MAUI/Views/OnboardingView.xaml
+++ b/src/GDSB.MAUI/Views/OnboardingView.xaml
@@ -17,6 +17,7 @@
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:views="clr-namespace:GDSB.MAUI.Views"
+             xmlns:loc="clr-namespace:GDSB.MAUI.Localization"
              x:Class="GDSB.MAUI.Views.OnboardingView">
 
     <Grid IsVisible="{Binding IsVisible}" BackgroundColor="#CC141414" Padding="24,40">
@@ -37,12 +38,12 @@
                             <VerticalStackLayout Spacing="6" HorizontalOptions="Center" VerticalOptions="Center">
                                 <GraphicsView x:Name="VaultFileMark" WidthRequest="52" HeightRequest="52"
                                               HorizontalOptions="Center" />
-                                <Label Text="meu-cofre.GDSBX" FontSize="10"
+                                <Label Text="{loc:Tr Onboarding_Slide1SampleFileName}" FontSize="10"
                                        TextColor="{StaticResource TextSecondaryDark}"
                                        HorizontalOptions="Center" />
                             </VerticalStackLayout>
                         </Border>
-                        <Label Text="Um arquivo seu, guardado onde você quiser"
+                        <Label Text="{loc:Tr Onboarding_Slide1Caption}"
                                FontSize="11.5" TextColor="{StaticResource TextMutedDark}"
                                HorizontalOptions="Center" HorizontalTextAlignment="Center" />
                     </VerticalStackLayout>
@@ -52,13 +53,13 @@
                                          IsVisible="{Binding CurrentIndex, Converter={StaticResource EqualsConverter}, ConverterParameter=1}">
                         <Border Style="{StaticResource HelpVisualFrameStyle}" HorizontalOptions="Center">
                             <Grid InputTransparent="True" Padding="0,0,0,20">
-                                <Label Text="Criar um cofre novo" TextColor="{StaticResource PrimaryDark}"
+                                <Label Text="{loc:Tr Unlock_CreateVaultLink}" TextColor="{StaticResource PrimaryDark}"
                                        FontSize="14" VerticalOptions="Start" HorizontalOptions="Center" />
                                 <views:TapHintView HorizontalOptions="Center" VerticalOptions="Start"
                                                    Margin="0,10,0,0" />
                             </Grid>
                         </Border>
-                        <Label Text="É este link, logo abaixo do cartão de senha"
+                        <Label Text="{loc:Tr Onboarding_Slide2Caption}"
                                FontSize="11.5" TextColor="{StaticResource TextMutedDark}"
                                HorizontalOptions="Center" HorizontalTextAlignment="Center" />
                     </VerticalStackLayout>
@@ -74,7 +75,7 @@
                                                            Spacing="9" InputTransparent="True">
                                         <GraphicsView x:Name="BiometricSampleIcon" WidthRequest="18" HeightRequest="18"
                                                       VerticalOptions="Center" />
-                                        <Label Text="Desbloquear com biometria" TextColor="{StaticResource White}"
+                                        <Label Text="{loc:Tr Unlock_UnlockWithBiometricButton}" TextColor="{StaticResource White}"
                                                FontFamily="OpenSansSemibold" FontSize="14" VerticalOptions="Center" />
                                     </HorizontalStackLayout>
                                 </Grid>
@@ -82,7 +83,7 @@
                                                    Margin="0,18,0,0" />
                             </Grid>
                         </Border>
-                        <Label Text="Aparece no lugar do campo de senha depois que você liga a digital"
+                        <Label Text="{loc:Tr Onboarding_Slide3Caption}"
                                FontSize="11.5" TextColor="{StaticResource TextMutedDark}"
                                HorizontalOptions="Center" HorizontalTextAlignment="Center" />
                     </VerticalStackLayout>
@@ -106,7 +107,7 @@
                 <VerticalStackLayout Grid.Row="3" Spacing="10">
                     <Button Text="{Binding AdvanceButtonText}" Style="{StaticResource PrimaryActionButtonStyle}"
                             Command="{Binding AdvanceCommand}" />
-                    <Button Text="Pular" Style="{StaticResource SecondaryActionButtonStyle}"
+                    <Button Text="{loc:Tr Onboarding_SkipButton}" Style="{StaticResource SecondaryActionButtonStyle}"
                             Command="{Binding SkipCommand}" IsVisible="{Binding ShowSkip}" />
                 </VerticalStackLayout>
 

--- a/tests/GDSB.MAUI.Tests/BackupRecoveryViewModelTests.cs
+++ b/tests/GDSB.MAUI.Tests/BackupRecoveryViewModelTests.cs
@@ -23,6 +23,7 @@ namespace GDSB.MAUI.Tests
             public FakeFilePickerService FilePickerService { get; } = new();
             public FakeNavigationService NavigationService { get; } = new();
             public FakeVaultSessionService VaultSessionService { get; } = new();
+            public FakeLocalizationService LocalizationService { get; } = new();
             public BackupRecoveryViewModel ViewModel { get; }
 
             public Profile Profile { get; } = new() { Nome = "Cofre de teste" };
@@ -34,7 +35,8 @@ namespace GDSB.MAUI.Tests
                     ProfileFileService,
                     FilePickerService,
                     NavigationService,
-                    VaultSessionService);
+                    VaultSessionService,
+                    LocalizationService);
 
                 ProfileFileService.OpenHandler = (_, password) => password == VaultUnlockCode
                     ? new ProfileOpenResult(Profile, WasLegacyFormat: false)
@@ -69,7 +71,7 @@ namespace GDSB.MAUI.Tests
             sut.ViewModel.RestorePassword = WrongVaultUnlockCode;
             await sut.ViewModel.ConfirmRestoreCommand.ExecuteAsync(null);
 
-            Assert.Equal("Senha incorreta ou arquivo corrompido.", sut.ViewModel.RestoreErrorMessage);
+            Assert.Equal("Unlock_GenericErrorMessage", sut.ViewModel.RestoreErrorMessage);
             Assert.Empty(sut.ProfileFileService.SaveCalls);
             Assert.Empty(sut.NavigationService.NavigateToRootCalls);
             Assert.True(sut.ViewModel.IsRestoring);

--- a/tests/GDSB.MAUI.Tests/BiometricOptInCoordinatorTests.cs
+++ b/tests/GDSB.MAUI.Tests/BiometricOptInCoordinatorTests.cs
@@ -11,11 +11,12 @@ namespace GDSB.MAUI.Tests
             public FakeBiometricUnlockService BiometricUnlockService { get; } = new();
             public FakeAlertService AlertService { get; } = new();
             public FakePreferencesService PreferencesService { get; } = new();
+            public FakeLocalizationService LocalizationService { get; } = new();
             public BiometricOptInCoordinator Coordinator { get; }
 
             public Sut()
             {
-                Coordinator = new BiometricOptInCoordinator(BiometricUnlockService, AlertService, PreferencesService);
+                Coordinator = new BiometricOptInCoordinator(BiometricUnlockService, AlertService, PreferencesService, LocalizationService);
             }
         }
 

--- a/tests/GDSB.MAUI.Tests/CreateVaultViewModelTests.cs
+++ b/tests/GDSB.MAUI.Tests/CreateVaultViewModelTests.cs
@@ -16,17 +16,19 @@ namespace GDSB.MAUI.Tests
             public FakePreferencesService PreferencesService { get; } = new();
             public FakeAlertService AlertService { get; } = new();
             public FakeVaultSessionService VaultSessionService { get; } = new();
+            public FakeLocalizationService LocalizationService { get; } = new();
             public CreateVaultViewModel ViewModel { get; }
 
             public Sut()
             {
-                var biometricOptIn = new BiometricOptInCoordinator(BiometricUnlockService, AlertService, PreferencesService);
+                var biometricOptIn = new BiometricOptInCoordinator(BiometricUnlockService, AlertService, PreferencesService, LocalizationService);
                 ViewModel = new CreateVaultViewModel(
                     ProfileFileService,
                     FilePickerService,
                     NavigationService,
                     BiometricUnlockService,
                     VaultSessionService,
+                    LocalizationService,
                     biometricOptIn);
             }
         }
@@ -41,7 +43,7 @@ namespace GDSB.MAUI.Tests
 
             await sut.ViewModel.CreateVaultCommand.ExecuteAsync(null);
 
-            Assert.Equal("A senha mestra precisa ter pelo menos 8 caracteres.", sut.ViewModel.ErrorMessage);
+            Assert.Equal("CreateVault_MinPasswordLengthMessage", sut.ViewModel.ErrorMessage);
             Assert.Empty(sut.ProfileFileService.SaveCalls);
         }
 
@@ -55,7 +57,15 @@ namespace GDSB.MAUI.Tests
 
             await sut.ViewModel.CreateVaultCommand.ExecuteAsync(null);
 
-            Assert.Equal("As senhas não coincidem.", sut.ViewModel.ErrorMessage);
+            Assert.Equal("Vault_PasswordsDoNotMatchMessage", sut.ViewModel.ErrorMessage);
+        }
+
+        [Fact]
+        public void NewViewModel_DefaultsVaultNameFromCatalog()
+        {
+            var sut = new Sut();
+
+            Assert.Equal("CreateVault_DefaultVaultName", sut.ViewModel.VaultName);
         }
 
         [Fact]

--- a/tests/GDSB.MAUI.Tests/HelpTopicsTests.cs
+++ b/tests/GDSB.MAUI.Tests/HelpTopicsTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Reflection;
 using GDSB.MAUI.Help;
 using Xunit;
@@ -8,10 +9,21 @@ namespace GDSB.MAUI.Tests
     // são o que segura as regras da rodada: cada id referenciado pelo XAML existe, cada amostra
     // aponta para uma chave declarada e, principalmente, NENHUM tópico é só texto. A regra "cada
     // painel mostra o controle de que fala" fica garantida por teste em vez de por disciplina.
+    //
+    // Fase 4 (multilíngue): HelpTopics.All passou a ler o catálogo na cultura vigente (em vez de
+    // materializar uma vez), então os testes de conteúdo (não só de id/estrutura) rodam nos dois
+    // idiomas - CultureScope troca CultureInfo.CurrentUICulture só pela duração de cada teste, sem
+    // vazar para os outros.
     public class HelpTopicsTests
     {
         private static readonly IReadOnlyList<string> DeclaredTopicIds = StringConstantsOf(typeof(HelpTopics.Ids));
         private static readonly IReadOnlyList<string> DeclaredVisualIds = StringConstantsOf(typeof(HelpVisuals.Ids));
+
+        public static IEnumerable<object[]> BothCultures()
+        {
+            yield return new object[] { "pt-BR" };
+            yield return new object[] { "en-US" };
+        }
 
         [Fact]
         public void Ids_EveryDeclaredTopicId_ExistsInCatalog()
@@ -42,24 +54,30 @@ namespace GDSB.MAUI.Tests
             Assert.Empty(duplicates);
         }
 
-        [Fact]
-        public void All_EveryTopic_HasTitleAndBlocks()
+        [Theory]
+        [MemberData(nameof(BothCultures))]
+        public void All_EveryTopic_HasTitleAndBlocks(string cultureName)
         {
+            using var _ = new CultureScope(cultureName);
+
             Assert.All(HelpTopics.All, topic =>
             {
-                Assert.False(string.IsNullOrWhiteSpace(topic.Title), $"Tópico '{topic.Id}' sem título.");
+                Assert.False(string.IsNullOrWhiteSpace(topic.Title), $"Tópico '{topic.Id}' sem título ({cultureName}).");
                 Assert.NotEmpty(topic.Blocks);
             });
         }
 
         // A regra central da rodada: painel só de texto é considerado incompleto.
-        [Fact]
-        public void All_EveryTopic_HasAtLeastOneVisualBlock()
+        [Theory]
+        [MemberData(nameof(BothCultures))]
+        public void All_EveryTopic_HasAtLeastOneVisualBlock(string cultureName)
         {
+            using var _ = new CultureScope(cultureName);
+
             Assert.All(HelpTopics.All, topic =>
                 Assert.True(
                     topic.Blocks.Any(block => block.Kind == HelpBlockKind.Visual),
-                    $"Tópico '{topic.Id}' não mostra nenhum controle - só descreve."));
+                    $"Tópico '{topic.Id}' não mostra nenhum controle - só descreve ({cultureName})."));
         }
 
         [Fact]
@@ -73,13 +91,16 @@ namespace GDSB.MAUI.Tests
                     $"Tópico '{pair.TopicId}' usa a amostra '{pair.Block.Value}', que não está em HelpVisuals.Ids."));
         }
 
-        [Fact]
-        public void All_EveryVisualBlock_HasCaption()
+        [Theory]
+        [MemberData(nameof(BothCultures))]
+        public void All_EveryVisualBlock_HasCaption(string cultureName)
         {
+            using var _ = new CultureScope(cultureName);
+
             Assert.All(VisualBlocks(), pair =>
                 Assert.False(
                     string.IsNullOrWhiteSpace(pair.Block.Caption),
-                    $"Amostra '{pair.Block.Value}' do tópico '{pair.TopicId}' está sem legenda."));
+                    $"Amostra '{pair.Block.Value}' do tópico '{pair.TopicId}' está sem legenda ({cultureName})."));
         }
 
         // Chave declarada que nenhum tópico usa é DataTemplate morto em HelpVisuals.xaml - some
@@ -100,14 +121,17 @@ namespace GDSB.MAUI.Tests
                 HelpVisuals.All.OrderBy(id => id, StringComparer.Ordinal));
         }
 
-        [Fact]
-        public void All_NoBlock_HasEmptyValue()
+        [Theory]
+        [MemberData(nameof(BothCultures))]
+        public void All_NoBlock_HasEmptyValue(string cultureName)
         {
+            using var _ = new CultureScope(cultureName);
+
             Assert.All(HelpTopics.All, topic =>
                 Assert.All(topic.Blocks, block =>
                     Assert.False(
                         string.IsNullOrWhiteSpace(block.Value),
-                        $"Tópico '{topic.Id}' tem um bloco {block.Kind} vazio.")));
+                        $"Tópico '{topic.Id}' tem um bloco {block.Kind} vazio ({cultureName}).")));
         }
 
         [Fact]
@@ -125,14 +149,41 @@ namespace GDSB.MAUI.Tests
 
         // O "?" único da tela de backup cobre quatro assuntos (como os backups aparecem, restaurar,
         // excluir e excluir todos) - sem Heading, o painel viraria um paredão de texto.
-        [Fact]
-        public void BackupRecovery_IsSplitByHeadings()
+        [Theory]
+        [MemberData(nameof(BothCultures))]
+        public void BackupRecovery_IsSplitByHeadings(string cultureName)
         {
+            using var _ = new CultureScope(cultureName);
+
             Assert.True(HelpTopics.TryGet(HelpTopics.Ids.BackupRecovery, out var topic));
 
             var headings = topic.Blocks.Count(block => block.Kind == HelpBlockKind.Heading);
 
             Assert.Equal(4, headings);
+        }
+
+        // Fase 4: o mesmo tópico sai com texto diferente depois de uma troca de idioma - é a versão
+        // "roda o VM nos dois idiomas" desta suíte, provando que HelpTopics.All não ficou preso na
+        // primeira leitura (o bug que a rodada existe para evitar).
+        [Fact]
+        public void BackupRecovery_Title_DiffersBetweenPtAndEn()
+        {
+            string ptTitle, enTitle;
+
+            using (new CultureScope("pt-BR"))
+            {
+                Assert.True(HelpTopics.TryGet(HelpTopics.Ids.BackupRecovery, out var topic));
+                ptTitle = topic.Title;
+            }
+
+            using (new CultureScope("en-US"))
+            {
+                Assert.True(HelpTopics.TryGet(HelpTopics.Ids.BackupRecovery, out var topic));
+                enTitle = topic.Title;
+            }
+
+            Assert.Equal("Recuperar um backup", ptTitle);
+            Assert.Equal("Recover a backup", enTitle);
         }
 
         private static IEnumerable<(string TopicId, HelpBlock Block)> VisualBlocks() =>
@@ -146,5 +197,31 @@ namespace GDSB.MAUI.Tests
                 .Where(field => field.IsLiteral && field.FieldType == typeof(string))
                 .Select(field => (string)field.GetRawConstantValue()!)
                 .ToList();
+
+        // Troca CultureInfo.CurrentCulture/CurrentUICulture só na thread deste teste, e devolve o
+        // valor original ao sair do using - HelpTopics.All lê CurrentUICulture a cada acesso
+        // (ver o comentário em HelpTopics.cs), então isto basta para exercitar os dois idiomas sem
+        // precisar de ILocalizationService nem vazar estado entre testes.
+        private sealed class CultureScope : IDisposable
+        {
+            private readonly CultureInfo _originalCulture;
+            private readonly CultureInfo _originalUiCulture;
+
+            public CultureScope(string cultureName)
+            {
+                _originalCulture = CultureInfo.CurrentCulture;
+                _originalUiCulture = CultureInfo.CurrentUICulture;
+
+                var culture = new CultureInfo(cultureName);
+                CultureInfo.CurrentCulture = culture;
+                CultureInfo.CurrentUICulture = culture;
+            }
+
+            public void Dispose()
+            {
+                CultureInfo.CurrentCulture = _originalCulture;
+                CultureInfo.CurrentUICulture = _originalUiCulture;
+            }
+        }
     }
 }

--- a/tests/GDSB.MAUI.Tests/OnboardingViewModelTests.cs
+++ b/tests/GDSB.MAUI.Tests/OnboardingViewModelTests.cs
@@ -9,7 +9,7 @@ namespace GDSB.MAUI.Tests
         private static (OnboardingViewModel ViewModel, FakePreferencesService Preferences) Build()
         {
             var preferences = new FakePreferencesService();
-            return (new OnboardingViewModel(preferences), preferences);
+            return (new OnboardingViewModel(preferences, new FakeLocalizationService()), preferences);
         }
 
         [Fact]
@@ -113,13 +113,13 @@ namespace GDSB.MAUI.Tests
             var (viewModel, _) = Build();
 
             Assert.True(viewModel.ShowSkip);
-            Assert.Equal("Próximo", viewModel.AdvanceButtonText);
+            Assert.Equal("Onboarding_AdvanceButtonNext", viewModel.AdvanceButtonText);
 
             viewModel.AdvanceCommand.Execute(null);
             viewModel.AdvanceCommand.Execute(null);
 
             Assert.False(viewModel.ShowSkip);
-            Assert.Equal("Começar", viewModel.AdvanceButtonText);
+            Assert.Equal("Onboarding_AdvanceButtonFinish", viewModel.AdvanceButtonText);
         }
 
         // O link "Como funciona?" é caminho de revisão: quem pediu pra rever quer rever, mesmo já

--- a/tests/GDSB.MAUI.Tests/UnlockViewModelTests.cs
+++ b/tests/GDSB.MAUI.Tests/UnlockViewModelTests.cs
@@ -35,7 +35,7 @@ namespace GDSB.MAUI.Tests
             public Sut()
             {
                 var biometricOptIn = new BiometricOptInCoordinator(BiometricUnlockService, AlertService, PreferencesService, LocalizationService);
-                Onboarding = new OnboardingViewModel(PreferencesService);
+                Onboarding = new OnboardingViewModel(PreferencesService, LocalizationService);
                 Language = new LanguageSelectorViewModel(LocalizationService);
                 ViewModel = new UnlockViewModel(
                     new VaultAccess(ProfileFileService, VaultSessionService),
@@ -337,7 +337,7 @@ namespace GDSB.MAUI.Tests
             var biometricUnlockService = new FakeBiometricUnlockService();
             var alertService = new FakeAlertService();
             var biometricOptIn = new BiometricOptInCoordinator(biometricUnlockService, alertService, preferencesService, localizationService);
-            var onboarding = new OnboardingViewModel(preferencesService);
+            var onboarding = new OnboardingViewModel(preferencesService, localizationService);
             var language = new LanguageSelectorViewModel(localizationService);
             var viewModel = new UnlockViewModel(
                 new VaultAccess(new FakeProfileFileService(), new FakeVaultSessionService()),

--- a/tests/GDSB.MAUI.Tests/UnlockViewModelTests.cs
+++ b/tests/GDSB.MAUI.Tests/UnlockViewModelTests.cs
@@ -1,6 +1,7 @@
 using GDSB.Domain.Entities;
 using GDSB.Domain.Exceptions;
 using GDSB.MAUI.Interfaces;
+using GDSB.MAUI.Localization;
 using GDSB.MAUI.Services;
 using GDSB.MAUI.Tests.Fakes;
 using GDSB.MAUI.ViewModels;
@@ -33,7 +34,7 @@ namespace GDSB.MAUI.Tests
 
             public Sut()
             {
-                var biometricOptIn = new BiometricOptInCoordinator(BiometricUnlockService, AlertService, PreferencesService);
+                var biometricOptIn = new BiometricOptInCoordinator(BiometricUnlockService, AlertService, PreferencesService, LocalizationService);
                 Onboarding = new OnboardingViewModel(PreferencesService);
                 Language = new LanguageSelectorViewModel(LocalizationService);
                 ViewModel = new UnlockViewModel(
@@ -57,7 +58,7 @@ namespace GDSB.MAUI.Tests
 
             await sut.ViewModel.UnlockCommand.ExecuteAsync(null);
 
-            Assert.Equal("Digite a senha mestra do cofre.", sut.ViewModel.ErrorMessage);
+            Assert.Equal("Unlock_EmptyPasswordMessage", sut.ViewModel.ErrorMessage);
             Assert.Empty(sut.NavigationService.NavigateToRootCalls);
         }
 
@@ -108,7 +109,7 @@ namespace GDSB.MAUI.Tests
 
             await sut.ViewModel.PickVaultCommand.ExecuteAsync(null);
 
-            Assert.Equal("Não foi possível abrir o seletor de arquivos.", sut.ViewModel.ErrorMessage);
+            Assert.Equal("Unlock_FilePickerErrorMessage", sut.ViewModel.ErrorMessage);
             Assert.False(sut.ViewModel.HasSelectedVault);
         }
 
@@ -148,7 +149,7 @@ namespace GDSB.MAUI.Tests
 
             await sut.ViewModel.UnlockCommand.ExecuteAsync(null);
 
-            Assert.Equal("Senha incorreta ou arquivo corrompido.", sut.ViewModel.ErrorMessage);
+            Assert.Equal("Unlock_GenericErrorMessage", sut.ViewModel.ErrorMessage);
         }
 
         [Fact]
@@ -324,5 +325,35 @@ namespace GDSB.MAUI.Tests
             Assert.Equal(0, sut.ViewModel.Onboarding.CurrentIndex);
         }
 
+        // Fase 2: usa a LocalizationService de verdade (não o fake, que devolve a própria chave) -
+        // é a prova de ponta a ponta de que uma propriedade calculada de um ViewModel (não só o
+        // catálogo isolado, já coberto por LocalizationServiceTests) muda de texto na troca de
+        // idioma, sem recriar nada.
+        [Fact]
+        public void UnlockButtonText_ReflectsCatalogInBothLanguages()
+        {
+            var preferencesService = new FakePreferencesService();
+            var localizationService = new LocalizationService(preferencesService);
+            var biometricUnlockService = new FakeBiometricUnlockService();
+            var alertService = new FakeAlertService();
+            var biometricOptIn = new BiometricOptInCoordinator(biometricUnlockService, alertService, preferencesService, localizationService);
+            var onboarding = new OnboardingViewModel(preferencesService);
+            var language = new LanguageSelectorViewModel(localizationService);
+            var viewModel = new UnlockViewModel(
+                new VaultAccess(new FakeProfileFileService(), new FakeVaultSessionService()),
+                new FakeFilePickerService(),
+                new FakeNavigationService(),
+                biometricUnlockService,
+                preferencesService,
+                alertService,
+                new UnlockOverlays(biometricOptIn, onboarding, language));
+
+            var ptText = viewModel.UnlockButtonText;
+            localizationService.SetLanguage(AppLanguage.En);
+            var enText = viewModel.UnlockButtonText;
+
+            Assert.Equal("Abrir cofre", ptText);
+            Assert.Equal("Open vault", enText);
+        }
     }
 }

--- a/tests/GDSB.MAUI.Tests/VaultSettingsViewModelTests.cs
+++ b/tests/GDSB.MAUI.Tests/VaultSettingsViewModelTests.cs
@@ -28,11 +28,12 @@ namespace GDSB.MAUI.Tests
             public FakeVaultBackupStore BackupStore { get; } = new();
             public FakeAlertService AlertService { get; } = new();
             public FakePreferencesService PreferencesService { get; } = new();
+            public FakeLocalizationService LocalizationService { get; } = new();
             public VaultSettingsViewModel ViewModel { get; }
 
             public Sut()
             {
-                var biometricOptIn = new BiometricOptInCoordinator(BiometricUnlockService, AlertService, PreferencesService);
+                var biometricOptIn = new BiometricOptInCoordinator(BiometricUnlockService, AlertService, PreferencesService, LocalizationService);
                 ViewModel = new VaultSettingsViewModel(
                     new VaultAccess(ProfileFileService, VaultSessionService),
                     FilePickerService,
@@ -40,6 +41,7 @@ namespace GDSB.MAUI.Tests
                     BiometricUnlockService,
                     BackupStore,
                     AlertService,
+                    LocalizationService,
                     biometricOptIn);
 
                 // Por padrão, reabrir com a senha atual (usado na validação da troca de senha) dá certo.
@@ -186,7 +188,7 @@ namespace GDSB.MAUI.Tests
 
             await sut.ViewModel.ChangePasswordCommand.ExecuteAsync(null);
 
-            Assert.Equal("Senha atual incorreta.", sut.ViewModel.PasswordErrorMessage);
+            Assert.Equal("VaultSettings_WrongCurrentPasswordMessage", sut.ViewModel.PasswordErrorMessage);
             Assert.Empty(sut.ProfileFileService.SaveCalls);
         }
 

--- a/tests/GDSB.MAUI.Tests/VaultViewModelTests.cs
+++ b/tests/GDSB.MAUI.Tests/VaultViewModelTests.cs
@@ -18,11 +18,12 @@ namespace GDSB.MAUI.Tests
             public FakeNavigationService NavigationService { get; } = new();
             public FakeAppLauncherService AppLauncherService { get; } = new();
             public FakeVaultSessionService VaultSessionService { get; } = new();
+            public FakeLocalizationService LocalizationService { get; } = new();
             public VaultViewModel ViewModel { get; }
 
             public Sut()
             {
-                ViewModel = new VaultViewModel(ClipboardService, AlertService, ProfileFileService, NavigationService, AppLauncherService, VaultSessionService);
+                ViewModel = new VaultViewModel(ClipboardService, AlertService, ProfileFileService, NavigationService, AppLauncherService, VaultSessionService, LocalizationService);
             }
 
             public void LoadProfile(Profile profile)
@@ -124,7 +125,7 @@ namespace GDSB.MAUI.Tests
 
             await sut.ViewModel.SaveItemCommand.ExecuteAsync(null);
 
-            Assert.Equal("Informe um nome para o item.", sut.ViewModel.ValidationError);
+            Assert.Equal("Vault_NameValidationMessage", sut.ViewModel.ValidationError);
             Assert.Empty(sut.ProfileFileService.SaveCalls);
         }
 
@@ -187,7 +188,7 @@ namespace GDSB.MAUI.Tests
             await sut.ViewModel.CopyUserCommand.ExecuteAsync(item);
 
             Assert.Equal(new[] { "user" }, sut.ClipboardService.Calls);
-            Assert.Equal("Usuário copiado", toastMessage);
+            Assert.Equal("Vault_UserCopiedToast", toastMessage);
         }
 
         [Fact]
@@ -202,7 +203,7 @@ namespace GDSB.MAUI.Tests
             await sut.ViewModel.CopyPasswordCommand.ExecuteAsync(item);
 
             Assert.Equal(new[] { "pass" }, sut.ClipboardService.Calls);
-            Assert.Equal("Senha copiada", toastMessage);
+            Assert.Equal("Vault_PasswordCopiedToast", toastMessage);
         }
 
         [Fact]


### PR DESCRIPTION
## Resumo

Fases 2 a 5 do plano multilíngue (pt-BR + inglês) descrito em `claude-context.md` e no [artifact do plano](https://claude.ai/code/artifact/f5f89a9f-0e1f-4144-9343-2a673d03adb7). A fase 1 ([PR #23](https://github.com/betinn/GDSB.MAUI/pull/23), já mergeada) provou o mecanismo de troca ao vivo numa tela só (`UnlockPage`); este PR aplica o mesmo padrão (`{loc:Tr Chave}` no XAML, `ILocalizationService` em C#) ao resto do app — migração mecânica, por isso as quatro fases saem num PR só, conforme combinado com o usuário.

- **Fase 2 — XAML restante**: as 9 telas/views que faltavam (`VaultSettingsPage`, `CreateVaultPage`, `BackupRecoveryPage`, `ItemEditorView`, `VaultPage`, `HelpVisuals`, `OnboardingView`, `BiometricOptInView`, `HelpSheetView`) tiveram todo `Text=`/`Placeholder=`/`Span.Text` literal substituído por `{loc:Tr Chave}`, reaproveitando a mesma chave onde o texto se repete entre telas (blocos PROTEÇÕES/BACKUPS compartilhados, réplicas do `HelpVisuals` apontando pra chave da tela real).
- **Fase 3 — ViewModels**: as seis ViewModels do plano (`UnlockViewModel`, `VaultViewModel`, `VaultSettingsViewModel`, `CreateVaultViewModel`, `BackupRecoveryViewModel`, `BiometricOptInCoordinator`) passam a herdar de `LocalizedObject` e a ler mensagens do catálogo em vez de `const string`. `BackupItemViewModel.CreatedAtDisplay`/`SizeDisplay` passam a formatar com `CultureInfo.CurrentCulture` explícito. `VaultBackupNaming.BuildName` (GDSB.Infrastructure) passa a usar `CultureInfo.InvariantCulture` explícito no timestamp do arquivo — o único ponto de risco de corromper dado que o plano pedia para confirmar antes de mexer na cultura da thread.
- **Fase 4 — Ajuda e tutorial**: `HelpTopics.All` deixa de ser materializado uma vez no inicializador estático — passa a reconstruir a partir do catálogo, com cache por cultura. `OnboardingViewModel.Slides`/`AdvanceButtonText` viram propriedades calculadas.
- **Fase 5 — Fechamento**: revisão do inglês inteiro (217 chaves), linha nova no README sobre o idioma configurável, e a tabela de status do `claude-context.md` fechada.

## Detalhes técnicos

- **99 + 48 + 8 = 155 chaves novas** em `AppStrings.resx`/`AppStrings.en.resx` (113 → 217 no total, incluindo as 14 da fase 1), sempre reaproveitando a mesma chave onde o texto é idêntico entre telas/ViewModels (`Common_Cancel`, `Common_Delete`, `Common_Copy`, `Common_Ok`, `Vault_NameRequiredMessage`, `Vault_PasswordsDoNotMatchMessage`, `Vault_ChoosePathErrorMessage`, `Vault_SaveToLocationErrorMessage`, `Vault_GenericSaveErrorMessage`, `Unlock_GenericErrorMessage`, `HelpVisual_SampleBackupKind`...).
- As duas frases com placeholder (confirmação de exclusão de item e mínimo de caracteres da senha) viram `Localization.Format(chave, args)`, com `{0}` posicional em vez de interpolação direta.
- `HelpButton`/`FieldLabelView` (controles instanciados direto pelo XAML, sem DI) resolvem o serviço via um novo `LocalizationServiceLocator`, extraído do que já era privado em `TrExtension` para não duplicar a lógica em três lugares.
- Serviços de plataforma (biometria Android/Windows, seletor de arquivo do Windows) recebem `ILocalizationService` por DI normal.
- `BackupRecoveryViewModel` assina `LanguageChanged` direto (além do que `LocalizedObject` já faz), porque `BackupItemViewModel` não é `ObservableObject` — a troca de idioma reconstrói a coleção inteira em vez de cada item se notificar.
- `"← Voltar"` separado em glifo estático + `Common_Back` via `FormattedText`, nas 3 páginas que tinham o texto colado na seta.
- `CreateVaultViewModel.VaultName` nasce com o default traduzido (`CreateVault_DefaultVaultName`), continua editável e é gravado no arquivo como qualquer nome digitado.

## Verificação

- `grep -nE '(Text|Placeholder)="[^"{]'` em todo `src/GDSB.MAUI/**/*.xaml` só devolve glifos, números soltos de chip e a marca "GDSB".
- Toda chave `{loc:Tr}`/`Localization.Get`/`Localization.Format` usada bate com o `.resx`, e toda chave do `.resx` é usada em algum lugar (217/217, sem órfã).
- `grep -rn 'CultureInfo\|ToString("' src/GDSB.Infrastructure src/GDSB.Domain` só devolve o uso intencional de `CultureInfo.InvariantCulture` em `VaultBackupNaming`.
- `AppStringsTests` confirma que os dois `.resx` têm exatamente as mesmas 217 chaves.
- 11 asserções em 6 arquivos de teste passaram a comparar com a chave do catálogo em vez do literal português (`FakeLocalizationService.Get` devolve a própria chave, de propósito); mais um teste de ponta a ponta com a `LocalizationService` de verdade provando que a mesma propriedade calculada sai diferente nos dois idiomas.
- `HelpTopicsTests`: as suítes de conteúdo viram `[Theory]` parametrizadas por cultura (pt-BR/en-US) via um `CultureScope` local ao teste.
- Nenhum comentário novo cai na armadilha do S1135 (palavra "todo" isolada).

## Test plan

- [x] `dotnet test tests/GDSB.Infrastructure.Tests` — 27 passando
- [x] `dotnet test tests/GDSB.MAUI.Tests` — 127 passando (8 novos: teste de ponta a ponta do `UnlockViewModel` nos dois idiomas, default traduzido do `CreateVaultViewModel`, `BackupRecovery_Title_DiffersBetweenPtAndEn`, e as suítes de `HelpTopicsTests` que viraram `[Theory]`)
- [ ] O build do app (Android/Windows) não compila neste ambiente (sem SDK correspondente) — compensado com verificação estática (XML bem formado, toda chave batendo com o `.resx`) durante as quatro fases; a compilação de verdade fica para o job `build-android` do CI
- [ ] Roteiro manual em aparelho Android (abrir cada tela nos dois idiomas, trocar no meio de um fluxo, matar e reabrir o app) — fora do alcance deste ambiente, listado no artifact do plano

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYd4tkf6rXgqhiL4GFkFQv


---
_Generated by [Claude Code](https://claude.ai/code/session_01VYd4tkf6rXgqhiL4GFkFQv)_