### PR TITLE
Versão discreta no rodapé + fechar editor de item arrastando

### DIFF
--- a/src/GDSB.MAUI.ViewModels/ViewModels/VaultViewModel.cs
+++ b/src/GDSB.MAUI.ViewModels/ViewModels/VaultViewModel.cs
@@ -163,6 +163,8 @@ namespace GDSB.MAUI.ViewModels
         public string EditorHeaderTitle => SelectedItem is null ? Localization.Get("Vault_NewItemTitle") : SelectedItem.BoxName;
 
         public string EditorHeaderInitial => SelectedItem?.Initial ?? "+";
+
+        public bool HasSearchText => !string.IsNullOrEmpty(SearchText);
 #pragma warning restore S2325
 
         public void ApplyQueryAttributes(IDictionary<string, object> query)
@@ -186,7 +188,14 @@ namespace GDSB.MAUI.ViewModels
         public void OnSizeChanged(double width) => IsWideLayout = width >= ResponsiveBreakpoints.TabletMinWidth;
 #pragma warning restore S2325
 
-        partial void OnSearchTextChanged(string value) => RefreshItems();
+        partial void OnSearchTextChanged(string value)
+        {
+            OnPropertyChanged(nameof(HasSearchText));
+            RefreshItems();
+        }
+
+        [RelayCommand]
+        private void ClearSearch() => SearchText = string.Empty;
 
         partial void OnFilterFavoritesOnlyChanged(bool value)
         {

--- a/src/GDSB.MAUI/GDSB.MAUI.csproj
+++ b/src/GDSB.MAUI/GDSB.MAUI.csproj
@@ -31,8 +31,8 @@
 		<ApplicationId>gdsb.app</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
-		<ApplicationVersion>2</ApplicationVersion>
+		<ApplicationDisplayVersion>1.0.6</ApplicationDisplayVersion>
+		<ApplicationVersion>6</ApplicationVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
@@ -44,46 +44,6 @@
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 		<AssemblyName>GDSB</AssemblyName>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-android|AnyCPU'">
-	  <ApplicationVersion>5</ApplicationVersion>
-	  <ApplicationDisplayVersion>1.0.5</ApplicationDisplayVersion>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-ios|AnyCPU'">
-	  <ApplicationVersion>5</ApplicationVersion>
-	  <ApplicationDisplayVersion>1.0.5</ApplicationDisplayVersion>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-maccatalyst|AnyCPU'">
-	  <ApplicationVersion>5</ApplicationVersion>
-	  <ApplicationDisplayVersion>1.0.5</ApplicationDisplayVersion>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-windows10.0.19041.0|AnyCPU'">
-	  <ApplicationVersion>5</ApplicationVersion>
-	  <ApplicationDisplayVersion>1.0.5</ApplicationDisplayVersion>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-android|AnyCPU'">
-	  <ApplicationVersion>5</ApplicationVersion>
-	  <ApplicationDisplayVersion>1.0.5</ApplicationDisplayVersion>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-ios|AnyCPU'">
-	  <ApplicationVersion>5</ApplicationVersion>
-	  <ApplicationDisplayVersion>1.0.5</ApplicationDisplayVersion>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-maccatalyst|AnyCPU'">
-	  <ApplicationVersion>5</ApplicationVersion>
-	  <ApplicationDisplayVersion>1.0.5</ApplicationDisplayVersion>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-windows10.0.19041.0|AnyCPU'">
-	  <ApplicationVersion>5</ApplicationVersion>
-	  <ApplicationDisplayVersion>1.0.5</ApplicationDisplayVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/GDSB.MAUI/UnlockPage.xaml
+++ b/src/GDSB.MAUI/UnlockPage.xaml
@@ -263,5 +263,16 @@
              fica por cima - ele é que explica o que a outra está perguntando. -->
         <views:OnboardingView BindingContext="{Binding Onboarding}" />
 
+        <!-- Rodapé de versão: fora do ScrollView de propósito. Dentro do RootScroll ele entraria na
+             conta do MinimumHeightRequest ajustado no OnSizeAllocated e empurraria a centralização
+             do bloco de desbloqueio; aqui ele fica ancorado no rodapé e nunca rola. InputTransparent
+             para não roubar toque de nada. -->
+        <Label x:Name="VersionLabel"
+               HorizontalOptions="Center" VerticalOptions="End"
+               Margin="0,0,0,10"
+               FontSize="11"
+               TextColor="{StaticResource TextMutedDark}"
+               InputTransparent="True" />
+
     </Grid>
 </ContentPage>

--- a/src/GDSB.MAUI/UnlockPage.xaml.cs
+++ b/src/GDSB.MAUI/UnlockPage.xaml.cs
@@ -21,6 +21,7 @@ public partial class UnlockPage : ContentPage
             StrokeWidth = 1.7f,
             Compact = true,
         };
