### PR TITLE
Add effort metadata to agents

### DIFF
--- a/.claude/agents/aplicador-lote.md
+++ b/.claude/agents/aplicador-lote.md
@@ -3,6 +3,7 @@ name: aplicador-lote
 description: Executor cego de tabela de edição. Recebe uma tabela de→para exata e uma lista fechada de arquivos, aplica e devolve o diff e a contagem por arquivo. Use para migração mecânica em massa - trocar centenas de literais por chaves de recurso, renomear um símbolo em muitos arquivos - depois que outro agente já decidiu o mapeamento. Não decide nada.
 tools: Read, Edit, Grep, Glob
 model: haiku
+effort: low
 ---
 
 Você aplica uma tabela de substituição que **outra pessoa já decidiu**. Você não escolhe nome, não

--- a/.claude/agents/cripto-backup.md
+++ b/.claude/agents/cripto-backup.md
@@ -3,6 +3,7 @@ name: cripto-backup
 description: Mexe em criptografia, no formato de arquivo .GDSBX, no ProfileFileService e em todo o subsistema de backup (nomes, retenção, poda, restauração) dentro de src/GDSB.Infrastructure. Use para qualquer mudança que toque bytes gravados em disco ou a política de backup. É o único agente autorizado nesse código.
 tools: Read, Write, Edit, Grep, Glob, Bash
 model: sonnet
+effort: high
 ---
 
 Você mexe no código que grava e lê o cofre do usuário. Um erro aqui **corrompe dado real e

--- a/.claude/agents/dev-viewmodels.md
+++ b/.claude/agents/dev-viewmodels.md
@@ -3,6 +3,7 @@ name: dev-viewmodels
 description: Implementa e altera ViewModels, serviços e abstrações de plataforma em src/GDSB.MAUI.ViewModels, e entidades/interfaces em src/GDSB.Domain. Use para lógica de tela testável, comando novo, abstração nova e refatoração de ViewModel. Não toca em XAML, .resx nem criptografia.
 tools: Read, Write, Edit, Grep, Glob, Bash
 model: sonnet
+effort: high
 ---
 
 Você escreve C# em `src/GDSB.MAUI.ViewModels` e `src/GDSB.Domain`. Alvo `net10.0`, `Nullable` e

--- a/.claude/agents/dev-xaml.md
+++ b/.claude/agents/dev-xaml.md
@@ -3,6 +3,7 @@ name: dev-xaml
 description: Implementa e altera a camada de UI do MAUI - Views, XAML, code-behind, Controls, Converters, Behaviors, Styles e as implementações de plataforma em src/GDSB.MAUI/Platforms. Use para tela nova, ajuste de layout, responsividade celular/tablet e integração com Android/Windows. Não escreve .resx nem lógica de ViewModel.
 tools: Read, Write, Edit, Grep, Glob, Bash
 model: sonnet
+effort: high
 ---
 
 Você escreve a camada visual do GDSB em `src/GDSB.MAUI`. .NET MAUI 10, XAML + code-behind mínimo.

--- a/.claude/agents/entrega-pr.md
+++ b/.claude/agents/entrega-pr.md
@@ -3,6 +3,7 @@ name: entrega-pr
 description: Executor cego de git e GitHub. Cria a branch da fase, commita com a mensagem recebida, faz push com retry, abre o PR com o título e corpo recebidos, tira um instantâneo do status dos checks e copia o comentário do sonarqubecloud[bot] verbatim. Use quando a sessão principal já tiver revisado o diff e redigido os textos. Não escreve texto de PR, não interpreta resultado e não espera check terminar.
 tools: Bash, Read, Grep, Glob, mcp__github__create_pull_request, mcp__github__pull_request_read, mcp__github__list_pull_requests, mcp__github__get_check_run, mcp__github__actions_list, mcp__github__get_job_logs
 model: haiku
+effort: low
 ---
 
 Você publica o que já foi decidido. **Não redige, não interpreta, não corrige código, não faz

--- a/.claude/agents/i18n.md
+++ b/.claude/agents/i18n.md
@@ -3,6 +3,7 @@ name: i18n
 description: Único escritor do catálogo de textos - Resources/AppStrings.resx e AppStrings.en.resx, AppStrings.Designer.cs, TrExtension, Help/HelpTopics.cs e Resources/HelpVisuals.xaml. Use para criar chave de tradução, traduzir tela, revisar o inglês e mexer no catálogo de ajuda. Nenhum outro agente escreve .resx.
 tools: Read, Write, Edit, Grep, Glob, Bash
 model: sonnet
+effort: high
 ---
 
 Você é o **escritor único** do catálogo de textos do GDSB. Outros agentes consomem chaves; quem as

--- a/.claude/agents/mapeador.md
+++ b/.claude/agents/mapeador.md
@@ -3,6 +3,7 @@ name: mapeador
 description: Reconhecimento somente-leitura do código do GDSB. Use antes de decidir qualquer coisa que dependa de "onde está" ou "quantos são" - inventariar literais, achar todos os usos de um símbolo, mapear o impacto de uma mudança, conferir se um padrão já existe em outro lugar. Devolve fatos com caminho:linha. Não use para um grep pontual, que sai mais barato inline.
 tools: Read, Grep, Glob, Bash
 model: sonnet
+effort: high
 ---
 
 Você mapeia o repositório GDSB.MAUI. **Você não edita arquivo nenhum.** Se a tarefa pedir edição,

--- a/.claude/agents/sonar.md
+++ b/.claude/agents/sonar.md
@@ -3,6 +3,7 @@ name: sonar
 description: Tria e corrige apontamentos do SonarAnalyzer/SonarCloud no código do GDSB. Use depois de uma varredura (feita pelo agente verificador) ou quando o comentário do sonarqubecloud[bot] chegar do PR. Conhece o catálogo de falsos positivos do projeto e a forma correta de suprimir cada um. Não roda build.
 tools: Read, Write, Edit, Grep, Glob
 model: sonnet
+effort: medium
 ---
 
 Você recebe uma lista de apontamentos com arquivo e linha e decide o que fazer com cada um. **Você

--- a/.claude/agents/testes.md
+++ b/.claude/agents/testes.md
@@ -3,6 +3,7 @@ name: testes
 description: Escreve e ajusta testes xUnit e fakes escritos à mão em tests/GDSB.Infrastructure.Tests e tests/GDSB.MAUI.Tests. Use para cobrir regressão, criar fake de interface nova e completar cobertura de uma fase. Não roda os testes - pede a execução ao agente verificador.
 tools: Read, Write, Edit, Grep, Glob
 model: sonnet
+effort: high
 ---
 
 Você escreve teste. **Você não roda comando** — quem executa é o agente `verificador`, e você lê o

--- a/.claude/agents/verificador.md
+++ b/.claude/agents/verificador.md
@@ -3,6 +3,7 @@ name: verificador
 description: Executor cego de receita de verificação. Roda build, dotnet test, o checklist estático de XAML e a varredura local do SonarAnalyzer, e devolve só o resultado comprimido - pass/fail e as linhas que falharam, nunca o log inteiro. Use sempre que for preciso rodar comando, para manter saída de build fora do contexto de quem decide. Nunca edita código.
 tools: Bash, Read, Glob, Grep
 model: haiku
+effort: low
 ---
 
 Você **executa e reporta**. Não decide, não corrige, não edita código-fonte, não commita. Se algo


### PR DESCRIPTION
Each Claude agent definition now includes an explicit effort level to help route work by expected complexity. This metadata-only update standardizes the agent front matter across the project and makes task planning and orchestration more consistent without changing behavior or prompts beyond the added field.