### PR TITLE
fix(sonar): fecha apontamentos abertos do SonarCloud no overall

### DIFF
--- a/src/GDSB.MAUI/Platforms/Android/Services/BiometricUnlockService.cs
+++ b/src/GDSB.MAUI/Platforms/Android/Services/BiometricUnlockService.cs
@@ -302,6 +302,8 @@ namespace GDSB.MAUI.Platforms.Android.Services
             // Corpo vazio é intencional: não há ação de sistema a tomar numa falha recuperável.
             public override void OnAuthenticationFailed()
             {
+                // Intencionalmente vazio: falha recuperável, o prompt continua aberto e o
+                // usuário pode tentar de novo sem nenhuma ação de sistema aqui.
             }
         }
     }

--- a/src/GDSB.MAUI/Platforms/Windows/CursorMappings.cs
+++ b/src/GDSB.MAUI/Platforms/Windows/CursorMappings.cs
@@ -16,8 +16,13 @@ namespace GDSB.MAUI.Platforms.Windows
         // passaria despercebido: o mapeamento simplesmente não valeria, sem erro nenhum.
         private const string MappingKey = "HoverCursor";
 
+        // Bypass de acessibilidade revisado e intencional: ver o comentário de bloco no topo do
+        // arquivo - é a técnica documentada pela comunidade .NET MAUI/WinUI para setar o cursor
+        // de hover, não um acesso indevido a estado interno.
+#pragma warning disable S3011
         private static readonly PropertyInfo? ProtectedCursorProperty =
             typeof(UIElement).GetProperty("ProtectedCursor", BindingFlags.Instance | BindingFlags.NonPublic);
+#pragma warning restore S3011
 
         private static readonly Lazy<InputCursor> HandCursor =
             new(() => InputSystemCursor.Create(InputSystemCursorShape.Hand));


### PR DESCRIPTION
## Resumo

- Corpo vazio de `OnAuthenticationFailed` (S1186, `BiometricUnlockService.cs`) agora tem a explicação também dentro do método, não só acima dele.
- Bypass de reflection em `CursorMappings.ProtectedCursorProperty` (S3011, security hotspot) ganhou supressão explícita, na mesma convenção de pragma comentado já usada no projeto (`S1172` em `BiometricUnlockService.cs`).
- Os demais apontamentos citados no overall (TODO em `ProfileFileService.cs` L61, `CursorMappings.cs` L27 e `IdleLockService.cs` L6; código comentado em `ProfileFileService.cs` L9) já não existem no código atual — foram corrigidos num commit anterior ("SonarCloud: correção de 75 issues") e o dashboard "overall" do SonarCloud ainda não foi re-escaneado desde então. Nenhuma ação de código foi necessária para esses.

## Plano de teste

- [x] `dotnet test tests/GDSB.Infrastructure.Tests` — 27 testes, passou
- [x] `dotnet test tests/GDSB.MAUI.Tests` — 127 testes, passou
- [x] 0 warnings de build
- [ ] `net10.0-android`/`net10.0-windows` não compilam neste ambiente (limitação de rede documentada); validação de build fica com o CI (`build-android`, `build-windows`)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDrsV1wXrzsRjJkcyHFopd

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDrsV1wXrzsRjJkcyHFopd)_