### PR TITLE
Set App display version to 1.1.0; add notes

### DIFF
--- a/Claude outputs/GDSB - Notas de Versao v1.1.0-alpha.md
+++ b/Claude outputs/GDSB - Notas de Versao v1.1.0-alpha.md
@@ -1,0 +1,13 @@
+# GDSB — v0.1.0-alpha.1
+
+Primeira versão de teste (alpha) do GDSB para Android/Windows.
+
+## Funcionalidades
+
+- Cofres de senha com CRUD completo (usuário, senha, URL, observações, favoritos) e criptografia forte (AES-256-GCM + PBKDF2).
+- Backups automáticos versionados, com retenção configurável e tela de restauração.
+- Biometria opcional para desbloqueio, auto-lock e limpeza de área de transferência configuráveis.
+- Idioma PT-BR/EN, tutorial guiado e layout responsivo (celular/tablet).
+- No Android, possibilidade de sincronização via Google Drive/OneDrive. App 100% offline.
+
+Versão alpha: bugs e ajustes de usabilidade são esperados.

--- a/src/GDSB.MAUI/GDSB.MAUI.csproj
+++ b/src/GDSB.MAUI/GDSB.MAUI.csproj
@@ -61,27 +61,35 @@
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-android|AnyCPU'">
 	  <ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
+	  <ApplicationVersion>8</ApplicationVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-ios|AnyCPU'">
 	  <ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
+	  <ApplicationVersion>8</ApplicationVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-maccatalyst|AnyCPU'">
 	  <ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
+	  <ApplicationVersion>8</ApplicationVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-windows10.0.19041.0|AnyCPU'">
 	  <ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
+	  <ApplicationVersion>8</ApplicationVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-android|AnyCPU'">
 	  <ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
+	  <ApplicationVersion>8</ApplicationVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-ios|AnyCPU'">
 	  <ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
+	  <ApplicationVersion>8</ApplicationVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-maccatalyst|AnyCPU'">
 	  <ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
+	  <ApplicationVersion>8</ApplicationVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-windows10.0.19041.0|AnyCPU'">
 	  <ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
+	  <ApplicationVersion>8</ApplicationVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/GDSB.MAUI/GDSB.MAUI.csproj
+++ b/src/GDSB.MAUI/GDSB.MAUI.csproj
@@ -59,6 +59,30 @@
 	<PropertyGroup Condition="'$(Configuration)' == 'Release' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
 		<AndroidLinkTool>r8</AndroidLinkTool>
 	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-android|AnyCPU'">
+	  <ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-ios|AnyCPU'">
+	  <ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-maccatalyst|AnyCPU'">
+	  <ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-windows10.0.19041.0|AnyCPU'">
+	  <ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-android|AnyCPU'">
+	  <ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-ios|AnyCPU'">
+	  <ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-maccatalyst|AnyCPU'">
+	  <ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-windows10.0.19041.0|AnyCPU'">
+	  <ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
+	</PropertyGroup>
 
 	<ItemGroup>
 		<!-- App Icon -->
@@ -156,12 +180,8 @@
 			<GdsbMappingDestDir>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', '..', 'artifacts', 'mapping', '$(ApplicationDisplayVersion)-$(ApplicationVersion)'))</GdsbMappingDestDir>
 		</PropertyGroup>
 		<MakeDir Directories="$(GdsbMappingDestDir)" Condition="'@(GdsbR8Mapping)' != ''" />
-		<Copy SourceFiles="@(GdsbR8Mapping)"
-		      DestinationFiles="@(GdsbR8Mapping -> '$(GdsbMappingDestDir)\%(RecursiveDir)%(Filename)%(Extension)')"
-		      Condition="'@(GdsbR8Mapping)' != ''" />
-		<Copy SourceFiles="@(GdsbR8Mapping)"
-		      DestinationFolder="$(PublishDir)"
-		      Condition="'@(GdsbR8Mapping)' != '' And '$(PublishDir)' != '' And Exists('$(PublishDir)')" />
+		<Copy SourceFiles="@(GdsbR8Mapping)" DestinationFiles="@(GdsbR8Mapping -> '$(GdsbMappingDestDir)\%(RecursiveDir)%(Filename)%(Extension)')" Condition="'@(GdsbR8Mapping)' != ''" />
+		<Copy SourceFiles="@(GdsbR8Mapping)" DestinationFolder="$(PublishDir)" Condition="'@(GdsbR8Mapping)' != '' And '$(PublishDir)' != '' And Exists('$(PublishDir)')" />
 	</Target>
 
 </Project>


### PR DESCRIPTION
Add Portuguese release notes for v1.1.0-alpha and update GDSB.MAUI.csproj to set ApplicationDisplayVersion=1.1.0 for Debug/Release across net10.0-android, net10.0-ios, net10.0-maccatalyst and net10.0-windows10.0.19041.0. Also compact R8 mapping Copy tasks into single-line elements to tidy the project file. No runtime behavior changes — only metadata and formatting updates.