+        VersionLabel.Text = $"v{AppInfo.Current.VersionString}";
     }
 
     // Mantém o conteúdo com pelo menos a altura visível: assim a linha "*" continua centralizando

--- a/src/GDSB.MAUI/VaultPage.xaml
+++ b/src/GDSB.MAUI/VaultPage.xaml
@@ -151,9 +151,18 @@
                 <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
                     <Border Grid.Column="0" BackgroundColor="{StaticResource SurfaceCardDark}" Stroke="{StaticResource BorderDarkBrush}"
                             StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="44">
-                        <Entry Placeholder="{loc:Tr Vault_SearchPlaceholder}" Text="{Binding SearchText}"
-                               TextColor="{StaticResource TextPrimaryDark}" PlaceholderColor="{StaticResource TextMutedDark}"
-                               BackgroundColor="Transparent" VerticalOptions="Center" />
+                        <Grid ColumnDefinitions="*,Auto">
+                            <Entry Grid.Column="0" Placeholder="{loc:Tr Vault_SearchPlaceholder}" Text="{Binding SearchText}"
+                                   TextColor="{StaticResource TextPrimaryDark}" PlaceholderColor="{StaticResource TextMutedDark}"
+                                   BackgroundColor="Transparent" VerticalOptions="Center" />
+                            <!-- Só aparece com texto digitado: sem isto era preciso apagar letra por letra
+                                 pelo teclado pra limpar a busca. -->
+                            <Button Grid.Column="1" Text="&#10005;" IsVisible="{Binding HasSearchText}"
+                                    Command="{Binding ClearSearchCommand}"
+                                    BackgroundColor="Transparent" TextColor="{StaticResource TextSecondaryDark}"
+                                    WidthRequest="30" HeightRequest="30" Padding="0" FontSize="12"
+                                    VerticalOptions="Center" />
+                        </Grid>
                     </Border>
                     <Button Grid.Column="1" Text="&#43;" FontSize="20" WidthRequest="44" HeightRequest="44" Padding="0"
                             Style="{StaticResource PrimaryActionButtonStyle}"
@@ -221,9 +230,16 @@
                     <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
                         <Border Grid.Column="0" BackgroundColor="{StaticResource SurfaceCardDark}" Stroke="{StaticResource BorderDarkBrush}"
                                 StrokeShape="RoundRectangle 12" Padding="14,0" HeightRequest="42">
-                            <Entry Placeholder="{loc:Tr Vault_SearchPlaceholder}" Text="{Binding SearchText}"
-                                   TextColor="{StaticResource TextPrimaryDark}" PlaceholderColor="{StaticResource TextMutedDark}"
-                                   BackgroundColor="Transparent" VerticalOptions="Center" />
+                            <Grid ColumnDefinitions="*,Auto">
+                                <Entry Grid.Column="0" Placeholder="{loc:Tr Vault_SearchPlaceholder}" Text="{Binding SearchText}"
+                                       TextColor="{StaticResource TextPrimaryDark}" PlaceholderColor="{StaticResource TextMutedDark}"
+                                       BackgroundColor="Transparent" VerticalOptions="Center" />
+                                <Button Grid.Column="1" Text="&#10005;" IsVisible="{Binding HasSearchText}"
+                                        Command="{Binding ClearSearchCommand}"
+                                        BackgroundColor="Transparent" TextColor="{StaticResource TextSecondaryDark}"
+                                        WidthRequest="28" HeightRequest="28" Padding="0" FontSize="11"
+                                        VerticalOptions="Center" />
+                            </Grid>
                         </Border>
                         <Button Grid.Column="1" Text="&#43;" FontSize="18" WidthRequest="42" HeightRequest="42" Padding="0"
                                 Style="{StaticResource PrimaryActionButtonStyle}"

--- a/src/GDSB.MAUI/VaultPage.xaml
+++ b/src/GDSB.MAUI/VaultPage.xaml
@@ -175,15 +175,33 @@
         <!-- Overlay do editor em bottom-sheet (só no layout compacto - no layout largo o editor já
              aparece no painel lateral; sem o IsCompactLayout aqui, isso vazava por cima do painel
              lateral esticado até o fim da janela quando IsEditorOpen ficava true no modo tablet). -->
-        <Grid IsVisible="{Binding IsCompactEditorOpen}" BackgroundColor="#99000000">
+        <Grid x:Name="EditorSheetOverlay" IsVisible="{Binding IsCompactEditorOpen}" BackgroundColor="#99000000">
             <Grid.GestureRecognizers>
                 <TapGestureRecognizer Command="{Binding CloseEditorCommand}" />
             </Grid.GestureRecognizers>
-            <Border VerticalOptions="End" BackgroundColor="{StaticResource SurfaceCardDark}"
-                    StrokeShape="RoundRectangle 22,22,0,0" StrokeThickness="0" Padding="20" MaximumHeightRequest="620">
-                <ScrollView>
-                    <views:ItemEditorView />
-                </ScrollView>
+            <Border x:Name="EditorSheet" VerticalOptions="End" BackgroundColor="{StaticResource SurfaceCardDark}"
+                    StrokeShape="RoundRectangle 22,22,0,0" StrokeThickness="0" Padding="20,6,20,20" MaximumHeightRequest="620">
+                <Grid RowDefinitions="Auto,*">
+
+                    <!-- Faixa de arraste: é aqui, e só aqui, que o PanGestureRecognizer mora. Pôr o
+                         pan no Border inteiro não funcionaria - o ScrollView do formulário consome o
+                         toque vertical antes no Android, e o gesto ficaria morto justamente sobre os
+                         campos. A alça é só a dica visual (InputTransparent): quem recebe o toque é
+                         a faixa inteira, não o traço dela. -->
+                    <Grid Grid.Row="0" HeightRequest="28" BackgroundColor="Transparent">
+                        <Grid.GestureRecognizers>
+                            <PanGestureRecognizer PanUpdated="OnEditorSheetPanUpdated" />
+                        </Grid.GestureRecognizers>
+                        <BoxView WidthRequest="40" HeightRequest="4" CornerRadius="2"
+                                 Color="{StaticResource BorderStrongDark}"
+                                 HorizontalOptions="Center" VerticalOptions="Center" InputTransparent="True" />
+                    </Grid>
+
+                    <ScrollView Grid.Row="1">
+                        <views:ItemEditorView />
+                    </ScrollView>
+
+                </Grid>
             </Border>
         </Grid>
 

--- a/src/GDSB.MAUI/VaultPage.xaml.cs
+++ b/src/GDSB.MAUI/VaultPage.xaml.cs
@@ -111,7 +111,7 @@ public partial class VaultPage : ContentPage
             ResetSheet();
     }
 
-    private void OnEditorSheetPanUpdated(object? sender, PanUpdatedEventArgs e)
+    private async void OnEditorSheetPanUpdated(object? sender, PanUpdatedEventArgs e)
     {
         switch (e.StatusType)
         {
@@ -140,11 +140,16 @@ public partial class VaultPage : ContentPage
             case GestureStatus.Canceled:
                 // TotalY chega zerado no Completed do Android - por isso o deslocamento final usa
                 // o último valor visto no Running, não e.TotalY.
-                SettleEditorSheet(Math.Max(0, _sheetPanStart + _sheetLastTotalY));
+                await SettleEditorSheetAsync(Math.Max(0, _sheetPanStart + _sheetLastTotalY));
                 break;
         }
     }
 
+    // S2325 ("make static") é falso positivo em ApplyEditorSheetOffset/ResetSheet: os dois só
+    // tocam EditorSheet e EditorSheetOverlay, campos de instância gerados por InitializeComponent
+    // a partir do x:Name no XAML - o Sonar não resolve esse tipo de campo. Mesmo caso de
+    // OnSecretCreated/OnSecretUpdated/OnSecretDeleted logo acima.
+#pragma warning disable S2325
     private void ApplyEditorSheetOffset(double offset)
     {
         EditorSheet.TranslationY = offset;
@@ -154,7 +159,15 @@ public partial class VaultPage : ContentPage
         EditorSheetOverlay.BackgroundColor = Color.FromRgba(0, 0, 0, 0.6 * (1 - progress));
     }
 
-    private async void SettleEditorSheet(double offset)
+    private void ResetSheet()
+    {
+        EditorSheet.CancelAnimations();
+        EditorSheet.TranslationY = 0;
+        EditorSheetOverlay.BackgroundColor = EditorScrimColor;
+    }
+#pragma warning restore S2325
+
+    private async Task SettleEditorSheetAsync(double offset)
     {
         var height = EditorSheet.Height;
         var threshold = Math.Max(SheetDismissMinThreshold, height * SheetDismissFractionThreshold);
@@ -172,12 +185,5 @@ public partial class VaultPage : ContentPage
             await EditorSheet.TranslateTo(0, 0, 140, Easing.CubicOut);
             ResetSheet();
         }
-    }
-
-    private void ResetSheet()
-    {
-        EditorSheet.CancelAnimations();
-        EditorSheet.TranslationY = 0;
-        EditorSheetOverlay.BackgroundColor = EditorScrimColor;
     }
 }

--- a/src/GDSB.MAUI/VaultPage.xaml.cs
+++ b/src/GDSB.MAUI/VaultPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using GDSB.MAUI.Services;
+﻿using System.ComponentModel;
+using GDSB.MAUI.Services;
 using GDSB.MAUI.ViewModels;
 using GDSB.MAUI.Views;
 
@@ -6,9 +7,21 @@ namespace GDSB.MAUI;
 
 public partial class VaultPage : ContentPage
 {
+    // Fração da altura da folha a partir da qual soltar o arrasto fecha em vez de voltar, e um
+    // piso em dp para folhas curtas (poucos campos), onde uma fração pequena viraria só alguns
+    // pixels e fecharia com quase nenhum arrasto.
+    private const double SheetDismissFractionThreshold = 0.28;
+    private const double SheetDismissMinThreshold = 80;
+    private static readonly Color EditorScrimColor = Color.FromRgba(0, 0, 0, 0.6);
+
     private readonly VaultViewModel _viewModel;
     private readonly ILocalizationService _localization;
     private CancellationTokenSource? _toastCts;
+
+    // TranslationY da folha quando o arrasto começou, e o último TotalY visto no Running - ver
+    // comentário em OnEditorSheetPanUpdated sobre por que o Completed do Android não serve.
+    private double _sheetPanStart;
+    private double _sheetLastTotalY;
 
     public VaultPage(VaultViewModel viewModel, ILocalizationService localization)
     {
@@ -20,6 +33,7 @@ public partial class VaultPage : ContentPage
         _viewModel.SecretCreated += OnSecretCreated;
         _viewModel.SecretUpdated += OnSecretUpdated;
         _viewModel.SecretDeleted += OnSecretDeleted;
+        _viewModel.PropertyChanged += OnViewModelPropertyChanged;
     }
 
     protected override void OnSizeAllocated(double width, double height)
@@ -86,4 +100,84 @@ public partial class VaultPage : ContentPage
     private async void OnSecretDeleted(object? sender, EventArgs e)
         => await SealOverlay.PlayAsync(LockSealMode.Delete, _localization.Get("Seal_SecretDeleted"), 740);
 #pragma warning restore S2325
+
+    // Fechar pelo "X", pelo toque no scrim ou salvando não mexe em TranslationY - só o próprio
+    // arrasto faz isso. Zerar aqui na reabertura (em vez de só ao final do arrasto) garante que os
+    // quatro caminhos de fechar deixem a folha pronta pra próxima abertura, mesmo se o gesto tiver
+    // sido interrompido de um jeito que ResetSheet não tenha rodado.
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(VaultViewModel.IsCompactEditorOpen) && _viewModel.IsCompactEditorOpen)
+            ResetSheet();
+    }
+
+    private void OnEditorSheetPanUpdated(object? sender, PanUpdatedEventArgs e)
+    {
+        switch (e.StatusType)
+        {
+            case GestureStatus.Started:
+                EditorSheet.CancelAnimations();
+                _sheetPanStart = EditorSheet.TranslationY;
+                _sheetLastTotalY = 0;
+
+#if ANDROID
+                // Fecha o teclado antes de começar a arrastar: com SafeAreaEdges="SoftInput" a
+                // página encolhe/estica quando o teclado abre ou fecha, e deixar isso acontecer no
+                // meio do arrasto reancoraria a folha embaixo do dedo.
+                Platforms.Android.KeyboardDismissal.Hide();
+#endif
+                break;
+
+            case GestureStatus.Running:
+                _sheetLastTotalY = e.TotalY;
+                ApplyEditorSheetOffset(Math.Max(0, _sheetPanStart + e.TotalY));
+                break;
+
+            // Canceled junto com Completed: no Android o gesto costuma terminar em Canceled quando
+            // o sistema assume o toque no meio do caminho, e sem tratar isso a folha ficaria parada
+            // onde o dedo a deixou.
+            case GestureStatus.Completed:
+            case GestureStatus.Canceled:
+                // TotalY chega zerado no Completed do Android - por isso o deslocamento final usa
+                // o último valor visto no Running, não e.TotalY.
+                SettleEditorSheet(Math.Max(0, _sheetPanStart + _sheetLastTotalY));
+                break;
+        }
+    }
+
+    private void ApplyEditorSheetOffset(double offset)
+    {
+        EditorSheet.TranslationY = offset;
+
+        var height = EditorSheet.Height;
+        var progress = height > 0 ? Math.Clamp(offset / height, 0, 1) : 0;
+        EditorSheetOverlay.BackgroundColor = Color.FromRgba(0, 0, 0, 0.6 * (1 - progress));
+    }
+
+    private async void SettleEditorSheet(double offset)
+    {
+        var height = EditorSheet.Height;
+        var threshold = Math.Max(SheetDismissMinThreshold, height * SheetDismissFractionThreshold);
+
+        if (offset >= threshold)
+        {
+            // Completa a saída antes de fechar de fato, senão o IsVisible=False do binding cortaria
+            // a folha no meio da tela em vez de deixá-la terminar de sair.
+            await EditorSheet.TranslateTo(0, height, 160, Easing.CubicIn);
+            _viewModel.CloseEditorCommand.Execute(null);
+            ResetSheet();
+        }
+        else
+        {
+            await EditorSheet.TranslateTo(0, 0, 140, Easing.CubicOut);
+            ResetSheet();
+        }
+    }
+
+    private void ResetSheet()
+    {
+        EditorSheet.CancelAnimations();
+        EditorSheet.TranslationY = 0;
+        EditorSheetOverlay.BackgroundColor = EditorScrimColor;
+    }
 }


### PR DESCRIPTION
## Summary

- Adiciona um rótulo discreto (`v1.0.6`) no rodapé da `UnlockPage`, fora do `ScrollView` para não afetar a centralização do conteúdo nem competir com o bloco de desbloqueio.
- No bottom-sheet de item do cofre (`VaultPage`), adiciona uma faixa de arraste dedicada (com alça) que segue o dedo e fecha ou volta ao lugar conforme a distância soltada — hoje só o "X" ou o toque no scrim fechavam, o que confundia quem tentava o gesto nativo do Android numa tela que sobrepõe outra.
- Consolida as 8 `PropertyGroup` de versão duplicadas do `.csproj` (uma por combinação Debug/Release × plataforma, todas idênticas) num único lugar, e faz o bump de `1.0.5`/`5` para `1.0.6`/`6`.

## Test plan

- [ ] `dotnet build src/GDSB.MAUI/GDSB.MAUI.csproj -p:GdsbAndroidOnly=true` — build Android limpo, versão `1.0.6`/`6` no `AndroidManifest` gerado
- [ ] Abrir o app → rodapé mostra `v1.0.6`, discreto, sem sobrepor os links de rodapé; rola/gira a tela e o rótulo continua fixo
- [ ] Abrir um item do cofre (celular) → alça aparece no topo da folha
- [ ] Arrastar pouco e soltar → folha volta ao lugar, scrim volta ao normal
- [ ] Arrastar mais de ~1/3 da folha e soltar → folha desliza pra fora e fecha
- [ ] Reabrir o mesmo item → folha aparece na posição correta (sem ficar "presa" fora da tela)
- [ ] Abrir o teclado (campo Senha) e arrastar a alça → teclado fecha e o arrasto funciona normalmente
- [ ] Rolar o formulário (arrastar sobre os campos) → rola normalmente, folha não se move
- [ ] "X" e toque no scrim continuam fechando como antes
- [ ] Salvar um item → folha fecha e o selo de confirmação toca normalmente
- [ ] Layout tablet (janela ≥ 700dp) → painel lateral sem alça, sem regressão

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8VxCJoKY9jVXwWkMPqcKj

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8VxCJoKY9jVXwWkMPqcKj)_